### PR TITLE
Remove cached CompositeFormat static fields from exception paths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -231,6 +231,13 @@ dotnet_diagnostic.CA1510.severity = none # Use ArgumentNullException.ThrowIfNull
 dotnet_diagnostic.CA1511.severity = none # Use ArgumentException.ThrowIf — prefer ThrowHelper
 dotnet_diagnostic.CA1512.severity = none # Use ArgumentOutOfRangeException.ThrowIfOutOfRange — prefer ThrowHelper
 
+# CA1863 suggests caching 'CompositeFormat' for format strings that are not constants. Every
+# flagged site formats a <Domain>ResourceStrings resx accessor on an exception/error path —
+# cold code that formats once per failure, where parse cost is noise next to the throw itself.
+# Caching would add per-message static state and freeze resource resolution at type-init,
+# against the documented resx + CurrentCulture convention (see CLAUDE.md, Static Text).
+dotnet_diagnostic.CA1863.severity = none # Use CompositeFormat — error paths are cold by construction
+
 # ---------------------------------------------------------------------------------------------------------------
 # Member ordering (StyleCop)
 # ---------------------------------------------------------------------------------------------------------------

--- a/Bodu.Core/src/ThrowHelper.Array-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Array-CallerExpression.cs
@@ -10,48 +10,11 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ArrayLength" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidArrayLength =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ArrayLength);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ArrayLengthMultipleOf" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidArrayLengthMultipleOf =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ArrayLengthMultipleOf);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ArrayOffset" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidArrayOffset =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ArrayOffset);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ArrayOffsetOrLength" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidArrayOffsetOrLength =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ArrayOffsetOrLength);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ArrayTooShort" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidArrayTooShort =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ArrayTooShort);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_IndexValidRange" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeIndexValidRange =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_IndexValidRange);
-
     /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if the array is <see langword="null" />, or an
     /// <see cref="ArgumentException" /> if it contains any non-numeric element.
@@ -171,7 +134,7 @@ public static partial class ThrowHelper
 
         if (array.Length != expectedLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayLength, expectedLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayLength, expectedLength),
                 paramName);
     }
 
@@ -206,7 +169,7 @@ public static partial class ThrowHelper
 
         if (array.Length < minimumLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayTooShort, minimumLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayTooShort, minimumLength),
                 paramName);
     }
 
@@ -251,11 +214,11 @@ public static partial class ThrowHelper
         if (index < 0)
             throw new ArgumentOutOfRangeException(
                 indexParamName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeIndexValidRange, paramName));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_IndexValidRange, paramName));
 
         if (array.Length - index < requiredLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayTooShort, requiredLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayTooShort, requiredLength),
                 paramName);
     }
 
@@ -309,7 +272,7 @@ public static partial class ThrowHelper
         if (array.Length < minLength || array.Length > maxLength)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireBetweenInclusive, minLength, maxLength));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive, minLength, maxLength));
     }
 
     /// <summary>
@@ -335,7 +298,7 @@ public static partial class ThrowHelper
 
         if (array.Length == 0 || array.Length % divisor != 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayLengthMultipleOf, divisor),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayLengthMultipleOf, divisor),
                 paramName);
     }
 
@@ -370,18 +333,18 @@ public static partial class ThrowHelper
         if (offset < 0 || offset > array.Length)
             throw new ArgumentOutOfRangeException(
                 paramOffsetName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayOffset, paramOffsetName));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayOffset, paramOffsetName));
 
         if (count < 0 || count > array.Length)
             throw new ArgumentOutOfRangeException(
                 paramCountName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayOffset, paramCountName));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayOffset, paramCountName));
 
         if (count > array.Length - offset)
             throw new ArgumentException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    s_argInvalidArrayOffsetOrLength,
+                    ResourceStrings.Arg_Invalid_ArrayOffsetOrLength,
                     paramOffsetName,
                     paramCountName,
                     paramArrayName));
@@ -441,7 +404,7 @@ public static partial class ThrowHelper
         if (index < 0 || index >= array.LongLength)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeIndexValidRange, array.LongLength));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_IndexValidRange, array.LongLength));
     }
 }
 

