### PR TITLE
Recover RBA rates via decimal cast and guard it with a conversion KAT

### DIFF
--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateWorkbookParser.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateWorkbookParser.cs
@@ -4,7 +4,6 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using System.Globalization;
 using Bodu.Formats.Excel.Binary;
 
 namespace Bodu.Financial.ExchangeRates.Rba;
@@ -231,7 +230,7 @@ internal static class RbaExchangeRateWorkbookParser
         List<RbaExchangeRateRow> rows = new(dataRows.Count);
         foreach (var row in dataRows)
         {
-            double serial = grid[(row, 0)].NumberValue!.Value;
+            var serial = grid[(row, 0)].NumberValue!.Value;
             if (!double.IsFinite(serial))
                 continue;
 
@@ -284,17 +283,20 @@ internal static class RbaExchangeRateWorkbookParser
     }
 
     /// <summary>
-    /// Recovers the exact published decimal from a workbook double by round-tripping through its shortest string form.
+    /// Recovers the published decimal rate from a workbook double.
     /// </summary>
     /// <param name="value">The cell value as a double.</param>
     /// <returns>The recovered decimal.</returns>
     /// <remarks>
-    /// RBA rates are published with limited precision (for example, <c>0.6828</c>). Converting the double through its
-    /// shortest round-trippable string recovers that published value without the trailing binary-to-decimal noise a
-    /// direct cast can introduce.
+    /// RBA rates are published with limited precision (for example, <c>0.6828</c>), yet the workbook stores each as an
+    /// 8-byte IEEE 754 double that can sit up to one unit in the last place away from that figure. The explicit
+    /// <see langword="double" />-to-<see langword="decimal" /> conversion rounds to 15 significant digits, which
+    /// absorbs that sub-15-digit binary noise and restores the published value; every RBA rate carries far fewer than
+    /// 15 significant digits, so none is truncated. A shortest-round-trip string conversion instead preserves the noise
+    /// — for example, yielding <c>6.6754999999999995</c> for a cell published as <c>6.6755</c>.
     /// </remarks>
