### PR TITLE
Add XML documentation examples to cryptography and hashing types

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing/HashingStream.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/HashingStream.cs
@@ -29,6 +29,20 @@ namespace Bodu.IO.Hashing;
 /// is not thread-safe, so concurrent reads and writes through the same <see cref="HashingStream" /> are not supported.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Compute a CRC-32 over a payload while streaming it to its destination — a single pass over the bytes.
+/// using var source = File.OpenRead("payload.bin");
+/// using var destination = File.Create("payload.copy");
+/// using var hashing = new HashingStream(source, new Crc32());
+///
+/// hashing.CopyTo(destination);   // every byte read from the source is fed to the CRC-32
+///
+/// byte[] checksum = hashing.GetCurrentHash();
+///]]>
+/// </code>
+/// </example>
 public sealed class HashingStream : Stream
 {
     /// <summary>
@@ -146,6 +160,23 @@ public sealed class HashingStream : Stream
     /// </summary>
     /// <returns>The digest accumulated since construction or the previous reset.</returns>
     /// <exception cref="ObjectDisposedException">The stream has been disposed.</exception>
+    /// <remarks>
+    /// Resetting between segments lets a single <see cref="HashingStream" /> produce an independent digest per framed
+    /// message over one connection, without allocating a new stream for each frame.
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// using var hashing = new HashingStream(connection, new Crc32(), leaveOpen: true);
+    /// foreach (var frame in frames)
+    /// {
+    ///     hashing.Write(frame);
+    ///     byte[] frameDigest = hashing.GetHashAndReset();   // digest of this frame only
+    ///     Send(frameDigest);
+    /// }
+    ///]]>
+    /// </code>
+    /// </example>
     public byte[] GetHashAndReset()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -358,8 +389,12 @@ public sealed class HashingStream : Stream
     /// <summary>
     /// Seeks within the stream. Not supported.
     /// </summary>
-    /// <param name="offset">Ignored.</param>
-    /// <param name="origin">Ignored.</param>
+    /// <param name="offset">
+    /// The byte offset relative to <paramref name="origin" />. Not used; the method always throws.
+    /// </param>
+    /// <param name="origin">
+    /// The reference point for <paramref name="offset" />. Not used; the method always throws.
+    /// </param>
     /// <returns>This method always throws.</returns>
     /// <exception cref="NotSupportedException">Always thrown; the stream does not support seeking.</exception>
     public override long Seek(long offset, SeekOrigin origin) =>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AuthenticationTag.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AuthenticationTag.cs
@@ -28,6 +28,18 @@ namespace Bodu.Security.Cryptography;
 /// position of the first mismatching byte from the comparison time.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Capture the tag emitted by an AEAD encryption and store or transmit it with the ciphertext.
+/// AuthenticationTag tag = AuthenticationTag.FromBytes(producedTag);
+///
+/// // On the decrypt side, verify the recomputed tag in fixed time before trusting the plaintext.
+/// if (!tag.FixedTimeEquals(recomputedTag))
+///     throw new CryptographicException("Authentication failed; the message was altered.");
+///]]>
+/// </code>
+/// </example>
 public readonly struct AuthenticationTag : IEquatable<AuthenticationTag>
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/HashValue.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/HashValue.cs
@@ -28,6 +28,20 @@ namespace Bodu.Security.Cryptography;
 /// against a locally computed one — use <see cref="FixedTimeEquals(HashValue)" />.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Wrap a freshly computed digest, then format it for logging or storage.
+/// HashValue digest = HashValue.FromBytes(SHA256.HashData(payload));
+/// string hex = digest.ToHexString();   // lowercase, e.g. "e3b0c442..."
+///
+/// // Compare the digest against an expected value in fixed time before trusting the payload.
+/// HashValue expected = HashValue.ParseHex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+/// if (!digest.FixedTimeEquals(expected))
+///     throw new CryptographicException("Digest mismatch.");
+///]]>
+/// </code>
+/// </example>
 public readonly struct HashValue : IEquatable<HashValue>
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Nonce.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Nonce.cs
@@ -25,6 +25,19 @@ namespace Bodu.Security.Cryptography;
 /// where random collision is negligible (for example the 24-byte XChaCha20 nonce).
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Generate a fresh 12-byte nonce for an AES-GCM operation; it is unique per message, not secret.
+/// Nonce nonce = Nonce.Random(12);
+/// using var aes = new AesGcm(key, tagSizeInBytes: 16);
+/// aes.Encrypt(nonce.AsSpan(), plaintext, ciphertext, tag);
+///
+/// // The nonce travels with the ciphertext; reconstruct it on the receiving side to decrypt.
+/// Nonce received = Nonce.FromBytes(wireNonceBytes);
+///]]>
+/// </code>
+/// </example>
 public readonly struct Nonce : IEquatable<Nonce>
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Salt.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Salt.cs
@@ -21,6 +21,19 @@ namespace Bodu.Security.Cryptography;
 /// empty value: <see cref="Length" /> is <c>0</c> and <see cref="IsEmpty" /> is <see langword="true" />.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Generate a 16-byte salt for password hashing and persist it next to the derived value.
+/// Salt salt = Salt.Random(16);
+/// byte[] derived = Rfc2898DeriveBytes.Pbkdf2(
+///     password, salt.AsSpan(), iterations: 100_000, HashAlgorithmName.SHA256, outputLength: 32);
+///
+/// // The salt is not secret: reload it alongside the stored hash to recompute the value later.
+/// Salt reloaded = Salt.FromBytes(storedSaltBytes);
+///]]>
+/// </code>
+/// </example>
 public readonly struct Salt : IEquatable<Salt>
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SecretBytes.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SecretBytes.cs
@@ -29,6 +29,26 @@ namespace Bodu.Security.Cryptography;
 /// This type is not thread-safe; callers coordinate concurrent access and disposal.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Hold secret key material for the scope of an operation; the pinned buffer is zeroed on dispose.
+/// using SecretBytes key = SecretBytes.Random(32);
+///
+/// // Hand a transient copy to a BCL API that requires a byte[], then erase that copy as well.
+/// byte[] transient = key.ToArray();
+/// try
+/// {
+///     using var hmac = new HMACSHA256(transient);
+///     // ... use hmac ...
+/// }
+/// finally
+/// {
+///     CryptographicOperations.ZeroMemory(transient);
+/// }
+///]]>
+/// </code>
+/// </example>
 public sealed class SecretBytes : IDisposable
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SignatureValue.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SignatureValue.cs
@@ -27,6 +27,21 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="FixedTimeEquals(SignatureValue)" /> compares the bytes only, in fixed time.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Record a signature together with the wire encoding its producer emitted.
+/// SignatureValue signature = SignatureValue.FromBytes(signatureBytes, SignatureFormat.P1363);
+///
+/// // Downstream code branches on the recorded format instead of guessing, avoiding the classic
+/// // failure of feeding a fixed-width P1363 signature to a verifier that expects ASN.1 DER.
+/// ReadOnlySpan<byte> bytes = signature.AsSpan();
+/// bool valid = signature.Format == SignatureFormat.Der
+///     ? VerifyDer(bytes)
+///     : VerifyP1363(bytes);
+///]]>
+/// </code>
+/// </example>
 public readonly struct SignatureValue : IEquatable<SignatureValue>
 {
     /// <summary>


### PR DESCRIPTION
## Summary

This change enhances the XML documentation for key types in `Bodu.Security.Cryptography` and `Bodu.IO.Hashing` by adding practical `<example>` blocks that demonstrate real-world usage patterns. Additionally, documentation for the `Seek` method in `HashingStream` is clarified to better explain why the parameters are not used.

## Key Changes

- **HashingStream**: Added a class-level example showing how to compute a hash while streaming data in a single pass, and improved `Seek` method parameter documentation to clarify that the method always throws and does not use its arguments.

- **SecretBytes**: Added an example demonstrating secure key material handling, including pinned buffer zeroing on disposal and safe transient copy erasure.

- **SignatureValue**: Added an example showing how to record a signature with its wire encoding format and use that format information to route to the correct verifier (avoiding format mismatch failures).

- **HashValue**: Added an example demonstrating digest wrapping, hex formatting, and fixed-time comparison against an expected value.

- **Nonce**: Added an example showing random nonce generation for AES-GCM encryption and reconstruction on the receiving side.

- **Salt**: Added an example demonstrating salt generation for password hashing with PBKDF2 and reloading for later recomputation.

- **AuthenticationTag**: Added an example showing tag capture during AEAD encryption and fixed-time verification during decryption.

- **GetHashAndReset method**: Added remarks and an example illustrating how to use the method to produce independent digests per framed message over a single connection without allocating new streams.

## Implementation Details

All examples follow the existing documentation style in the repository, use `<![CDATA[…]]>` to preserve code formatting, and demonstrate practical scenarios that align with the security and cryptographic best practices these types are designed to support.

https://claude.ai/code/session_01UHGywX5kFug7YzvF4JKHw5