--- a/Bodu.Core/src/ThrowHelper.Collection-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Collection-CallerExpression.cs
@@ -10,18 +10,11 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_CollectionTooSmall" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidCollectionTooSmall =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_CollectionTooSmall);
-
     /// <summary>
     /// Throws an <see cref="ArgumentException" /> if the collection has fewer than <paramref name="minCount" />
     /// elements.
@@ -42,7 +35,7 @@ public static partial class ThrowHelper
         ThrowIfNull(collection, paramName);
         if (collection.Count < minCount)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidCollectionTooSmall, minCount),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_CollectionTooSmall, minCount),
                 paramName);
     }
 
@@ -101,7 +94,7 @@ public static partial class ThrowHelper
             throw new ArgumentException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    s_argInvalidParameterRequiredIf,
+                    ResourceStrings.Arg_Invalid_ParameterRequiredIf,
                     paramName,
                     conditionalParamName,
                     conditionalValue),

--- a/Bodu.Core/src/ThrowHelper.Comparison-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Comparison-CallerExpression.cs
@@ -10,78 +10,11 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_GreaterThanOrEqualOtherParameter" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidGreaterThanOrEqualOtherParameter =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_GreaterThanOrEqualOtherParameter);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_GreaterThanOtherParameter" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidGreaterThanOtherParameter =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_GreaterThanOtherParameter);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_LessThanOrEqualOtherParameter" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidLessThanOrEqualOtherParameter =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_LessThanOrEqualOtherParameter);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_LessThanOtherParameter" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidLessThanOtherParameter =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_LessThanOtherParameter);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_RequireBetweenExclusive" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeRequireBetweenExclusive =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_RequireBetweenExclusive);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeRequireBetweenInclusive =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_RequireGreaterThan" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeRequireGreaterThan =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_RequireGreaterThan);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_RequireGreaterThanOrEqual" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeRequireGreaterThanOrEqual =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_RequireGreaterThanOrEqual);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_RequireLessThan" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeRequireLessThan =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_RequireLessThan);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_RequireLessThanOrEqual" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeRequireLessThanOrEqual =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_RequireLessThanOrEqual);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ParameterRequiredIf" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidParameterRequiredIf =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ParameterRequiredIf);
-
     /// <summary>
     /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is greater than
     /// <paramref name="max" />.
@@ -102,7 +35,7 @@ public static partial class ThrowHelper
         if (value.CompareTo(max) > 0)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireLessThanOrEqual, max));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireLessThanOrEqual, max));
     }
 
     /// <summary>
@@ -125,7 +58,7 @@ public static partial class ThrowHelper
         if (value.CompareTo(max) >= 0)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireLessThan, max));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireLessThan, max));
     }
 
     /// <summary>
@@ -149,7 +82,7 @@ public static partial class ThrowHelper
     {
         if (value.CompareTo(other) >= 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidGreaterThanOrEqualOtherParameter, otherName),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_GreaterThanOrEqualOtherParameter, otherName),
                 paramName);
     }
 
@@ -174,7 +107,7 @@ public static partial class ThrowHelper
     {
         if (value.CompareTo(other) > 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidGreaterThanOtherParameter, otherName),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_GreaterThanOtherParameter, otherName),
                 paramName);
     }
 
@@ -198,7 +131,7 @@ public static partial class ThrowHelper
         if (value.CompareTo(min) < 0)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireGreaterThanOrEqual, min));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireGreaterThanOrEqual, min));
     }
 
     /// <summary>
@@ -236,7 +169,7 @@ public static partial class ThrowHelper
         {
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireGreaterThanOrEqual, min));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireGreaterThanOrEqual, min));
         }
     }
 
@@ -260,7 +193,7 @@ public static partial class ThrowHelper
         if (value.CompareTo(min) <= 0)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireGreaterThan, min));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireGreaterThan, min));
     }
 
     /// <summary>
@@ -284,7 +217,7 @@ public static partial class ThrowHelper
     {
         if (value.CompareTo(other) <= 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidLessThanOrEqualOtherParameter, otherName),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_LessThanOrEqualOtherParameter, otherName),
                 paramName);
     }
 