-    private static decimal RecoverDecimal(double value) =>
-        decimal.Parse(value.ToString("R", CultureInfo.InvariantCulture), NumberStyles.Float, CultureInfo.InvariantCulture);
+    internal static decimal RecoverDecimal(double value) =>
+        (decimal)value;
 
     /// <summary>
     /// Reads the trimmed text of a cell, returning an empty string when the cell is absent, non-text, or the row is

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateWorkbookParserTests.RecoverDecimal.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateWorkbookParserTests.RecoverDecimal.cs
@@ -1,0 +1,54 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RbaExchangeRateWorkbookParserTests.RecoverDecimal.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using Bodu.Test.Kat;
+
+namespace Bodu.Financial.ExchangeRates.Rba;
+
+/// <content>
+/// Verifies that workbook cell values are recovered as the decimal rate RBA published, across the range of magnitudes
+/// and decimal precisions the era files contain.
+/// </content>
+public partial class RbaExchangeRateWorkbookParserTests
+{
+    /// <summary>
+    /// Gets the decimal-recovery known-answer rows: each pairs the <see langword="double" /> stored in a workbook cell
+    /// with the decimal RBA published for it. The rows span sub-unit and large magnitudes, two to eight decimal places,
+    /// and stored values that sit one unit in the last place from the published figure.
+    /// </summary>
+    /// <returns>One object array per known-answer row.</returns>
+    public static IEnumerable<object[]> RecoverDecimalCases =>
+        new[]
+        {
+            new ValidKat<double, decimal>("four decimal places, sub-unit (USD)", 0.6828, 0.6828m),
+            new ValidKat<double, decimal>("four decimal places, single digit (CNY)", 4.6994, 4.6994m),
+            new ValidKat<double, decimal>("two decimal places, three digit (JPY)", 112.71, 112.71m),
+            new ValidKat<double, decimal>("two decimal places, large magnitude", 841.23, 841.23m),
+            new ValidKat<double, decimal>("integer rate, no decimal places", 9019d, 9019m),
+            new ValidKat<double, decimal>("eight decimal places preserved", 1.23456789, 1.23456789m),
+            new ValidKat<double, decimal>("stored one ULP below published (ZAR 2010-01-04)", 6.6754999999999995, 6.6755m),
+            new ValidKat<double, decimal>("stored one ULP above published (SAR 2011-02-10)", 3.7781000000000002, 3.7781m),
+        }
+        .Select(kat => new object[] { kat });
+
+    /// <summary>
+    /// Verifies that <see cref="RbaExchangeRateWorkbookParser.RecoverDecimal(double)" /> returns the decimal RBA
+    /// published for a workbook cell regardless of the value's magnitude or decimal precision, including stored doubles
+    /// that differ from the published figure by one unit in the last place.
+    /// </summary>
+    /// <param name="kat">The known-answer row pairing a workbook double with its published decimal.</param>
+    [TestMethod]
+    [DynamicData(nameof(RecoverDecimalCases), DynamicDataDisplayName = nameof(KatDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(KatDisplayName))]
+    public void RecoverDecimal_WhenWorkbookDouble_ShouldReturnPublishedDecimal(ValidKat<double, decimal> kat)
+    {
+        ArgumentNullException.ThrowIfNull(kat);
+
+        var actual = RbaExchangeRateWorkbookParser.RecoverDecimal(kat.Input);
+
+        Assert.AreEqual(kat.Expected, actual);
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateWorkbookParserTests.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateWorkbookParserTests.cs
@@ -14,7 +14,7 @@ namespace Bodu.Financial.ExchangeRates.Rba;
 /// Verifies that <see cref="RbaExchangeRateWorkbookParser" /> interprets the RBA workbook layout correctly.
 /// </summary>
 [TestClass]
-public class RbaExchangeRateWorkbookParserTests
+public partial class RbaExchangeRateWorkbookParserTests
 {
     /// <summary>
     /// Parses the embedded sample workbook with default options.


### PR DESCRIPTION
## Summary

Fixes the two known-answer rows that fail on `master` (`2010-2013.xls` **AUD/ZAR 2010-01-04** and **AUD/SAR 2011-02-10**) and adds a focused, fixture-independent regression test for the workbook-double → published-decimal conversion.

## Root cause

Each rate is stored in the workbook as a full 8-byte IEEE-754 `double` (a `NUMBER` record), and that double can sit up to **one unit in the last place** from the figure RBA published. For example, the ZAR cell published as `6.6755` is physically stored as `6.6754999999999995`. `RbaExchangeRateWorkbookParser.RecoverDecimal` round-tripped the double through its shortest string form (`double.ToString("R")` → `decimal.Parse`), which faithfully reproduced that binary noise — so it returned `6.6754999999999995` instead of `6.6755`. Only the handful of cells whose stored double is the off-by-1-ULP neighbour were affected (2 of 1,075 known-answer rows).

## Fix

`RecoverDecimal` now uses the explicit `double`-to-`decimal` cast. Its documented **15-significant-digit rounding** absorbs the sub-15-digit binary noise and restores the published value. Every RBA rate carries far fewer than 15 significant digits, so nothing is truncated and every previously-correct value is byte-identical (verified across magnitudes: `0.6828`, `4.6994`, `112.71`, `841.23`, integers, and 8-dp values).

## Regression infrastructure

New member-based partial `RbaExchangeRateWorkbookParserTests.RecoverDecimal.cs` — a data-driven known-answer test (`ValidKat<double, decimal>`) over the conversion, spanning sub-unit to large magnitudes and two-to-eight decimal places, and pinning the two stored-one-ULP-off cases (`6.6755`, `3.7781`). `RecoverDecimal` is now `internal` (the test assembly already has `InternalsVisibleTo`) so the guard runs **without** the large per-era workbook fixtures — CI protects the conversion regardless of which `.xls` files are committed. It's left in the default BVT tier so it always runs.

## Verification

`dotnet test … --settings regression.runsettings` → **1,328 passed, 0 failed** against current `master` (the full embedded era set), including the two previously-failing rows and the eight new conversion cases. Formatter clean.

https://claude.ai/code/session_011CNjpUDdVQRZSXcPqJdkt3

---
_Generated by [Claude Code](https://claude.ai/code/session_011CNjpUDdVQRZSXcPqJdkt3)_