@@ -308,7 +241,7 @@ public static partial class ThrowHelper
     {
         if (value.CompareTo(other) < 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidLessThanOtherParameter, otherName),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_LessThanOtherParameter, otherName),
                 paramName);
     }
 
@@ -339,14 +272,14 @@ public static partial class ThrowHelper
             if (value.CompareTo(min) < 0 || value.CompareTo(max) > 0)
                 throw new ArgumentOutOfRangeException(
                     paramName,
-                    string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireBetweenInclusive, min, max));
+                    string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive, min, max));
         }
         else
         {
             if (value.CompareTo(min) <= 0 || value.CompareTo(max) >= 0)
                 throw new ArgumentOutOfRangeException(
                     paramName,
-                    string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireBetweenExclusive, min, max));
+                    string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireBetweenExclusive, min, max));
         }
     }
 }

--- a/Bodu.Core/src/ThrowHelper.Equality-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Equality-CallerExpression.cs
@@ -10,24 +10,11 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_ValuesNotEqual" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidValuesNotEqual =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_ValuesNotEqual);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_ValuesEqual" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeValuesEqual =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_ValuesEqual);
-
     /// <summary>
     /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> equals
     /// <paramref name="other" />.
@@ -48,7 +35,7 @@ public static partial class ThrowHelper
         if (value.Equals(other))
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeValuesEqual, other));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_ValuesEqual, other));
     }
 
     /// <summary>
@@ -70,7 +57,7 @@ public static partial class ThrowHelper
     {
         if (!value.Equals(other))
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidValuesNotEqual, other),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ValuesNotEqual, other),
                 paramName);
     }
 }

--- a/Bodu.Core/src/ThrowHelper.Numeric-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Numeric-CallerExpression.cs
@@ -11,30 +11,11 @@
 using System.Globalization;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_PositiveMultipleOf" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidPositiveMultipleOf =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_PositiveMultipleOf);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_CountExceedsAvailable" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeCountExceedsAvailable =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_CountExceedsAvailable);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_SequenceRangeOverflow" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeSequenceRangeOverflow =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_SequenceRangeOverflow);
-
     /// <summary>
     /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="count" /> is negative or exceeds
     /// <paramref name="available" />.
@@ -56,7 +37,7 @@ public static partial class ThrowHelper
         if (count < 0 || count > available)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeCountExceedsAvailable, available));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_CountExceedsAvailable, available));
     }
 
     /// <summary>
@@ -101,7 +82,7 @@ public static partial class ThrowHelper
         if (value <= T.Zero || value % divisor != T.Zero)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidPositiveMultipleOf, divisor));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_PositiveMultipleOf, divisor));
     }
 
     /// <summary>
@@ -186,7 +167,7 @@ public static partial class ThrowHelper
         if (count > 0 && start > int.MaxValue - (count - 1))
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeSequenceRangeOverflow, nameof(Int32)));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_SequenceRangeOverflow, nameof(Int32)));
     }
 
     /// <summary>
@@ -210,7 +191,7 @@ public static partial class ThrowHelper
         if (count > 0 && start > long.MaxValue - (count - 1))
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeSequenceRangeOverflow, nameof(Int64)));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_SequenceRangeOverflow, nameof(Int64)));
     }
 
     /// <summary>

--- a/Bodu.Core/src/ThrowHelper.Span-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Span-CallerExpression.cs
@@ -10,37 +10,12 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Bodu.Extensions;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_DestinationTooSmall" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidDestinationTooSmall =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_DestinationTooSmall);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_SpanLength" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidSpanLength =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_SpanLength);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_SpanLengthMultipleOf" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidSpanLengthMultipleOf =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_SpanLengthMultipleOf);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_SpanTooShort" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidSpanTooShort =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_SpanTooShort);
-
     /// <summary>
     /// Throws an exception if the span does not have exactly <paramref name="expectedLength" /> elements.
     /// </summary>
@@ -58,7 +33,7 @@ public static partial class ThrowHelper
     {
         if (span.Length != expectedLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanLength, expectedLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanLength, expectedLength),
                 paramName);
     }
 
@@ -89,7 +64,7 @@ public static partial class ThrowHelper
     {
         if (span.Length < minimumLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanTooShort, minimumLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanTooShort, minimumLength),
                 paramName);
     }
 
@@ -110,7 +85,7 @@ public static partial class ThrowHelper
     {
         if (span.Length != expectedLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanLength, expectedLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanLength, expectedLength),
                 paramName);
     }
 
@@ -142,7 +117,7 @@ public static partial class ThrowHelper
     {
         if (span.Length < minimumLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanTooShort, minimumLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanTooShort, minimumLength),
                 paramName);
     }
 
@@ -172,7 +147,7 @@ public static partial class ThrowHelper
         if (span.Length < minLength || span.Length > maxLength)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireBetweenInclusive, minLength, maxLength));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive, minLength, maxLength));
     }
 
     /// <summary>
@@ -201,7 +176,7 @@ public static partial class ThrowHelper
         if (span.Length < minLength || span.Length > maxLength)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeRequireBetweenInclusive, minLength, maxLength));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive, minLength, maxLength));
     }
 
     /// <summary>
@@ -313,18 +288,18 @@ public static partial class ThrowHelper
         if (offset < 0 || offset > span.Length)
             throw new ArgumentOutOfRangeException(
                 paramOffsetName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayOffset, paramOffsetName));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayOffset, paramOffsetName));
 
         if (count < 0 || count > span.Length)
             throw new ArgumentOutOfRangeException(
                 paramCountName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidArrayOffset, paramCountName));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_ArrayOffset, paramCountName));
 
         if (count > span.Length - offset)
             throw new ArgumentException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    s_argInvalidArrayOffsetOrLength,
+                    ResourceStrings.Arg_Invalid_ArrayOffsetOrLength,
                     paramOffsetName,
                     paramCountName,
                     paramSpanName));
@@ -362,7 +337,7 @@ public static partial class ThrowHelper
 
         if (destination.Length < source.Length)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidDestinationTooSmall, ResourceStrings.BufferKind_Array, destination.Length),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_DestinationTooSmall, ResourceStrings.BufferKind_Array, destination.Length),
                 paramDestinationName);
     }
 
@@ -389,7 +364,7 @@ public static partial class ThrowHelper
     {
         if (destination.Length < source.Length)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidDestinationTooSmall, ResourceStrings.BufferKind_Span, destination.Length),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_DestinationTooSmall, ResourceStrings.BufferKind_Span, destination.Length),
                 paramDestinationName);
     }
 
@@ -410,7 +385,7 @@ public static partial class ThrowHelper
     {
         if (span.Length - index < requiredLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanTooShort, requiredLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanTooShort, requiredLength),
                 paramName);
     }
 
@@ -433,7 +408,7 @@ public static partial class ThrowHelper
             throw new ArgumentException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    s_argInvalidSpanTooShort,
+                    ResourceStrings.Arg_Invalid_SpanTooShort,
                     requiredLength),
                 paramName);
     }
@@ -463,7 +438,7 @@ public static partial class ThrowHelper
 
         if ((throwIfZero && span.Length == 0) || span.Length % divisor != 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanLengthMultipleOf, divisor),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanLengthMultipleOf, divisor),
                 paramName);
     }
 
@@ -490,7 +465,7 @@ public static partial class ThrowHelper
     {
         if ((throwIfZero && span.Length == 0) || span.Length % divisor != 0)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidSpanLengthMultipleOf, divisor),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_SpanLengthMultipleOf, divisor),
                 paramName);
     }
 
@@ -518,7 +493,7 @@ public static partial class ThrowHelper
         if ((uint)index >= (uint)span.Length)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeIndexValidRange, span.Length));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_IndexValidRange, span.Length));
     }
 
     /// <summary>
@@ -545,7 +520,7 @@ public static partial class ThrowHelper
         if ((uint)index >= (uint)span.Length)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeIndexValidRange, span.Length));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_IndexValidRange, span.Length));
     }
 }
 

--- a/Bodu.Core/src/ThrowHelper.String-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.String-CallerExpression.cs
@@ -10,30 +10,11 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_StringLength" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidStringLength =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_StringLength);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_StringLengthRange" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidStringLengthRange =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_StringLengthRange);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_StringTooLong" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidStringTooLong =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_StringTooLong);
-
     /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <see langword="null" />, or an
     /// <see cref="ArgumentException" /> if it is an empty string.
@@ -102,7 +83,7 @@ public static partial class ThrowHelper
         if (value.Length > maxLength)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidStringTooLong, maxLength));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_StringTooLong, maxLength));
     }
 
     /// <summary>
@@ -130,7 +111,7 @@ public static partial class ThrowHelper
 
         if (value.Length != expectedLength)
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidStringLength, expectedLength),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_StringLength, expectedLength),
                 paramName);
     }
 
@@ -162,7 +143,7 @@ public static partial class ThrowHelper
         if (value.Length < minLength || value.Length > maxLength)
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidStringLengthRange, minLength, maxLength));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_StringLengthRange, minLength, maxLength));
     }
 }
 

--- a/Bodu.Core/src/ThrowHelper.Type-CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.Type-CallerExpression.cs
@@ -10,24 +10,11 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Bodu;
 
 public static partial class ThrowHelper
 {
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_Invalid_MustBeOfType" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argInvalidMustBeOfType =
-        CompositeFormat.Parse(ResourceStrings.Arg_Invalid_MustBeOfType);
-
-    /// <summary>
-    /// Cached parsed format for <see cref="ResourceStrings.Arg_OutOfRange_EnumValue" />.
-    /// </summary>
-    private static readonly CompositeFormat s_argOutOfRangeEnumValue =
-        CompositeFormat.Parse(ResourceStrings.Arg_OutOfRange_EnumValue);
-
     /// <summary>
     /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not a defined member of
     /// <typeparamref name="TEnum" />.
@@ -46,7 +33,7 @@ public static partial class ThrowHelper
         if (!Enum.IsDefined(typeof(TEnum), value))
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(CultureInfo.CurrentCulture, s_argOutOfRangeEnumValue, typeof(TEnum).Name, value));
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_OutOfRange_EnumValue, typeof(TEnum).Name, value));
     }
 
     /// <summary>
@@ -92,13 +79,13 @@ public static partial class ThrowHelper
         {
             if (default(T) is not null)
                 throw new ArgumentException(
-                    string.Format(CultureInfo.CurrentCulture, s_argInvalidMustBeOfType, typeof(T)),
+                    string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_MustBeOfType, typeof(T)),
                     paramName);
         }
         else if (value is not T)
         {
             throw new ArgumentException(
-                string.Format(CultureInfo.CurrentCulture, s_argInvalidMustBeOfType, typeof(T)),
+                string.Format(CultureInfo.CurrentCulture, ResourceStrings.Arg_Invalid_MustBeOfType, typeof(T)),
                 paramName);
         }
     }

--- a/Bodu.Text.Formats/src/Text.Delimited/Delimited.Parser.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/Delimited.Parser.cs
@@ -14,18 +14,6 @@ namespace Bodu.Text.Delimited;
 
 public static partial class Delimited
 {
-    private static readonly CompositeFormat s_unterminatedQuotedField =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DelimitedUnterminatedQuotedField);
-
-    private static readonly CompositeFormat s_duplicateHeader =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DelimitedDuplicateHeader);
-
-    private static readonly CompositeFormat s_fieldCountMismatch =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DelimitedFieldCountMismatch);
-
-    private static readonly CompositeFormat s_malformedRecord =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DelimitedMalformedRecord);
-
     /// <summary>
     /// Throws a <see cref="DelimitedFormatException" /> for an unterminated quoted field.
     /// </summary>
@@ -33,7 +21,7 @@ public static partial class Delimited
     [DoesNotReturn]
     internal static void ThrowUnterminatedQuotedField(int lineNumber) =>
         throw new DelimitedFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_unterminatedQuotedField, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DelimitedUnterminatedQuotedField, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DelimitedFormatException" /> for a duplicated header name.
@@ -43,7 +31,7 @@ public static partial class Delimited
     [DoesNotReturn]
     internal static void ThrowDuplicateHeader(string headerName, int lineNumber) =>
         throw new DelimitedFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_duplicateHeader, headerName, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DelimitedDuplicateHeader, headerName, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DelimitedFormatException" /> for a character that appears after the closing quote of a
@@ -54,7 +42,7 @@ public static partial class Delimited
     [DoesNotReturn]
     internal static void ThrowMalformedRecord(char unexpected, int lineNumber) =>
         throw new DelimitedFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_malformedRecord, unexpected, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DelimitedMalformedRecord, unexpected, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DelimitedFormatException" /> when a data row's field count does not match the header.
@@ -65,7 +53,7 @@ public static partial class Delimited
     [DoesNotReturn]
     internal static void ThrowFieldCountMismatch(int rowLineNumber, int rowFieldCount, int headerFieldCount) =>
         throw new DelimitedFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_fieldCountMismatch, rowLineNumber, rowFieldCount, headerFieldCount),
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DelimitedFieldCountMismatch, rowLineNumber, rowFieldCount, headerFieldCount),
             rowLineNumber);
 
     /// <summary>

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedRow.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedRow.cs
@@ -6,7 +6,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 
 namespace Bodu.Text.Delimited;
 
@@ -45,9 +44,6 @@ namespace Bodu.Text.Delimited;
 /// </example>
 public sealed class DelimitedRow
 {
-    private static readonly CompositeFormat s_headerNotFound =
-        CompositeFormat.Parse(FormatsResourceStrings.Op_Invalid_DelimitedHeaderNotFound);
-
     /// <summary>
     /// The column-name-to-index map built from the document's header row, or <see langword="null" /> when the document
     /// was parsed without a header row.
@@ -234,5 +230,5 @@ public sealed class DelimitedRow
     [DoesNotReturn]
     private static void ThrowHeaderNotFound(string header) =>
         throw new KeyNotFoundException(
-            string.Format(CultureInfo.CurrentCulture, s_headerNotFound, header));
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Op_Invalid_DelimitedHeaderNotFound, header));
 }

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnv.Parser.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnv.Parser.cs
@@ -14,21 +14,6 @@ namespace Bodu.Text.DotEnv;
 
 public static partial class DotEnv
 {
-    private static readonly CompositeFormat s_duplicateKey =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DotEnvDuplicateKey);
-
-    private static readonly CompositeFormat s_invalidKey =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DotEnvInvalidKey);
-
-    private static readonly CompositeFormat s_malformedEntry =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DotEnvMalformedEntry);
-
-    private static readonly CompositeFormat s_unterminatedDoubleQuote =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DotEnvUnterminatedDoubleQuote);
-
-    private static readonly CompositeFormat s_unterminatedSingleQuote =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_DotEnvUnterminatedSingleQuote);
-
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for a duplicate key.
     /// </summary>
@@ -37,7 +22,7 @@ public static partial class DotEnv
     [DoesNotReturn]
     private static void ThrowDuplicateKey(string key, int lineNumber) =>
         throw new DotEnvFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_duplicateKey, key, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DotEnvDuplicateKey, key, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for an invalid key name.
@@ -47,7 +32,7 @@ public static partial class DotEnv
     [DoesNotReturn]
     internal static void ThrowInvalidKey(string key, int lineNumber) =>
         throw new DotEnvFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_invalidKey, key, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DotEnvInvalidKey, key, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for a malformed entry line.
@@ -56,7 +41,7 @@ public static partial class DotEnv
     [DoesNotReturn]
     internal static void ThrowMalformedEntry(int lineNumber) =>
         throw new DotEnvFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_malformedEntry, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DotEnvMalformedEntry, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for an unterminated double-quoted string.
@@ -65,7 +50,7 @@ public static partial class DotEnv
     [DoesNotReturn]
     internal static void ThrowUnterminatedDoubleQuote(int lineNumber) =>
         throw new DotEnvFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_unterminatedDoubleQuote, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DotEnvUnterminatedDoubleQuote, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for an unterminated single-quoted string.
@@ -74,7 +59,7 @@ public static partial class DotEnv
     [DoesNotReturn]
     internal static void ThrowUnterminatedSingleQuote(int lineNumber) =>
         throw new DotEnvFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_unterminatedSingleQuote, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_DotEnvUnterminatedSingleQuote, lineNumber), lineNumber);
 
     /// <summary>
     /// Provides character-by-character DotEnv parsing over a <see cref="ReadOnlySpan{T}" /> of characters.

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnvDocument.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnvDocument.cs
@@ -6,7 +6,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 
 namespace Bodu.Text.DotEnv;
 
@@ -40,12 +39,6 @@ namespace Bodu.Text.DotEnv;
 /// </example>
 public sealed class DotEnvDocument
 {
-    /// <summary>
-    /// Cached format for the <c>KeyNotFound</c> message.
-    /// </summary>
-    private static readonly CompositeFormat s_keyNotFound =
-        CompositeFormat.Parse(FormatsResourceStrings.Op_Invalid_DotEnvKeyNotFound);
-
     private readonly List<DotEnvEntry> _entries;
     private readonly Dictionary<string, DotEnvEntry> _lookup;
 
@@ -102,7 +95,7 @@ public sealed class DotEnvDocument
         ThrowHelper.ThrowIfNull(key);
 
         return !_lookup.TryGetValue(key, out DotEnvEntry? entry)
-            ? throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, s_keyNotFound, key))
+            ? throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Op_Invalid_DotEnvKeyNotFound, key))
             : entry.GetValue<T>();
     }
 

--- a/Bodu.Text.Formats/src/Text.Ini/Ini.Parser.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/Ini.Parser.cs
@@ -6,27 +6,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 
 namespace Bodu.Text.Ini;
 
 public static partial class Ini
 {
-    private static readonly CompositeFormat s_iniDuplicateKey =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_IniDuplicateKey);
-
-    private static readonly CompositeFormat s_iniDuplicateSection =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_IniDuplicateSection);
-
-    private static readonly CompositeFormat s_iniGlobalKeyDisallowed =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_IniGlobalKeyDisallowed);
-
-    private static readonly CompositeFormat s_iniMalformedSectionHeader =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_IniMalformedSectionHeader);
-
-    private static readonly CompositeFormat s_iniMissingKey =
-        CompositeFormat.Parse(FormatsResourceStrings.Format_Invalid_IniMissingKey);
-
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a duplicate key.
     /// </summary>
@@ -35,7 +19,7 @@ public static partial class Ini
     [DoesNotReturn]
     private static void ThrowDuplicateKey(string key, int lineNumber) =>
         throw new IniFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_iniDuplicateKey, key, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_IniDuplicateKey, key, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a duplicate section name.
@@ -45,7 +29,7 @@ public static partial class Ini
     [DoesNotReturn]
     private static void ThrowDuplicateSection(string name, int lineNumber) =>
         throw new IniFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_iniDuplicateSection, name, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_IniDuplicateSection, name, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> when a key appears before the first section header and global
@@ -55,7 +39,7 @@ public static partial class Ini
     [DoesNotReturn]
     internal static void ThrowGlobalKeyDisallowed(int lineNumber) =>
         throw new IniFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_iniGlobalKeyDisallowed, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_IniGlobalKeyDisallowed, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a malformed section header.
@@ -64,7 +48,7 @@ public static partial class Ini
     [DoesNotReturn]
     internal static void ThrowMalformedSectionHeader(int lineNumber) =>
         throw new IniFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_iniMalformedSectionHeader, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_IniMalformedSectionHeader, lineNumber), lineNumber);
 
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a property line with an empty key.
@@ -73,7 +57,7 @@ public static partial class Ini
     [DoesNotReturn]
     internal static void ThrowMissingKey(int lineNumber) =>
         throw new IniFormatException(
-            string.Format(CultureInfo.CurrentCulture, s_iniMissingKey, lineNumber), lineNumber);
+            string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Format_Invalid_IniMissingKey, lineNumber), lineNumber);
 
     /// <summary>
     /// Provides line-by-line INI parsing over a <see cref="ReadOnlySpan{T}" /> of characters.

--- a/Bodu.Text.Formats/src/Text.Ini/IniSection.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/IniSection.cs
@@ -6,7 +6,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 
 namespace Bodu.Text.Ini;
 
@@ -42,12 +41,6 @@ namespace Bodu.Text.Ini;
 /// </example>
 public sealed class IniSection
 {
-    /// <summary>
-    /// Cached format for the <c>KeyNotFound</c> message.
-    /// </summary>
-    private static readonly CompositeFormat s_keyNotFound =
-        CompositeFormat.Parse(FormatsResourceStrings.Op_Invalid_IniSectionKeyNotFound);
-
     private readonly List<IniEntry> _entries;
     private readonly Dictionary<string, IniEntry> _lookup;
     private readonly List<IniComment> _leadingComments = new();
@@ -191,7 +184,7 @@ public sealed class IniSection
         ThrowHelper.ThrowIfNull(key);
 
         return !_lookup.TryGetValue(key, out IniEntry? entry)
-            ? throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, s_keyNotFound, key))
+            ? throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, FormatsResourceStrings.Op_Invalid_IniSectionKeyNotFound, key))
             : entry.GetValue<T>();
     }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,6 +458,8 @@ Every project that throws exceptions, prints diagnostics, or otherwise exposes u
 
 Use `{0}`, `{1}`, … for format placeholders and combine via `string.Format(CultureInfo.CurrentCulture, …)` at the throw site. All user-facing resource text — exception messages, validation diagnostics, and similar display strings — is formatted with `CultureInfo.CurrentCulture`; reserve `CultureInfo.InvariantCulture` for wire/serialization, code generation, and round-trippable parsing where the format must not vary by culture. Diagnostics live in code, not in the resource string — keep messages short and free of conditional grammar; let the caller insert the dynamic context.
 
+Analyzer note: **CA1863** ("Use 'CompositeFormat'") is disabled repo-wide in `.editorconfig`. Every site it flags formats a resx accessor on an exception/error path that runs once per failure, so caching parsed formats buys nothing measurable and would freeze resource resolution at type-init. Format resource-backed messages with plain `string.Format(CultureInfo.CurrentCulture, <Domain>ResourceStrings.<Key>, …)` at the throw/error site; do not introduce cached `CompositeFormat` fields for them.
+
 **Cross-file ThrowHelper convention:**
 
 Mirror the partial-file pattern used by `FinancialThrowHelper`:


### PR DESCRIPTION
## Summary

Remove static `CompositeFormat` caching fields from exception and error-reporting code paths across the codebase. These cached fields were parsed at type initialization and stored as static state, but the performance benefit is negligible on cold exception paths where the parse cost is dwarfed by the throw itself.

## Changes

- **ThrowHelper partial files** (`Comparison`, `Span`, `Array`, `Numeric`, `String`, `Type`, `Equality`, `Collection`): Removed all `CompositeFormat.Parse()` static field declarations and updated call sites to pass resource string accessors directly to `string.Format()`.

- **Text format parsers** (`Ini.Parser`, `DotEnv.Parser`, `Delimited.Parser`): Removed cached `CompositeFormat` fields and inlined resource strings at throw sites.

- **Document classes** (`DotEnvDocument`, `IniSection`, `DelimitedRow`): Removed cached format fields used in `KeyNotFoundException` and header-lookup error messages.

- **Removed imports**: Eliminated `using System.Text;` from all affected files (no longer needed for `CompositeFormat`).

- **.editorconfig**: Added justification for disabling CA1863 (the analyzer that suggests caching `CompositeFormat`). The diagnostic is suppressed because every flagged site formats a resource string on an exception/error path — cold code where parse cost is negligible compared to the throw, and caching would add unnecessary per-message static state and freeze resource resolution at type initialization against the documented resx + `CurrentCulture` convention.

## Rationale

Per CLAUDE.md (Static Text section), resource strings should be combined via `string.Format(CultureInfo.CurrentCulture, …)` at the throw site. Caching `CompositeFormat` objects as static fields contradicts this pattern by:
- Adding per-message static state
- Freezing resource resolution at type initialization
- Providing negligible performance gain on exception paths (which are inherently cold)

This change aligns the codebase with the documented convention and reduces unnecessary static initialization overhead.

https://claude.ai/code/session_01KyWju6svtx7u2BT6ugwJLS