### PR TITLE
Add structured logging support across calendar and exchange-rate libraries

### DIFF
--- a/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/src/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/src/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/src/Financial.ExchangeRates.Boe.DependencyInjection/BoeFinancialServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/src/Financial.ExchangeRates.Boe.DependencyInjection/BoeFinancialServiceBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Bodu.Financial.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Bodu.Financial.ExchangeRates.Boe.DependencyInjection;
@@ -76,7 +77,7 @@ public static class BoeFinancialServiceBuilderExtensions
         {
             HttpClient client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientName);
             BoeExchangeRateOptions options = serviceProvider.GetRequiredService<IOptions<BoeExchangeRateOptions>>().Value;
-            return new BoeExchangeRateProvider(client, options);
+            return new BoeExchangeRateProvider(client, options, serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<BoeExchangeRateProvider>());
         });
         services.TryAddSingleton<IDatedExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<BoeExchangeRateProvider>());
         services.TryAddSingleton<IExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<BoeExchangeRateProvider>());

--- a/Bodu.Financial.ExchangeRates.Boe/README.md
+++ b/Bodu.Financial.ExchangeRates.Boe/README.md
@@ -47,4 +47,37 @@ foreach (BoeSeriesInfo info in provider.GetAvailablePairs())
   user-agent — so the query can be pointed at a mirror or proxy without touching caching or
   series configuration. See the `*.DependencyInjection` package for `AddBoeReferenceRates`.
 
+## Logging
+
+The provider logs through `Microsoft.Extensions.Logging`. Pass an `ILogger` to the
+constructor, or let the `*.DependencyInjection` package wire one for you (category
+`Bodu.Financial.ExchangeRates.Boe.BoeExchangeRateProvider`). When no logger is supplied it
+defaults to `NullLogger.Instance`, so logging is entirely opt-in and free when unused.
+
+The levels follow the conventions used by `Microsoft.Extensions.Http`, EF Core, and the
+Azure SDK — the completed download is the one `Information` line per range loaded, payload
+detail is `Trace`, and degraded paths are `Warning`. Every level is individually
+configurable on `BoeExchangeRateOptions`:
+
+| Event | Default level | Option property |
+|---|---|---|
+| A range download is starting | `Debug` | `DownloadStartingLogLevel` |
+| A range loaded (with its observation count) | `Information` | `DownloadCompletedLogLevel` |
+| Each individual rate observation ingested | `Trace` | `ObservationIngestedLogLevel` |
+| A range download failed (logged, then re-thrown) | `Warning` | `DownloadFailedLogLevel` |
+
+```csharp
+// Quieten the per-range line and turn off per-observation tracing entirely.
+var options = new BoeExchangeRateOptions
+{
+    DownloadCompletedLogLevel = LogLevel.Debug,
+    ObservationIngestedLogLevel = LogLevel.None,
+};
+```
+
+The default verbosity is deliberately low: at `Information` you see one line per range
+loaded; at `Debug` you additionally see when downloads start; only at `Trace` do you get a
+line per rate observation (which can be thousands per range — keep it for targeted
+debugging).
+
 Part of the [Bodu](https://github.com/bodu/bodu) utility library.

--- a/Bodu.Financial.ExchangeRates.Boe/src/Bodu.Financial.ExchangeRates.Boe.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Bodu.Financial.ExchangeRates.Boe.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\..\Bodu.Text.Formats\src\Bodu.Text.Formats.csproj" />

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateOptions.cs
@@ -13,9 +13,16 @@ using Microsoft.Extensions.Logging;
 /// spot exchange-rate data.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Every member carries a working default, so the options bind cleanly through <c>Microsoft.Extensions.Options</c> and
 /// require no configuration for the common case. The dependency-injection package binds this type from configuration
 /// and a <c>configure</c> delegate.
+/// </para>
+/// <para>
+/// The <c>*LogLevel</c> members set the <see cref="LogLevel" /> at which each diagnostic the provider emits is logged,
+/// so consumers can re-tune verbosity per concern without category-wide log filters. Set any of them to
+/// <see cref="LogLevel.None" /> to suppress that event entirely.
+/// </para>
 /// </remarks>
 public sealed class BoeExchangeRateOptions
 {

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateOptions.cs
@@ -6,6 +6,8 @@
 
 namespace Bodu.Financial.ExchangeRates.Boe;
 
+using Microsoft.Extensions.Logging;
+
 /// <summary>
 /// Configures how the <see cref="BoeExchangeRateProvider" /> downloads, caches, and interprets Bank of England daily
 /// spot exchange-rate data.
@@ -82,6 +84,30 @@ public sealed class BoeExchangeRateOptions
     /// are treated as refreshable rather than immutable.
     /// </remarks>
     public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// Gets or sets the level at which the start of a range download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    public LogLevel DownloadStartingLogLevel { get; set; } = LogLevel.Debug;
+
+    /// <summary>
+    /// Gets or sets the level at which a completed range download (with its observation count) is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Information" />.</value>
+    public LogLevel DownloadCompletedLogLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Gets or sets the level at which a failed range download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Warning" />.</value>
+    public LogLevel DownloadFailedLogLevel { get; set; } = LogLevel.Warning;
+
+    /// <summary>
+    /// Gets or sets the level at which each individual ingested rate observation is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Trace" />.</value>
+    public LogLevel ObservationIngestedLogLevel { get; set; } = LogLevel.Trace;
 
     /// <summary>
     /// Validates the options, throwing when a required value is missing.

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
@@ -29,6 +29,14 @@ namespace Bodu.Financial.ExchangeRates.Boe;
 /// around that date and retry. Inverse pairs, same-currency identity, and date-resolution policies are inherited from
 /// <see cref="FixedDatedExchangeRateProvider" />.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
+/// package) the provider records: the start of a range download (<see cref="LogLevel.Debug" />), a completed download
+/// with its observation count (<see cref="LogLevel.Information" />), each ingested observation
+/// (<see cref="LogLevel.Trace" />), and a failed download (<see cref="LogLevel.Warning" />, then re-thrown). Every level
+/// is configurable through the corresponding <c>*LogLevel</c> property on <see cref="BoeExchangeRateOptions" />; omitting
+/// the logger selects <see cref="NullLogger.Instance" />, so logging is opt-in and free when unused.
+/// </para>
 /// </remarks>
 public sealed class BoeExchangeRateProvider
     : IDatedExchangeRateProvider, IExchangeRateProvider

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
@@ -5,6 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Financial.ExchangeRates.Boe;
 
@@ -89,17 +91,26 @@ public sealed class BoeExchangeRateProvider
     private volatile FixedDatedExchangeRateProvider _snapshot;
 
     /// <summary>
+    /// The logger that records range downloads and on-demand network fetches.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="BoeExchangeRateProvider" /> class backed by the IADB CSV endpoint,
     /// queried with the supplied HTTP client.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to download range responses.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records range downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    public BoeExchangeRateProvider(HttpClient httpClient, BoeExchangeRateOptions options)
-        : this(CreateSource(httpClient, options), options)
+    public BoeExchangeRateProvider(HttpClient httpClient, BoeExchangeRateOptions options, ILogger? logger = null)
+        : this(CreateSource(httpClient, options), options, logger)
     {
     }
 
@@ -109,11 +120,15 @@ public sealed class BoeExchangeRateProvider
     /// </summary>
     /// <param name="source">The table source.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records range downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    internal BoeExchangeRateProvider(IBoeExchangeRateTableSource source, BoeExchangeRateOptions options)
+    internal BoeExchangeRateProvider(IBoeExchangeRateTableSource source, BoeExchangeRateOptions options, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -121,6 +136,7 @@ public sealed class BoeExchangeRateProvider
 
         _source = source;
         _options = options;
+        _logger = logger ?? NullLogger.Instance;
         _book = _builder.ToBook();
         _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
@@ -208,13 +224,25 @@ public sealed class BoeExchangeRateProvider
                 return;
         }
 
-        BoeExchangeRateTable table = await _source.GetTableAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
+        Log.FeedLoadStarting(_logger, startDate, endDate);
+
+        BoeExchangeRateTable table;
+        try
+        {
+            table = await _source.GetTableAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.FeedLoadFailed(_logger, startDate, endDate, ex);
+            throw;
+        }
 
         lock (_gate)
         {
-            Accumulate(table);
+            var count = Accumulate(table);
             _loadedRanges.Add((startDate, endDate));
             RebuildSnapshot();
+            Log.FeedLoaded(_logger, startDate, endDate, count);
         }
     }
 
@@ -331,13 +359,20 @@ public sealed class BoeExchangeRateProvider
     /// Upserts a parsed table's observations and series metadata into the accumulator.
     /// </summary>
     /// <param name="table">The parsed table.</param>
-    private void Accumulate(BoeExchangeRateTable table)
+    /// <returns>The number of rate observations upserted.</returns>
+    private int Accumulate(BoeExchangeRateTable table)
     {
         foreach (BoeSeriesInfo info in table.GetSeriesInfo())
             _series[info.Pair] = info;
 
+        var count = 0;
         foreach (ExchangeRate rate in table.EnumerateRates())
+        {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            count++;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
@@ -369,6 +369,7 @@ public sealed class BoeExchangeRateProvider
         foreach (ExchangeRate rate in table.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
@@ -224,7 +224,7 @@ public sealed class BoeExchangeRateProvider
                 return;
         }
 
-        Log.FeedLoadStarting(_logger, startDate, endDate);
+        Log.FeedLoadStarting(_logger, _options.DownloadStartingLogLevel, startDate, endDate);
 
         BoeExchangeRateTable table;
         try
@@ -233,7 +233,7 @@ public sealed class BoeExchangeRateProvider
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            Log.FeedLoadFailed(_logger, startDate, endDate, ex);
+            Log.FeedLoadFailed(_logger, _options.DownloadFailedLogLevel, startDate, endDate, ex);
             throw;
         }
 
@@ -242,7 +242,7 @@ public sealed class BoeExchangeRateProvider
             var count = Accumulate(table);
             _loadedRanges.Add((startDate, endDate));
             RebuildSnapshot();
-            Log.FeedLoaded(_logger, startDate, endDate, count);
+            Log.FeedLoaded(_logger, _options.DownloadCompletedLogLevel, startDate, endDate, count);
         }
     }
 
@@ -369,7 +369,7 @@ public sealed class BoeExchangeRateProvider
         foreach (ExchangeRate rate in table.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/Log.cs
@@ -35,8 +35,19 @@ internal static partial class Log
     /// <param name="startDate">The inclusive start of the loaded range.</param>
     /// <param name="endDate">The inclusive end of the loaded range.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the range.</param>
-    [LoggerMessage(EventId = 4202, Level = LogLevel.Debug, Message = "Loaded BoE range '{startDate}'..'{endDate}' with {rateCount} rate observation(s)")]
+    [LoggerMessage(EventId = 4202, Level = LogLevel.Information, Message = "Loaded BoE range '{startDate}'..'{endDate}' with {rateCount} rate observation(s)")]
     public static partial void FeedLoaded(ILogger logger, DateOnly startDate, DateOnly endDate, int rateCount);
+
+    /// <summary>
+    /// Logs an individual rate observation ingested from a range, for fine-grained diagnostics.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The observed rate.</param>
+    [LoggerMessage(EventId = 4205, Level = LogLevel.Trace, Message = "Ingested BoE observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that a range download failed.

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/Log.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Boe;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted by <see cref="BoeExchangeRateProvider" />
+/// while downloading and serving Bank of England daily spot rates.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that a range download is starting.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="startDate">The inclusive start of the range being downloaded.</param>
+    /// <param name="endDate">The inclusive end of the range being downloaded.</param>
+    [LoggerMessage(EventId = 4201, Level = LogLevel.Debug, Message = "Downloading BoE range '{startDate}'..'{endDate}'")]
+    public static partial void FeedLoadStarting(ILogger logger, DateOnly startDate, DateOnly endDate);
+
+    /// <summary>
+    /// Logs that a range was downloaded and its observations were accumulated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="startDate">The inclusive start of the loaded range.</param>
+    /// <param name="endDate">The inclusive end of the loaded range.</param>
+    /// <param name="rateCount">The number of rate observations accumulated from the range.</param>
+    [LoggerMessage(EventId = 4202, Level = LogLevel.Debug, Message = "Loaded BoE range '{startDate}'..'{endDate}' with {rateCount} rate observation(s)")]
+    public static partial void FeedLoaded(ILogger logger, DateOnly startDate, DateOnly endDate, int rateCount);
+
+    /// <summary>
+    /// Logs that a range download failed.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="startDate">The inclusive start of the range whose download failed.</param>
+    /// <param name="endDate">The inclusive end of the range whose download failed.</param>
+    /// <param name="exception">The exception that caused the failure.</param>
+    [LoggerMessage(EventId = 4203, Level = LogLevel.Warning, Message = "Failed to download BoE range '{startDate}'..'{endDate}'")]
+    public static partial void FeedLoadFailed(ILogger logger, DateOnly startDate, DateOnly endDate, Exception exception);
+}

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/Log.cs
@@ -23,39 +23,43 @@ internal static partial class Log
     /// Logs that a range download is starting.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="startDate">The inclusive start of the range being downloaded.</param>
     /// <param name="endDate">The inclusive end of the range being downloaded.</param>
-    [LoggerMessage(EventId = 4201, Level = LogLevel.Debug, Message = "Downloading BoE range '{startDate}'..'{endDate}'")]
-    public static partial void FeedLoadStarting(ILogger logger, DateOnly startDate, DateOnly endDate);
+    [LoggerMessage(EventId = 4201, Message = "Downloading BoE range '{startDate}'..'{endDate}'")]
+    public static partial void FeedLoadStarting(ILogger logger, LogLevel level, DateOnly startDate, DateOnly endDate);
 
     /// <summary>
     /// Logs that a range was downloaded and its observations were accumulated.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="startDate">The inclusive start of the loaded range.</param>
     /// <param name="endDate">The inclusive end of the loaded range.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the range.</param>
-    [LoggerMessage(EventId = 4202, Level = LogLevel.Information, Message = "Loaded BoE range '{startDate}'..'{endDate}' with {rateCount} rate observation(s)")]
-    public static partial void FeedLoaded(ILogger logger, DateOnly startDate, DateOnly endDate, int rateCount);
+    [LoggerMessage(EventId = 4202, Message = "Loaded BoE range '{startDate}'..'{endDate}' with {rateCount} rate observation(s)")]
+    public static partial void FeedLoaded(ILogger logger, LogLevel level, DateOnly startDate, DateOnly endDate, int rateCount);
 
     /// <summary>
     /// Logs an individual rate observation ingested from a range, for fine-grained diagnostics.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The observation date.</param>
     /// <param name="rate">The observed rate.</param>
-    [LoggerMessage(EventId = 4205, Level = LogLevel.Trace, Message = "Ingested BoE observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
-    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
+    [LoggerMessage(EventId = 4205, Message = "Ingested BoE observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, LogLevel level, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that a range download failed.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="startDate">The inclusive start of the range whose download failed.</param>
     /// <param name="endDate">The inclusive end of the range whose download failed.</param>
     /// <param name="exception">The exception that caused the failure.</param>
-    [LoggerMessage(EventId = 4203, Level = LogLevel.Warning, Message = "Failed to download BoE range '{startDate}'..'{endDate}'")]
-    public static partial void FeedLoadFailed(ILogger logger, DateOnly startDate, DateOnly endDate, Exception exception);
+    [LoggerMessage(EventId = 4203, Message = "Failed to download BoE range '{startDate}'..'{endDate}'")]
+    public static partial void FeedLoadFailed(ILogger logger, LogLevel level, DateOnly startDate, DateOnly endDate, Exception exception);
 }

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/src/Financial.ExchangeRates.Caching.DependencyInjection/ExchangeRateCachingServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/src/Financial.ExchangeRates.Caching.DependencyInjection/ExchangeRateCachingServiceBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Bodu.Financial.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Bodu.Financial.ExchangeRates.Caching.DependencyInjection;
@@ -142,7 +143,8 @@ public static class ExchangeRateCachingServiceBuilderExtensions
                 sources(serviceProvider),
                 serviceProvider.GetRequiredService<IExchangeRateCache>(),
                 serviceProvider.GetRequiredService<IOptions<CachingExchangeRateOptions>>().Value,
-                serviceProvider.GetService<TimeProvider>()));
+                serviceProvider.GetService<TimeProvider>(),
+                serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<CachingDatedExchangeRateProvider>()));
 
         return builder;
     }

--- a/Bodu.Financial.ExchangeRates.Caching/README.md
+++ b/Bodu.Financial.ExchangeRates.Caching/README.md
@@ -47,3 +47,36 @@ concrete provider (Yahoo / RBA / ECB / BoE)
 
 For dependency-injection wiring, see
 `Bodu.Financial.ExchangeRates.Caching.DependencyInjection`.
+
+## Logging
+
+The caching provider logs through `Microsoft.Extensions.Logging`. Pass an `ILogger` to the
+constructor, or let the `*.DependencyInjection` package wire one for you (category
+`Bodu.Financial.ExchangeRates.Caching.CachingDatedExchangeRateProvider`). When no logger is
+supplied it defaults to `NullLogger.Instance`, so logging is entirely opt-in and free when
+unused.
+
+Single-date lookups happen on the read hot path (once per conversion), so their hit/miss
+diagnostics default to `Trace` — following the convention of dedicated cache libraries such
+as CacheManager, which keep per-operation logging at `Trace` to avoid flooding at high call
+rates. Coarser range operations default to `Debug`. The actual network hit is logged by the
+wrapped source provider (typically at `Information`), not here. Every level is individually
+configurable on `CachingExchangeRateOptions`:
+
+| Event | Default level | Option property |
+|---|---|---|
+| A single-date lookup served from the cache | `Trace` | `CacheHitLogLevel` |
+| A single-date cache miss resolved from a source and cached | `Trace` | `CacheMissLogLevel` |
+| A range lookup served entirely from the cache | `Debug` | `CacheRangeHitLogLevel` |
+| A range lookup refetched from a source and re-cached | `Debug` | `CacheRangeRefetchLogLevel` |
+
+```csharp
+// Promote per-lookup cache diagnostics to Debug for a noisy local debugging session.
+var options = new CachingExchangeRateOptions
+{
+    CacheHitLogLevel = LogLevel.Debug,
+    CacheMissLogLevel = LogLevel.Debug,
+};
+```
+
+Part of the [Bodu](https://github.com/bodu/bodu) utility library.

--- a/Bodu.Financial.ExchangeRates.Caching/src/Bodu.Financial.ExchangeRates.Caching.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Bodu.Financial.ExchangeRates.Caching.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\..\Bodu.Text.Toml\src\Bodu.Text.Toml.csproj" />

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProvider.cs
@@ -25,6 +25,16 @@ namespace Bodu.Financial.ExchangeRates.Caching;
 /// When several sources are supplied the provider behaves as a caching composite, consulting the sources in the order
 /// they were supplied and returning the first that can satisfy the request.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
+/// package) the provider records, on the read hot path, a single-date cache hit and a single-date miss-then-store
+/// (both <see cref="LogLevel.Trace" /> by default, mirroring per-operation cache logging in libraries such as
+/// CacheManager), and, for ranges, a cache hit and a refetch (both <see cref="LogLevel.Debug" /> by default). The
+/// underlying network fetch is logged by the wrapped source, not here. Every level is configurable through the
+/// corresponding <c>Cache*LogLevel</c> property on <see cref="CachingExchangeRateOptions" />; omitting the logger
+/// selects <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance" />, so logging is opt-in and free
+/// when unused.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProvider.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
 
 namespace Bodu.Financial.ExchangeRates.Caching;
 
@@ -75,6 +76,10 @@ public sealed class CachingDatedExchangeRateProvider
     /// The time source used to evaluate freshness and stamp newly cached rows. <see langword="null" /> selects
     /// <see cref="TimeProvider.System" />.
     /// </param>
+    /// <param name="logger">
+    /// The logger that records cache hits, misses, and refetches. <see langword="null" /> selects
+    /// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="sources" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
@@ -85,8 +90,9 @@ public sealed class CachingDatedExchangeRateProvider
     public CachingDatedExchangeRateProvider(
         IEnumerable<KeyValuePair<string, IDatedExchangeRateProvider>> sources,
         CachingExchangeRateOptions options,
-        TimeProvider? timeProvider = null)
-        : this(sources, CreateCache(options), options, timeProvider)
+        TimeProvider? timeProvider = null,
+        ILogger? logger = null)
+        : this(sources, CreateCache(options), options, timeProvider, logger)
     {
     }
 
@@ -104,6 +110,10 @@ public sealed class CachingDatedExchangeRateProvider
     /// The time source used to evaluate freshness and stamp newly cached rows. <see langword="null" /> selects
     /// <see cref="TimeProvider.System" />.
     /// </param>
+    /// <param name="logger">
+    /// The logger that records cache hits, misses, and refetches. <see langword="null" /> selects
+    /// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="sources" />, <paramref name="cache" />, or <paramref name="options" /> is
     /// <see langword="null" />.
@@ -116,8 +126,9 @@ public sealed class CachingDatedExchangeRateProvider
         IEnumerable<KeyValuePair<string, IDatedExchangeRateProvider>> sources,
         IExchangeRateCache cache,
         CachingExchangeRateOptions options,
-        TimeProvider? timeProvider = null)
-        : base(cache, options, timeProvider)
+        TimeProvider? timeProvider = null,
+        ILogger? logger = null)
+        : base(cache, options, timeProvider, logger)
     {
         _sources = ValidateSources(sources);
     }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateOptions.cs
@@ -14,8 +14,16 @@ namespace Bodu.Financial.ExchangeRates.Caching;
 /// rate stays fresh, and per-provider overrides of that default.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Every member carries a working default, so the options bind cleanly through <c>Microsoft.Extensions.Options</c> and
 /// require no configuration for the common case.
+/// </para>
+/// <para>
+/// The <c>Cache*LogLevel</c> members set the <see cref="LogLevel" /> at which each cache diagnostic is logged, so
+/// consumers can re-tune verbosity per concern without category-wide log filters. The per-lookup hit and miss events
+/// default to <see cref="LogLevel.Trace" /> because they run on the read hot path; the range events default to
+/// <see cref="LogLevel.Debug" />. Set any member to <see cref="LogLevel.None" /> to suppress that event entirely.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateOptions.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
 
 namespace Bodu.Financial.ExchangeRates.Caching;
 
@@ -60,6 +61,30 @@ public sealed class CachingExchangeRateOptions
     /// <see cref="DefaultExpiry" />.
     /// </value>
     public IDictionary<string, TimeSpan> ProviderExpiry { get; } = new Dictionary<string, TimeSpan>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets or sets the level at which a single-date lookup served from the cache is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Trace" />.</value>
+    public LogLevel CacheHitLogLevel { get; set; } = LogLevel.Trace;
+
+    /// <summary>
+    /// Gets or sets the level at which a single-date cache miss resolved from a source and then cached is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Trace" />.</value>
+    public LogLevel CacheMissLogLevel { get; set; } = LogLevel.Trace;
+
+    /// <summary>
+    /// Gets or sets the level at which a range lookup served entirely from the cache is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    public LogLevel CacheRangeHitLogLevel { get; set; } = LogLevel.Debug;
+
+    /// <summary>
+    /// Gets or sets the level at which a range lookup refetched from a source and re-cached is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    public LogLevel CacheRangeRefetchLogLevel { get; set; } = LogLevel.Debug;
 
     /// <summary>
     /// Resolves the caching duration for a provider, returning its specific override when present and the default

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
@@ -5,6 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Financial.ExchangeRates.Caching;
 
@@ -46,6 +48,11 @@ public abstract class CachingExchangeRateProviderBase
     private readonly TimeProvider _timeProvider;
 
     /// <summary>
+    /// The logger that records cache hits, misses, and refetches.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CachingExchangeRateProviderBase" /> class.
     /// </summary>
     /// <param name="cache">The cache that serves fresh rates and stores resolved observations.</param>
@@ -54,11 +61,15 @@ public abstract class CachingExchangeRateProviderBase
     /// The time source used to evaluate freshness and stamp newly cached rows. <see langword="null" /> selects
     /// <see cref="TimeProvider.System" />.
     /// </param>
+    /// <param name="logger">
+    /// The logger that records cache hits, misses, and refetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="cache" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    protected CachingExchangeRateProviderBase(IExchangeRateCache cache, CachingExchangeRateOptions options, TimeProvider? timeProvider)
+    protected CachingExchangeRateProviderBase(IExchangeRateCache cache, CachingExchangeRateOptions options, TimeProvider? timeProvider, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(cache);
         ThrowHelper.ThrowIfNull(options);
@@ -67,6 +78,7 @@ public abstract class CachingExchangeRateProviderBase
         _cache = cache;
         _options = options;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <summary>
@@ -94,11 +106,15 @@ public abstract class CachingExchangeRateProviderBase
             var duration = _options.GetExpiry(source.Key);
 
             if (TryServeFromCache(source.Key, duration, fromIsoCode, toIsoCode, date, options, now, out result))
+            {
+                Log.CacheHit(_logger, source.Key, fromIsoCode, toIsoCode, date);
                 return true;
+            }
 
             if (source.Value.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
             {
                 StoreResult(source.Key, duration, fromIsoCode, toIsoCode, result, now);
+                Log.CacheMissStored(_logger, source.Key, fromIsoCode, toIsoCode, date);
                 return true;
             }
         }
@@ -126,7 +142,10 @@ public abstract class CachingExchangeRateProviderBase
             var duration = _options.GetExpiry(source.Key);
 
             if (TryServeRangeFromCache(source.Key, duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
+            {
+                Log.RangeCacheHit(_logger, source.Key, fromIsoCode, toIsoCode);
                 return cached;
+            }
 
             IReadOnlyList<ExchangeRate> fetched =
                 await source.Value.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false);
@@ -134,6 +153,7 @@ public abstract class CachingExchangeRateProviderBase
             if (fetched.Count > 0)
             {
                 StoreRange(source.Key, duration, pair, fetched, now);
+                Log.RangeRefetched(_logger, source.Key, fromIsoCode, toIsoCode, fetched.Count);
                 return fetched;
             }
         }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
@@ -107,14 +107,14 @@ public abstract class CachingExchangeRateProviderBase
 
             if (TryServeFromCache(source.Key, duration, fromIsoCode, toIsoCode, date, options, now, out result))
             {
-                Log.CacheHit(_logger, source.Key, fromIsoCode, toIsoCode, date);
+                Log.CacheHit(_logger, _options.CacheHitLogLevel, source.Key, fromIsoCode, toIsoCode, date);
                 return true;
             }
 
             if (source.Value.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
             {
                 StoreResult(source.Key, duration, fromIsoCode, toIsoCode, result, now);
-                Log.CacheMissStored(_logger, source.Key, fromIsoCode, toIsoCode, date);
+                Log.CacheMissStored(_logger, _options.CacheMissLogLevel, source.Key, fromIsoCode, toIsoCode, date);
                 return true;
             }
         }
@@ -143,7 +143,7 @@ public abstract class CachingExchangeRateProviderBase
 
             if (TryServeRangeFromCache(source.Key, duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
             {
-                Log.RangeCacheHit(_logger, source.Key, fromIsoCode, toIsoCode);
+                Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, source.Key, fromIsoCode, toIsoCode);
                 return cached;
             }
 
@@ -153,7 +153,7 @@ public abstract class CachingExchangeRateProviderBase
             if (fetched.Count > 0)
             {
                 StoreRange(source.Key, duration, pair, fetched, now);
-                Log.RangeRefetched(_logger, source.Key, fromIsoCode, toIsoCode, fetched.Count);
+                Log.RangeRefetched(_logger, _options.CacheRangeRefetchLogLevel, source.Key, fromIsoCode, toIsoCode, fetched.Count);
                 return fetched;
             }
         }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Caching;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted by
+/// <see cref="CachingExchangeRateProviderBase" /> while serving rates from the cache and delegating to wrapped sources.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that a single-date lookup was served from the cache.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="source">The source name the fresh rows are cached under.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The requested date.</param>
+    [LoggerMessage(EventId = 4501, Level = LogLevel.Debug, Message = "Served {fromIsoCode}->{toIsoCode} on {date} from cache for source '{source}'")]
+    public static partial void CacheHit(ILogger logger, string source, string fromIsoCode, string toIsoCode, DateOnly date);
+
+    /// <summary>
+    /// Logs that a single-date lookup missed the cache and was resolved from a wrapped source and then cached.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="source">The source name consulted on the miss.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The requested date.</param>
+    [LoggerMessage(EventId = 4502, Level = LogLevel.Debug, Message = "Cache miss for {fromIsoCode}->{toIsoCode} on {date}; resolved from source '{source}' and cached")]
+    public static partial void CacheMissStored(ILogger logger, string source, string fromIsoCode, string toIsoCode, DateOnly date);
+
+    /// <summary>
+    /// Logs that a range lookup was served entirely from the cache.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="source">The source name the fresh rows are cached under.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    [LoggerMessage(EventId = 4503, Level = LogLevel.Debug, Message = "Served {fromIsoCode}->{toIsoCode} range from cache for source '{source}'")]
+    public static partial void RangeCacheHit(ILogger logger, string source, string fromIsoCode, string toIsoCode);
+
+    /// <summary>
+    /// Logs that a range lookup was refetched from a wrapped source and re-cached.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="source">The source name consulted on the miss.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="count">The number of rates refetched.</param>
+    [LoggerMessage(EventId = 4504, Level = LogLevel.Debug, Message = "Refetched {count} {fromIsoCode}->{toIsoCode} rate(s) from source '{source}' and cached the range")]
+    public static partial void RangeRefetched(ILogger logger, string source, string fromIsoCode, string toIsoCode, int count);
+}

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
@@ -27,7 +27,7 @@ internal static partial class Log
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The requested date.</param>
-    [LoggerMessage(EventId = 4501, Level = LogLevel.Debug, Message = "Served {fromIsoCode}->{toIsoCode} on {date} from cache for source '{source}'")]
+    [LoggerMessage(EventId = 4501, Level = LogLevel.Trace, Message = "Served {fromIsoCode}->{toIsoCode} on {date} from cache for source '{source}'")]
     public static partial void CacheHit(ILogger logger, string source, string fromIsoCode, string toIsoCode, DateOnly date);
 
     /// <summary>
@@ -38,7 +38,7 @@ internal static partial class Log
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The requested date.</param>
-    [LoggerMessage(EventId = 4502, Level = LogLevel.Debug, Message = "Cache miss for {fromIsoCode}->{toIsoCode} on {date}; resolved from source '{source}' and cached")]
+    [LoggerMessage(EventId = 4502, Level = LogLevel.Trace, Message = "Cache miss for {fromIsoCode}->{toIsoCode} on {date}; resolved from source '{source}' and cached")]
     public static partial void CacheMissStored(ILogger logger, string source, string fromIsoCode, string toIsoCode, DateOnly date);
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
@@ -23,42 +23,46 @@ internal static partial class Log
     /// Logs that a single-date lookup was served from the cache.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="source">The source name the fresh rows are cached under.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The requested date.</param>
-    [LoggerMessage(EventId = 4501, Level = LogLevel.Trace, Message = "Served {fromIsoCode}->{toIsoCode} on {date} from cache for source '{source}'")]
-    public static partial void CacheHit(ILogger logger, string source, string fromIsoCode, string toIsoCode, DateOnly date);
+    [LoggerMessage(EventId = 4501, Message = "Served {fromIsoCode}->{toIsoCode} on {date} from cache for source '{source}'")]
+    public static partial void CacheHit(ILogger logger, LogLevel level, string source, string fromIsoCode, string toIsoCode, DateOnly date);
 
     /// <summary>
     /// Logs that a single-date lookup missed the cache and was resolved from a wrapped source and then cached.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="source">The source name consulted on the miss.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The requested date.</param>
-    [LoggerMessage(EventId = 4502, Level = LogLevel.Trace, Message = "Cache miss for {fromIsoCode}->{toIsoCode} on {date}; resolved from source '{source}' and cached")]
-    public static partial void CacheMissStored(ILogger logger, string source, string fromIsoCode, string toIsoCode, DateOnly date);
+    [LoggerMessage(EventId = 4502, Message = "Cache miss for {fromIsoCode}->{toIsoCode} on {date}; resolved from source '{source}' and cached")]
+    public static partial void CacheMissStored(ILogger logger, LogLevel level, string source, string fromIsoCode, string toIsoCode, DateOnly date);
 
     /// <summary>
     /// Logs that a range lookup was served entirely from the cache.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="source">The source name the fresh rows are cached under.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    [LoggerMessage(EventId = 4503, Level = LogLevel.Debug, Message = "Served {fromIsoCode}->{toIsoCode} range from cache for source '{source}'")]
-    public static partial void RangeCacheHit(ILogger logger, string source, string fromIsoCode, string toIsoCode);
+    [LoggerMessage(EventId = 4503, Message = "Served {fromIsoCode}->{toIsoCode} range from cache for source '{source}'")]
+    public static partial void RangeCacheHit(ILogger logger, LogLevel level, string source, string fromIsoCode, string toIsoCode);
 
     /// <summary>
     /// Logs that a range lookup was refetched from a wrapped source and re-cached.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="source">The source name consulted on the miss.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="count">The number of rates refetched.</param>
-    [LoggerMessage(EventId = 4504, Level = LogLevel.Debug, Message = "Refetched {count} {fromIsoCode}->{toIsoCode} rate(s) from source '{source}' and cached the range")]
-    public static partial void RangeRefetched(ILogger logger, string source, string fromIsoCode, string toIsoCode, int count);
+    [LoggerMessage(EventId = 4504, Message = "Refetched {count} {fromIsoCode}->{toIsoCode} rate(s) from source '{source}' and cached the range")]
+    public static partial void RangeRefetched(ILogger logger, LogLevel level, string source, string fromIsoCode, string toIsoCode, int count);
 }

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProviderTests.Logging.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProviderTests.Logging.cs
@@ -26,7 +26,7 @@ public sealed partial class CachingDatedExchangeRateProviderTests
 
         _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
 
-        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Debug && e.EventId.Id == 4502));
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Trace && e.EventId.Id == 4502));
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public sealed partial class CachingDatedExchangeRateProviderTests
 
         _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
 
-        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Debug && e.EventId.Id == 4501));
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Trace && e.EventId.Id == 4501));
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProviderTests.Logging.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProviderTests.Logging.cs
@@ -45,6 +45,24 @@ public sealed partial class CachingDatedExchangeRateProviderTests
     }
 
     /// <summary>
+    /// Verifies that a configured non-default <see cref="CachingExchangeRateOptions.CacheHitLogLevel" /> is honoured,
+    /// so a cache hit is emitted at the configured level rather than the <see cref="LogLevel.Trace" /> default.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenCacheHitLogLevelConfigured_ShouldLogAtConfiguredLevel()
+    {
+        CapturingLogger logger = new();
+        _options.CacheHitLogLevel = LogLevel.Information;
+        SeedCache(new ExchangeRatePair("AUD", "USD"), (new DateOnly(2023, 1, 3), 0.5m));
+        CachingDatedExchangeRateProvider sut = new(new[] { Source(Provider, InnerWith()) }, _cache, _options, _clock, logger);
+
+        _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Information && e.EventId.Id == 4501));
+        Assert.IsFalse(logger.Entries.Any(e => e.Level == LogLevel.Trace && e.EventId.Id == 4501));
+    }
+
+    /// <summary>
     /// Verifies that serving a fresh cached rate without a logger succeeds, confirming the default <c>null</c> logger
     /// path is a no-op.
     /// </summary>

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProviderTests.Logging.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingDatedExchangeRateProviderTests.Logging.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CachingDatedExchangeRateProviderTests.Logging.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Caching;
+
+/// <summary>
+/// Verifies that <see cref="CachingDatedExchangeRateProvider" /> emits cache-hit and cache-miss diagnostics through a
+/// supplied logger and remains silent when no logger is supplied.
+/// </summary>
+public sealed partial class CachingDatedExchangeRateProviderTests
+{
+    /// <summary>
+    /// Verifies that a cache miss resolved from the inner source emits a miss-and-store record.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenCacheMissAndLoggerSupplied_ShouldLogMissStored()
+    {
+        CapturingLogger logger = new();
+        CountingDatedExchangeRateProvider inner = InnerWith(("AUD", "USD", new DateOnly(2023, 1, 3), 0.5m));
+        CachingDatedExchangeRateProvider sut = new(new[] { Source(Provider, inner) }, _cache, _options, _clock, logger);
+
+        _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Debug && e.EventId.Id == 4502));
+    }
+
+    /// <summary>
+    /// Verifies that a fresh cached rate served without consulting the inner source emits a cache-hit record.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenCacheFreshAndLoggerSupplied_ShouldLogCacheHit()
+    {
+        CapturingLogger logger = new();
+        SeedCache(new ExchangeRatePair("AUD", "USD"), (new DateOnly(2023, 1, 3), 0.5m));
+        CachingDatedExchangeRateProvider sut = new(new[] { Source(Provider, InnerWith()) }, _cache, _options, _clock, logger);
+
+        _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Debug && e.EventId.Id == 4501));
+    }
+
+    /// <summary>
+    /// Verifies that serving a fresh cached rate without a logger succeeds, confirming the default <c>null</c> logger
+    /// path is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenNoLoggerSupplied_ShouldServeWithoutLogging()
+    {
+        SeedCache(new ExchangeRatePair("AUD", "USD"), (new DateOnly(2023, 1, 3), 0.5m));
+        CachingDatedExchangeRateProvider sut = CreateDecorator(InnerWith());
+
+        ExchangeRateLookupResult result = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        Assert.AreEqual(0.5m, result.Rate.Rate);
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CapturingLogger.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CapturingLogger.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CapturingLogger.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Caching;
+
+/// <summary>
+/// A minimal <see cref="ILogger" /> that records the level, event id, and rendered message of every entry, used to
+/// assert that the caching provider emits the expected diagnostics.
+/// </summary>
+internal sealed class CapturingLogger
+    : ILogger
+{
+    /// <summary>
+    /// Gets the recorded entries in emission order.
+    /// </summary>
+    public List<(LogLevel Level, EventId EventId, string Message)> Entries { get; } = new();
+
+    /// <inheritdoc />
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull =>
+        NullScope.Instance;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) =>
+        true;
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        Entries.Add((logLevel, eventId, formatter(state, exception)));
+    }
+
+    /// <summary>
+    /// A no-op scope returned by <see cref="BeginScope{TState}(TState)" />.
+    /// </summary>
+    private sealed class NullScope
+        : IDisposable
+    {
+        /// <summary>
+        /// Gets the shared instance.
+        /// </summary>
+        public static NullScope Instance { get; } = new();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/src/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/src/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/src/Financial.ExchangeRates.Ecb.DependencyInjection/EcbFinancialServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/src/Financial.ExchangeRates.Ecb.DependencyInjection/EcbFinancialServiceBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Bodu.Financial.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Bodu.Financial.ExchangeRates.Ecb.DependencyInjection;
@@ -76,7 +77,7 @@ public static class EcbFinancialServiceBuilderExtensions
         {
             HttpClient client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientName);
             EcbExchangeRateOptions options = serviceProvider.GetRequiredService<IOptions<EcbExchangeRateOptions>>().Value;
-            return new EcbExchangeRateProvider(client, options);
+            return new EcbExchangeRateProvider(client, options, serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<EcbExchangeRateProvider>());
         });
         services.TryAddSingleton<IDatedExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<EcbExchangeRateProvider>());
         services.TryAddSingleton<IExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<EcbExchangeRateProvider>());

--- a/Bodu.Financial.ExchangeRates.Ecb/README.md
+++ b/Bodu.Financial.ExchangeRates.Ecb/README.md
@@ -48,4 +48,38 @@ foreach (EcbSeriesInfo info in provider.GetAvailablePairs())
   feeds can be pointed at a mirror or proxy without touching caching or feed selection. See
   the `*.DependencyInjection` package for `AddEcbReferenceRates`.
 
+## Logging
+
+The provider logs through `Microsoft.Extensions.Logging`. Pass an `ILogger` to the
+constructor, or let the `*.DependencyInjection` package wire one for you (category
+`Bodu.Financial.ExchangeRates.Ecb.EcbExchangeRateProvider`). When no logger is supplied it
+defaults to `NullLogger.Instance`, so logging is entirely opt-in and free when unused.
+
+The levels follow the conventions used by `Microsoft.Extensions.Http`, EF Core, and the
+Azure SDK — the completed download is the one `Information` line per fetch, payload detail
+is `Trace`, and degraded paths are `Warning`. Every level is individually configurable on
+`EcbExchangeRateOptions`:
+
+| Event | Default level | Option property |
+|---|---|---|
+| A feed download is starting | `Debug` | `DownloadStartingLogLevel` |
+| A feed loaded (with its observation count) | `Information` | `DownloadCompletedLogLevel` |
+| Each individual rate observation ingested | `Trace` | `ObservationIngestedLogLevel` |
+| A feed download failed (logged, then re-thrown) | `Warning` | `DownloadFailedLogLevel` |
+| A synchronous lookup triggered a blocking network fetch | `Warning` | `SynchronousNetworkFetchLogLevel` |
+
+```csharp
+// Quieten the per-fetch line and turn off per-observation tracing entirely.
+var options = new EcbExchangeRateOptions
+{
+    DownloadCompletedLogLevel = LogLevel.Debug,
+    ObservationIngestedLogLevel = LogLevel.None,
+};
+```
+
+The default verbosity is deliberately low: at `Information` you see one line per feed
+loaded; at `Debug` you additionally see when downloads start; only at `Trace` do you get a
+line per rate observation (which can be thousands per feed — keep it for targeted
+debugging).
+
 Part of the [Bodu](https://github.com/bodu/bodu) utility library.

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Bodu.Financial.ExchangeRates.Ecb.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Bodu.Financial.ExchangeRates.Ecb.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateOptions.cs
@@ -6,6 +6,8 @@
 
 namespace Bodu.Financial.ExchangeRates.Ecb;
 
+using Microsoft.Extensions.Logging;
+
 /// <summary>
 /// Configures how the <see cref="EcbExchangeRateProvider" /> downloads, caches, and interprets ECB euro reference-rate
 /// data.
@@ -78,6 +80,36 @@ public sealed class EcbExchangeRateOptions
     /// <value>The alias map; defaults to an empty map because the ECB publishes ISO 4217 codes directly.</value>
     public IDictionary<string, string> CurrencyAliases { get; set; } =
         new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets or sets the level at which the start of a feed download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    public LogLevel DownloadStartingLogLevel { get; set; } = LogLevel.Debug;
+
+    /// <summary>
+    /// Gets or sets the level at which a completed feed download (with its observation count) is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Information" />.</value>
+    public LogLevel DownloadCompletedLogLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Gets or sets the level at which a failed feed download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Warning" />.</value>
+    public LogLevel DownloadFailedLogLevel { get; set; } = LogLevel.Warning;
+
+    /// <summary>
+    /// Gets or sets the level at which each individual ingested rate observation is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Trace" />.</value>
+    public LogLevel ObservationIngestedLogLevel { get; set; } = LogLevel.Trace;
+
+    /// <summary>
+    /// Gets or sets the level at which a synchronous, blocking on-demand network fetch is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Warning" />.</value>
+    public LogLevel SynchronousNetworkFetchLogLevel { get; set; } = LogLevel.Warning;
 
     /// <summary>
     /// Validates the options, throwing when a required value is missing.

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateOptions.cs
@@ -13,9 +13,16 @@ using Microsoft.Extensions.Logging;
 /// data.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Every member carries a working default, so the options bind cleanly through <c>Microsoft.Extensions.Options</c> and
 /// require no configuration for the common case. The dependency-injection package binds this type from configuration
 /// and a <c>configure</c> delegate.
+/// </para>
+/// <para>
+/// The <c>*LogLevel</c> members set the <see cref="LogLevel" /> at which each diagnostic the provider emits is logged,
+/// so consumers can re-tune verbosity per concern without category-wide log filters. Set any of them to
+/// <see cref="LogLevel.None" /> to suppress that event entirely.
+/// </para>
 /// </remarks>
 public sealed class EcbExchangeRateOptions
 {

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
@@ -409,6 +409,7 @@ public sealed class EcbExchangeRateProvider
         foreach (ExchangeRate rate in table.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
@@ -185,7 +185,7 @@ public sealed class EcbExchangeRateProvider
 
         if (_options.AllowSynchronousNetworkAccess && TryLoadFeedForDate(date))
         {
-            Log.SynchronousNetworkFetch(_logger, date);
+            Log.SynchronousNetworkFetch(_logger, _options.SynchronousNetworkFetchLogLevel, date);
             return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
         }
 
@@ -240,7 +240,7 @@ public sealed class EcbExchangeRateProvider
                 return;
         }
 
-        Log.FeedLoadStarting(_logger, feed.Name);
+        Log.FeedLoadStarting(_logger, _options.DownloadStartingLogLevel, feed.Name);
 
         EcbExchangeRateTable table;
         try
@@ -249,7 +249,7 @@ public sealed class EcbExchangeRateProvider
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            Log.FeedLoadFailed(_logger, feed.Name, ex);
+            Log.FeedLoadFailed(_logger, _options.DownloadFailedLogLevel, feed.Name, ex);
             throw;
         }
 
@@ -260,7 +260,7 @@ public sealed class EcbExchangeRateProvider
 
             var count = Accumulate(table);
             RebuildSnapshot();
-            Log.FeedLoaded(_logger, feed.Name, count);
+            Log.FeedLoaded(_logger, _options.DownloadCompletedLogLevel, feed.Name, count);
         }
     }
 
@@ -409,7 +409,7 @@ public sealed class EcbExchangeRateProvider
         foreach (ExchangeRate rate in table.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
@@ -5,6 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Financial.ExchangeRates.Ecb;
 
@@ -90,17 +92,26 @@ public sealed class EcbExchangeRateProvider
     private volatile FixedDatedExchangeRateProvider _snapshot;
 
     /// <summary>
+    /// The logger that records feed downloads and on-demand network fetches.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="EcbExchangeRateProvider" /> class backed by the ECB
     /// <c>eurofxref</c> feeds, downloaded with the supplied HTTP client.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to download feed files.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records feed downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    public EcbExchangeRateProvider(HttpClient httpClient, EcbExchangeRateOptions options)
-        : this(CreateSource(httpClient, options), options)
+    public EcbExchangeRateProvider(HttpClient httpClient, EcbExchangeRateOptions options, ILogger? logger = null)
+        : this(CreateSource(httpClient, options), options, logger)
     {
     }
 
@@ -110,11 +121,15 @@ public sealed class EcbExchangeRateProvider
     /// </summary>
     /// <param name="source">The table source.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records feed downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    internal EcbExchangeRateProvider(IEcbExchangeRateTableSource source, EcbExchangeRateOptions options)
+    internal EcbExchangeRateProvider(IEcbExchangeRateTableSource source, EcbExchangeRateOptions options, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -122,6 +137,7 @@ public sealed class EcbExchangeRateProvider
 
         _source = source;
         _options = options;
+        _logger = logger ?? NullLogger.Instance;
         _book = _builder.ToBook();
         _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
@@ -168,7 +184,10 @@ public sealed class EcbExchangeRateProvider
             return true;
 
         if (_options.AllowSynchronousNetworkAccess && TryLoadFeedForDate(date))
+        {
+            Log.SynchronousNetworkFetch(_logger, date);
             return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
+        }
 
         result = default;
         return false;
@@ -221,15 +240,27 @@ public sealed class EcbExchangeRateProvider
                 return;
         }
 
-        EcbExchangeRateTable table = await _source.GetTableAsync(feed, cancellationToken).ConfigureAwait(false);
+        Log.FeedLoadStarting(_logger, feed.Name);
+
+        EcbExchangeRateTable table;
+        try
+        {
+            table = await _source.GetTableAsync(feed, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.FeedLoadFailed(_logger, feed.Name, ex);
+            throw;
+        }
 
         lock (_gate)
         {
             if (!_loadedFeeds.Add(feed.Name))
                 return;
 
-            Accumulate(table);
+            var count = Accumulate(table);
             RebuildSnapshot();
+            Log.FeedLoaded(_logger, feed.Name, count);
         }
     }
 
@@ -368,13 +399,20 @@ public sealed class EcbExchangeRateProvider
     /// Upserts a parsed table's observations and series metadata into the accumulator.
     /// </summary>
     /// <param name="table">The parsed table.</param>
-    private void Accumulate(EcbExchangeRateTable table)
+    /// <returns>The number of rate observations upserted.</returns>
+    private int Accumulate(EcbExchangeRateTable table)
     {
         foreach (EcbSeriesInfo info in table.GetSeriesInfo())
             _series[info.Pair] = info;
 
+        var count = 0;
         foreach (ExchangeRate rate in table.EnumerateRates())
+        {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            count++;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
@@ -30,6 +30,15 @@ namespace Bodu.Financial.ExchangeRates.Ecb;
 /// snapshot that backs the synchronous lookups, so inverse pairs, same-currency identity, and date-resolution policies
 /// are inherited from <see cref="FixedDatedExchangeRateProvider" />.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
+/// package) the provider records: the start of a feed download (<see cref="LogLevel.Debug" />), a completed download
+/// with its observation count (<see cref="LogLevel.Information" />), each ingested observation
+/// (<see cref="LogLevel.Trace" />), a failed download (<see cref="LogLevel.Warning" />, then re-thrown), and a
+/// synchronous on-demand network fetch (<see cref="LogLevel.Warning" />). Every level is configurable through the
+/// corresponding <c>*LogLevel</c> property on <see cref="EcbExchangeRateOptions" />; omitting the logger selects
+/// <see cref="NullLogger.Instance" />, so logging is opt-in and free when unused.
+/// </para>
 /// </remarks>
 public sealed class EcbExchangeRateProvider
     : IDatedExchangeRateProvider, IExchangeRateProvider

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/Log.cs
@@ -23,44 +23,49 @@ internal static partial class Log
     /// Logs that a feed download is starting.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="feed">The name of the feed being downloaded.</param>
-    [LoggerMessage(EventId = 4101, Level = LogLevel.Debug, Message = "Downloading ECB feed '{feed}'")]
-    public static partial void FeedLoadStarting(ILogger logger, string feed);
+    [LoggerMessage(EventId = 4101, Message = "Downloading ECB feed '{feed}'")]
+    public static partial void FeedLoadStarting(ILogger logger, LogLevel level, string feed);
 
     /// <summary>
     /// Logs that a feed was downloaded and its observations were accumulated.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="feed">The name of the loaded feed.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the feed.</param>
-    [LoggerMessage(EventId = 4102, Level = LogLevel.Information, Message = "Loaded ECB feed '{feed}' with {rateCount} rate observation(s)")]
-    public static partial void FeedLoaded(ILogger logger, string feed, int rateCount);
+    [LoggerMessage(EventId = 4102, Message = "Loaded ECB feed '{feed}' with {rateCount} rate observation(s)")]
+    public static partial void FeedLoaded(ILogger logger, LogLevel level, string feed, int rateCount);
 
     /// <summary>
     /// Logs an individual rate observation ingested from a feed, for fine-grained diagnostics.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The observation date.</param>
     /// <param name="rate">The observed rate.</param>
-    [LoggerMessage(EventId = 4105, Level = LogLevel.Trace, Message = "Ingested ECB observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
-    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
+    [LoggerMessage(EventId = 4105, Message = "Ingested ECB observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, LogLevel level, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that a feed download failed.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="feed">The name of the feed whose download failed.</param>
     /// <param name="exception">The exception that caused the failure.</param>
-    [LoggerMessage(EventId = 4103, Level = LogLevel.Warning, Message = "Failed to download ECB feed '{feed}'")]
-    public static partial void FeedLoadFailed(ILogger logger, string feed, Exception exception);
+    [LoggerMessage(EventId = 4103, Message = "Failed to download ECB feed '{feed}'")]
+    public static partial void FeedLoadFailed(ILogger logger, LogLevel level, string feed, Exception exception);
 
     /// <summary>
     /// Logs that a synchronous lookup triggered an on-demand network fetch.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="date">The date whose covering feed was fetched synchronously.</param>
-    [LoggerMessage(EventId = 4104, Level = LogLevel.Warning, Message = "Performed synchronous ECB network fetch to resolve a rate for {date}")]
-    public static partial void SynchronousNetworkFetch(ILogger logger, DateOnly date);
+    [LoggerMessage(EventId = 4104, Message = "Performed synchronous ECB network fetch to resolve a rate for {date}")]
+    public static partial void SynchronousNetworkFetch(ILogger logger, LogLevel level, DateOnly date);
 }

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/Log.cs
@@ -33,8 +33,19 @@ internal static partial class Log
     /// <param name="logger">The logger that receives the message.</param>
     /// <param name="feed">The name of the loaded feed.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the feed.</param>
-    [LoggerMessage(EventId = 4102, Level = LogLevel.Debug, Message = "Loaded ECB feed '{feed}' with {rateCount} rate observation(s)")]
+    [LoggerMessage(EventId = 4102, Level = LogLevel.Information, Message = "Loaded ECB feed '{feed}' with {rateCount} rate observation(s)")]
     public static partial void FeedLoaded(ILogger logger, string feed, int rateCount);
+
+    /// <summary>
+    /// Logs an individual rate observation ingested from a feed, for fine-grained diagnostics.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The observed rate.</param>
+    [LoggerMessage(EventId = 4105, Level = LogLevel.Trace, Message = "Ingested ECB observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that a feed download failed.

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/Log.cs
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Ecb;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted by <see cref="EcbExchangeRateProvider" />
+/// while downloading and serving ECB euro reference rates.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that a feed download is starting.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="feed">The name of the feed being downloaded.</param>
+    [LoggerMessage(EventId = 4101, Level = LogLevel.Debug, Message = "Downloading ECB feed '{feed}'")]
+    public static partial void FeedLoadStarting(ILogger logger, string feed);
+
+    /// <summary>
+    /// Logs that a feed was downloaded and its observations were accumulated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="feed">The name of the loaded feed.</param>
+    /// <param name="rateCount">The number of rate observations accumulated from the feed.</param>
+    [LoggerMessage(EventId = 4102, Level = LogLevel.Debug, Message = "Loaded ECB feed '{feed}' with {rateCount} rate observation(s)")]
+    public static partial void FeedLoaded(ILogger logger, string feed, int rateCount);
+
+    /// <summary>
+    /// Logs that a feed download failed.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="feed">The name of the feed whose download failed.</param>
+    /// <param name="exception">The exception that caused the failure.</param>
+    [LoggerMessage(EventId = 4103, Level = LogLevel.Warning, Message = "Failed to download ECB feed '{feed}'")]
+    public static partial void FeedLoadFailed(ILogger logger, string feed, Exception exception);
+
+    /// <summary>
+    /// Logs that a synchronous lookup triggered an on-demand network fetch.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="date">The date whose covering feed was fetched synchronously.</param>
+    [LoggerMessage(EventId = 4104, Level = LogLevel.Warning, Message = "Performed synchronous ECB network fetch to resolve a rate for {date}")]
+    public static partial void SynchronousNetworkFetch(ILogger logger, DateOnly date);
+}

--- a/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/src/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/src/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/src/Financial.ExchangeRates.Rba.DependencyInjection/RbaFinancialServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/src/Financial.ExchangeRates.Rba.DependencyInjection/RbaFinancialServiceBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Bodu.Financial.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Bodu.Financial.ExchangeRates.Rba.DependencyInjection;
@@ -76,7 +77,7 @@ public static class RbaFinancialServiceBuilderExtensions
         {
             HttpClient client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientName);
             RbaExchangeRateOptions options = serviceProvider.GetRequiredService<IOptions<RbaExchangeRateOptions>>().Value;
-            return new RbaExchangeRateProvider(client, options);
+            return new RbaExchangeRateProvider(client, options, serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<RbaExchangeRateProvider>());
         });
         services.TryAddSingleton<IDatedExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<RbaExchangeRateProvider>());
         services.TryAddSingleton<IExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<RbaExchangeRateProvider>());

--- a/Bodu.Financial.ExchangeRates.Rba/README.md
+++ b/Bodu.Financial.ExchangeRates.Rba/README.md
@@ -43,4 +43,37 @@ foreach (RbaSeriesInfo info in provider.GetAvailablePairs())
   `Microsoft.Extensions.Options`; see the `*.DependencyInjection` package for
   `AddRbaHistoricalRates`.
 
+## Logging
+
+The provider logs through `Microsoft.Extensions.Logging`. Pass an `ILogger` to the
+constructor, or let the `*.DependencyInjection` package wire one for you (category
+`Bodu.Financial.ExchangeRates.Rba.RbaExchangeRateProvider`). When no logger is supplied it
+defaults to `NullLogger.Instance`, so logging is entirely opt-in and free when unused.
+
+The levels follow the conventions used by `Microsoft.Extensions.Http`, EF Core, and the
+Azure SDK — the completed download is the one `Information` line per fetch, payload detail
+is `Trace`, and degraded paths are `Warning`. Every level is individually configurable on
+`RbaExchangeRateOptions`:
+
+| Event | Default level | Option property |
+|---|---|---|
+| An era download is starting | `Debug` | `DownloadStartingLogLevel` |
+| An era loaded (with its observation count) | `Information` | `DownloadCompletedLogLevel` |
+| Each individual rate observation ingested | `Trace` | `ObservationIngestedLogLevel` |
+| An era download failed (logged, then re-thrown) | `Warning` | `DownloadFailedLogLevel` |
+
+```csharp
+// Quieten the per-fetch line and turn off per-observation tracing entirely.
+var options = new RbaExchangeRateOptions
+{
+    DownloadCompletedLogLevel = LogLevel.Debug,
+    ObservationIngestedLogLevel = LogLevel.None,
+};
+```
+
+The default verbosity is deliberately low: at `Information` you see one line per era
+loaded; at `Debug` you additionally see when downloads start; only at `Trace` do you get a
+line per rate observation (which can be thousands per era — keep it for targeted
+debugging).
+
 Part of the [Bodu](https://github.com/bodu/bodu) utility library.

--- a/Bodu.Financial.ExchangeRates.Rba/src/Bodu.Financial.ExchangeRates.Rba.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Bodu.Financial.ExchangeRates.Rba.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\..\Bodu.Formats.Excel.Binary\src\Bodu.Formats.Excel.Binary.csproj" />

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/Log.cs
@@ -23,36 +23,40 @@ internal static partial class Log
     /// Logs that an era download is starting.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="era">The label of the era being downloaded.</param>
-    [LoggerMessage(EventId = 4301, Level = LogLevel.Debug, Message = "Downloading RBA era '{era}'")]
-    public static partial void EraLoadStarting(ILogger logger, string era);
+    [LoggerMessage(EventId = 4301, Message = "Downloading RBA era '{era}'")]
+    public static partial void EraLoadStarting(ILogger logger, LogLevel level, string era);
 
     /// <summary>
     /// Logs that an era was downloaded and its observations were accumulated.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="era">The label of the loaded era.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the era.</param>
-    [LoggerMessage(EventId = 4302, Level = LogLevel.Information, Message = "Loaded RBA era '{era}' with {rateCount} rate observation(s)")]
-    public static partial void EraLoaded(ILogger logger, string era, int rateCount);
+    [LoggerMessage(EventId = 4302, Message = "Loaded RBA era '{era}' with {rateCount} rate observation(s)")]
+    public static partial void EraLoaded(ILogger logger, LogLevel level, string era, int rateCount);
 
     /// <summary>
     /// Logs an individual rate observation ingested from an era, for fine-grained diagnostics.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The observation date.</param>
     /// <param name="rate">The observed rate.</param>
-    [LoggerMessage(EventId = 4305, Level = LogLevel.Trace, Message = "Ingested RBA observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
-    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
+    [LoggerMessage(EventId = 4305, Message = "Ingested RBA observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, LogLevel level, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that an era download failed.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="era">The label of the era whose download failed.</param>
     /// <param name="exception">The exception that caused the failure.</param>
-    [LoggerMessage(EventId = 4303, Level = LogLevel.Warning, Message = "Failed to download RBA era '{era}'")]
-    public static partial void EraLoadFailed(ILogger logger, string era, Exception exception);
+    [LoggerMessage(EventId = 4303, Message = "Failed to download RBA era '{era}'")]
+    public static partial void EraLoadFailed(ILogger logger, LogLevel level, string era, Exception exception);
 }

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/Log.cs
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Rba;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted by <see cref="RbaExchangeRateProvider" />
+/// while downloading and serving RBA historical exchange rates.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that an era download is starting.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="era">The label of the era being downloaded.</param>
+    [LoggerMessage(EventId = 4301, Level = LogLevel.Debug, Message = "Downloading RBA era '{era}'")]
+    public static partial void EraLoadStarting(ILogger logger, string era);
+
+    /// <summary>
+    /// Logs that an era was downloaded and its observations were accumulated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="era">The label of the loaded era.</param>
+    /// <param name="rateCount">The number of rate observations accumulated from the era.</param>
+    [LoggerMessage(EventId = 4302, Level = LogLevel.Debug, Message = "Loaded RBA era '{era}' with {rateCount} rate observation(s)")]
+    public static partial void EraLoaded(ILogger logger, string era, int rateCount);
+
+    /// <summary>
+    /// Logs that an era download failed.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="era">The label of the era whose download failed.</param>
+    /// <param name="exception">The exception that caused the failure.</param>
+    [LoggerMessage(EventId = 4303, Level = LogLevel.Warning, Message = "Failed to download RBA era '{era}'")]
+    public static partial void EraLoadFailed(ILogger logger, string era, Exception exception);
+}

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/Log.cs
@@ -33,8 +33,19 @@ internal static partial class Log
     /// <param name="logger">The logger that receives the message.</param>
     /// <param name="era">The label of the loaded era.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the era.</param>
-    [LoggerMessage(EventId = 4302, Level = LogLevel.Debug, Message = "Loaded RBA era '{era}' with {rateCount} rate observation(s)")]
+    [LoggerMessage(EventId = 4302, Level = LogLevel.Information, Message = "Loaded RBA era '{era}' with {rateCount} rate observation(s)")]
     public static partial void EraLoaded(ILogger logger, string era, int rateCount);
+
+    /// <summary>
+    /// Logs an individual rate observation ingested from an era, for fine-grained diagnostics.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The observed rate.</param>
+    [LoggerMessage(EventId = 4305, Level = LogLevel.Trace, Message = "Ingested RBA observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that an era download failed.

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateOptions.cs
@@ -12,9 +12,16 @@ using Microsoft.Extensions.Logging;
 /// Configures how the <see cref="RbaExchangeRateProvider" /> downloads, caches, and interprets RBA exchange-rate data.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Every member carries a working default, so the options bind cleanly through <c>Microsoft.Extensions.Options</c> and
 /// require no configuration for the common case. The dependency-injection package binds this type from configuration
 /// and a <c>configure</c> delegate.
+/// </para>
+/// <para>
+/// The <c>*LogLevel</c> members set the <see cref="LogLevel" /> at which each diagnostic the provider emits is logged,
+/// so consumers can re-tune verbosity per concern without category-wide log filters. Set any of them to
+/// <see cref="LogLevel.None" /> to suppress that event entirely.
+/// </para>
 /// </remarks>
 public sealed class RbaExchangeRateOptions
 {

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateOptions.cs
@@ -6,6 +6,8 @@
 
 namespace Bodu.Financial.ExchangeRates.Rba;
 
+using Microsoft.Extensions.Logging;
+
 /// <summary>
 /// Configures how the <see cref="RbaExchangeRateProvider" /> downloads, caches, and interprets RBA exchange-rate data.
 /// </summary>
@@ -85,6 +87,30 @@ public sealed class RbaExchangeRateOptions
     /// <value>The alias map; defaults to mapping <c>SDR</c> to the ISO code <c>XDR</c>.</value>
     public IDictionary<string, string> CurrencyAliases { get; set; } =
         new Dictionary<string, string>(StringComparer.Ordinal) { ["SDR"] = "XDR" };
+
+    /// <summary>
+    /// Gets or sets the level at which the start of an era download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    public LogLevel DownloadStartingLogLevel { get; set; } = LogLevel.Debug;
+
+    /// <summary>
+    /// Gets or sets the level at which a completed era download (with its observation count) is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Information" />.</value>
+    public LogLevel DownloadCompletedLogLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Gets or sets the level at which a failed era download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Warning" />.</value>
+    public LogLevel DownloadFailedLogLevel { get; set; } = LogLevel.Warning;
+
+    /// <summary>
+    /// Gets or sets the level at which each individual ingested rate observation is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Trace" />.</value>
+    public LogLevel ObservationIngestedLogLevel { get; set; } = LogLevel.Trace;
 
     /// <summary>
     /// Validates the options, throwing when a required value is missing.

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
@@ -382,6 +382,7 @@ public sealed class RbaExchangeRateProvider
         foreach (ExchangeRate rate in table.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
@@ -5,6 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Financial.ExchangeRates.Rba;
 
@@ -89,17 +91,26 @@ public sealed class RbaExchangeRateProvider
     private volatile FixedDatedExchangeRateProvider _snapshot;
 
     /// <summary>
+    /// The logger that records era downloads and on-demand network fetches.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="RbaExchangeRateProvider" /> class backed by the RBA <c>.xls</c>
     /// files, downloaded with the supplied HTTP client.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to download era files.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records era downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    public RbaExchangeRateProvider(HttpClient httpClient, RbaExchangeRateOptions options)
-        : this(CreateSource(httpClient, options), options)
+    public RbaExchangeRateProvider(HttpClient httpClient, RbaExchangeRateOptions options, ILogger? logger = null)
+        : this(CreateSource(httpClient, options), options, logger)
     {
     }
 
@@ -109,11 +120,15 @@ public sealed class RbaExchangeRateProvider
     /// </summary>
     /// <param name="source">The table source.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records era downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    internal RbaExchangeRateProvider(IRbaExchangeRateTableSource source, RbaExchangeRateOptions options)
+    internal RbaExchangeRateProvider(IRbaExchangeRateTableSource source, RbaExchangeRateOptions options, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -121,6 +136,7 @@ public sealed class RbaExchangeRateProvider
 
         _source = source;
         _options = options;
+        _logger = logger ?? NullLogger.Instance;
         _book = _builder.ToBook();
         _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
@@ -218,15 +234,27 @@ public sealed class RbaExchangeRateProvider
                 return;
         }
 
-        RbaExchangeRateTable table = await _source.GetTableAsync(era, cancellationToken).ConfigureAwait(false);
+        Log.EraLoadStarting(_logger, era.Label);
+
+        RbaExchangeRateTable table;
+        try
+        {
+            table = await _source.GetTableAsync(era, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.EraLoadFailed(_logger, era.Label, ex);
+            throw;
+        }
 
         lock (_gate)
         {
             if (!_loadedEras.Add(era.Label))
                 return;
 
-            Accumulate(table);
+            var count = Accumulate(table);
             RebuildSnapshot();
+            Log.EraLoaded(_logger, era.Label, count);
         }
     }
 
@@ -344,13 +372,20 @@ public sealed class RbaExchangeRateProvider
     /// Upserts a parsed table's observations and series metadata into the accumulator.
     /// </summary>
     /// <param name="table">The parsed table.</param>
-    private void Accumulate(RbaExchangeRateTable table)
+    /// <returns>The number of rate observations upserted.</returns>
+    private int Accumulate(RbaExchangeRateTable table)
     {
         foreach (RbaSeriesInfo info in table.GetSeriesInfo())
             _series[info.Pair] = info;
 
+        var count = 0;
         foreach (ExchangeRate rate in table.EnumerateRates())
+        {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            count++;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
@@ -29,6 +29,14 @@ namespace Bodu.Financial.ExchangeRates.Rba;
 /// <see cref="ExchangeRateBook" /> snapshot that backs the synchronous lookups, so inverse pairs, same-currency
 /// identity, and date-resolution policies are inherited from <see cref="FixedDatedExchangeRateProvider" />.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
+/// package) the provider records: the start of an era download (<see cref="LogLevel.Debug" />), a completed download
+/// with its observation count (<see cref="LogLevel.Information" />), each ingested observation
+/// (<see cref="LogLevel.Trace" />), and a failed download (<see cref="LogLevel.Warning" />, then re-thrown). Every level
+/// is configurable through the corresponding <c>*LogLevel</c> property on <see cref="RbaExchangeRateOptions" />; omitting
+/// the logger selects <see cref="NullLogger.Instance" />, so logging is opt-in and free when unused.
+/// </para>
 /// </remarks>
 public sealed class RbaExchangeRateProvider
     : IDatedExchangeRateProvider, IExchangeRateProvider

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
@@ -234,7 +234,7 @@ public sealed class RbaExchangeRateProvider
                 return;
         }
 
-        Log.EraLoadStarting(_logger, era.Label);
+        Log.EraLoadStarting(_logger, _options.DownloadStartingLogLevel, era.Label);
 
         RbaExchangeRateTable table;
         try
@@ -243,7 +243,7 @@ public sealed class RbaExchangeRateProvider
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            Log.EraLoadFailed(_logger, era.Label, ex);
+            Log.EraLoadFailed(_logger, _options.DownloadFailedLogLevel, era.Label, ex);
             throw;
         }
 
@@ -254,7 +254,7 @@ public sealed class RbaExchangeRateProvider
 
             var count = Accumulate(table);
             RebuildSnapshot();
-            Log.EraLoaded(_logger, era.Label, count);
+            Log.EraLoaded(_logger, _options.DownloadCompletedLogLevel, era.Label, count);
         }
     }
 
@@ -382,7 +382,7 @@ public sealed class RbaExchangeRateProvider
         foreach (ExchangeRate rate in table.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/src/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/src/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/src/Financial.ExchangeRates.Yahoo.DependencyInjection/YahooFinancialServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/src/Financial.ExchangeRates.Yahoo.DependencyInjection/YahooFinancialServiceBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Bodu.Financial.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection;
@@ -76,7 +77,7 @@ public static class YahooFinancialServiceBuilderExtensions
         {
             HttpClient client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientName);
             YahooExchangeRateOptions options = serviceProvider.GetRequiredService<IOptions<YahooExchangeRateOptions>>().Value;
-            return new YahooExchangeRateProvider(client, options);
+            return new YahooExchangeRateProvider(client, options, serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<YahooExchangeRateProvider>());
         });
         services.TryAddSingleton<IDatedExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<YahooExchangeRateProvider>());
         services.TryAddSingleton<IExchangeRateProvider>(static serviceProvider => serviceProvider.GetRequiredService<YahooExchangeRateProvider>());

--- a/Bodu.Financial.ExchangeRates.Yahoo/README.md
+++ b/Bodu.Financial.ExchangeRates.Yahoo/README.md
@@ -67,3 +67,39 @@ decimal latest = provider.GetRate("EUR", "GBP");
 
 See [`Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection`](../Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection)
 for `AddYahooExchangeRates` / `AddBoduYahooExchangeRates`.
+
+## Logging
+
+The provider logs through `Microsoft.Extensions.Logging`. Pass an `ILogger` to the
+constructor, or let the `*.DependencyInjection` package wire one for you (category
+`Bodu.Financial.ExchangeRates.Yahoo.YahooExchangeRateProvider`). When no logger is supplied
+it defaults to `NullLogger.Instance`, so logging is entirely opt-in and free when unused.
+
+The levels follow the conventions used by `Microsoft.Extensions.Http`, EF Core, and the
+Azure SDK — the completed download is the one `Information` line per fetch, payload detail
+is `Trace`, and degraded paths are `Warning`. Every level is individually configurable on
+`YahooExchangeRateOptions`:
+
+| Event | Default level | Option property |
+|---|---|---|
+| A pair/chart download is starting | `Debug` | `DownloadStartingLogLevel` |
+| A pair/chart loaded (with its observation count) | `Information` | `DownloadCompletedLogLevel` |
+| Each individual rate observation ingested | `Trace` | `ObservationIngestedLogLevel` |
+| A pair/chart download failed (logged, then re-thrown) | `Warning` | `DownloadFailedLogLevel` |
+| A synchronous lookup triggered a blocking network fetch | `Warning` | `SynchronousNetworkFetchLogLevel` |
+
+```csharp
+// Quieten the per-fetch line and turn off per-observation tracing entirely.
+var options = new YahooExchangeRateOptions
+{
+    DownloadCompletedLogLevel = LogLevel.Debug,
+    ObservationIngestedLogLevel = LogLevel.None,
+};
+```
+
+The default verbosity is deliberately low: at `Information` you see one line per pair/chart
+loaded; at `Debug` you additionally see when downloads start; only at `Trace` do you get a
+line per rate observation (which can be hundreds per chart — keep it for targeted
+debugging).
+
+Part of the [Bodu](https://github.com/bodu/bodu) utility library.

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Bodu.Financial.ExchangeRates.Yahoo.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Bodu.Financial.ExchangeRates.Yahoo.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
   </ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/Log.cs
@@ -23,44 +23,49 @@ internal static partial class Log
     /// Logs that a pair download is starting.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="symbol">The Yahoo Finance ticker symbol being downloaded.</param>
-    [LoggerMessage(EventId = 4401, Level = LogLevel.Debug, Message = "Downloading Yahoo Finance chart '{symbol}'")]
-    public static partial void PairLoadStarting(ILogger logger, string symbol);
+    [LoggerMessage(EventId = 4401, Message = "Downloading Yahoo Finance chart '{symbol}'")]
+    public static partial void PairLoadStarting(ILogger logger, LogLevel level, string symbol);
 
     /// <summary>
     /// Logs that a pair was downloaded and its observations were accumulated.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="symbol">The Yahoo Finance ticker symbol that was downloaded.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the chart.</param>
-    [LoggerMessage(EventId = 4402, Level = LogLevel.Information, Message = "Loaded Yahoo Finance chart '{symbol}' with {rateCount} rate observation(s)")]
-    public static partial void PairLoaded(ILogger logger, string symbol, int rateCount);
+    [LoggerMessage(EventId = 4402, Message = "Loaded Yahoo Finance chart '{symbol}' with {rateCount} rate observation(s)")]
+    public static partial void PairLoaded(ILogger logger, LogLevel level, string symbol, int rateCount);
 
     /// <summary>
     /// Logs an individual rate observation ingested from a chart, for fine-grained diagnostics.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="fromIsoCode">The source-currency ISO code.</param>
     /// <param name="toIsoCode">The destination-currency ISO code.</param>
     /// <param name="date">The observation date.</param>
     /// <param name="rate">The observed rate.</param>
-    [LoggerMessage(EventId = 4405, Level = LogLevel.Trace, Message = "Ingested Yahoo Finance observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
-    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
+    [LoggerMessage(EventId = 4405, Message = "Ingested Yahoo Finance observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, LogLevel level, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that a pair download failed.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="symbol">The Yahoo Finance ticker symbol whose download failed.</param>
     /// <param name="exception">The exception that caused the failure.</param>
-    [LoggerMessage(EventId = 4403, Level = LogLevel.Warning, Message = "Failed to download Yahoo Finance chart '{symbol}'")]
-    public static partial void PairLoadFailed(ILogger logger, string symbol, Exception exception);
+    [LoggerMessage(EventId = 4403, Message = "Failed to download Yahoo Finance chart '{symbol}'")]
+    public static partial void PairLoadFailed(ILogger logger, LogLevel level, string symbol, Exception exception);
 
     /// <summary>
     /// Logs that a synchronous lookup triggered an on-demand network fetch.
     /// </summary>
     /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
     /// <param name="date">The date around which a window was fetched synchronously.</param>
-    [LoggerMessage(EventId = 4404, Level = LogLevel.Warning, Message = "Performed synchronous Yahoo Finance network fetch to resolve a rate for {date}")]
-    public static partial void SynchronousNetworkFetch(ILogger logger, DateOnly date);
+    [LoggerMessage(EventId = 4404, Message = "Performed synchronous Yahoo Finance network fetch to resolve a rate for {date}")]
+    public static partial void SynchronousNetworkFetch(ILogger logger, LogLevel level, DateOnly date);
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/Log.cs
@@ -33,8 +33,19 @@ internal static partial class Log
     /// <param name="logger">The logger that receives the message.</param>
     /// <param name="symbol">The Yahoo Finance ticker symbol that was downloaded.</param>
     /// <param name="rateCount">The number of rate observations accumulated from the chart.</param>
-    [LoggerMessage(EventId = 4402, Level = LogLevel.Debug, Message = "Loaded Yahoo Finance chart '{symbol}' with {rateCount} rate observation(s)")]
+    [LoggerMessage(EventId = 4402, Level = LogLevel.Information, Message = "Loaded Yahoo Finance chart '{symbol}' with {rateCount} rate observation(s)")]
     public static partial void PairLoaded(ILogger logger, string symbol, int rateCount);
+
+    /// <summary>
+    /// Logs an individual rate observation ingested from a chart, for fine-grained diagnostics.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The observed rate.</param>
+    [LoggerMessage(EventId = 4405, Level = LogLevel.Trace, Message = "Ingested Yahoo Finance observation {fromIsoCode}->{toIsoCode} on {date} = {rate}")]
+    public static partial void ObservationIngested(ILogger logger, string fromIsoCode, string toIsoCode, DateOnly date, decimal rate);
 
     /// <summary>
     /// Logs that a pair download failed.

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/Log.cs
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Yahoo;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted by <see cref="YahooExchangeRateProvider" />
+/// while fetching and serving Yahoo Finance exchange rates.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that a pair download is starting.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="symbol">The Yahoo Finance ticker symbol being downloaded.</param>
+    [LoggerMessage(EventId = 4401, Level = LogLevel.Debug, Message = "Downloading Yahoo Finance chart '{symbol}'")]
+    public static partial void PairLoadStarting(ILogger logger, string symbol);
+
+    /// <summary>
+    /// Logs that a pair was downloaded and its observations were accumulated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="symbol">The Yahoo Finance ticker symbol that was downloaded.</param>
+    /// <param name="rateCount">The number of rate observations accumulated from the chart.</param>
+    [LoggerMessage(EventId = 4402, Level = LogLevel.Debug, Message = "Loaded Yahoo Finance chart '{symbol}' with {rateCount} rate observation(s)")]
+    public static partial void PairLoaded(ILogger logger, string symbol, int rateCount);
+
+    /// <summary>
+    /// Logs that a pair download failed.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="symbol">The Yahoo Finance ticker symbol whose download failed.</param>
+    /// <param name="exception">The exception that caused the failure.</param>
+    [LoggerMessage(EventId = 4403, Level = LogLevel.Warning, Message = "Failed to download Yahoo Finance chart '{symbol}'")]
+    public static partial void PairLoadFailed(ILogger logger, string symbol, Exception exception);
+
+    /// <summary>
+    /// Logs that a synchronous lookup triggered an on-demand network fetch.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="date">The date around which a window was fetched synchronously.</param>
+    [LoggerMessage(EventId = 4404, Level = LogLevel.Warning, Message = "Performed synchronous Yahoo Finance network fetch to resolve a rate for {date}")]
+    public static partial void SynchronousNetworkFetch(ILogger logger, DateOnly date);
+}

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
@@ -23,6 +23,11 @@ using Microsoft.Extensions.Logging;
 /// template, and the <see cref="SymbolFormat" /> used to build the foreign-exchange ticker. The chart bar interval is
 /// fixed at one day, and the date range is supplied per call through the provider's lookup and range methods.
 /// </para>
+/// <para>
+/// The <c>*LogLevel</c> members set the <see cref="LogLevel" /> at which each diagnostic the provider emits is logged,
+/// so consumers can re-tune verbosity per concern without category-wide log filters. Set any of them to
+/// <see cref="LogLevel.None" /> to suppress that event entirely.
+/// </para>
 /// </remarks>
 public sealed class YahooExchangeRateOptions
 {

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
@@ -6,6 +6,8 @@
 
 namespace Bodu.Financial.ExchangeRates.Yahoo;
 
+using Microsoft.Extensions.Logging;
+
 /// <summary>
 /// Configures how the <see cref="YahooExchangeRateProvider" /> addresses and interprets the Yahoo Finance chart REST
 /// service.
@@ -107,6 +109,36 @@ public sealed class YahooExchangeRateOptions
     /// <value>The alias map; defaults to an empty map.</value>
     public IDictionary<string, string> CurrencyAliases { get; set; } =
         new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets or sets the level at which the start of a chart download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    public LogLevel DownloadStartingLogLevel { get; set; } = LogLevel.Debug;
+
+    /// <summary>
+    /// Gets or sets the level at which a completed chart download (with its observation count) is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Information" />.</value>
+    public LogLevel DownloadCompletedLogLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Gets or sets the level at which a failed chart download is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Warning" />.</value>
+    public LogLevel DownloadFailedLogLevel { get; set; } = LogLevel.Warning;
+
+    /// <summary>
+    /// Gets or sets the level at which each individual ingested rate observation is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Trace" />.</value>
+    public LogLevel ObservationIngestedLogLevel { get; set; } = LogLevel.Trace;
+
+    /// <summary>
+    /// Gets or sets the level at which a synchronous, blocking on-demand network fetch is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Warning" />.</value>
+    public LogLevel SynchronousNetworkFetchLogLevel { get; set; } = LogLevel.Warning;
 
     /// <summary>
     /// Validates the options, throwing when a required value is missing or a template lacks its placeholder.

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
@@ -344,6 +344,7 @@ public sealed class YahooExchangeRateProvider
         foreach (ExchangeRate rate in chart.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
@@ -29,6 +29,15 @@ namespace Bodu.Financial.ExchangeRates.Yahoo;
 /// <see cref="ExchangeRateBook" /> snapshot that backs the synchronous lookups, so inverse pairs, same-currency
 /// identity, and date-resolution policies are inherited from <see cref="FixedDatedExchangeRateProvider" />.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
+/// package) the provider records: the start of a pair/chart download (<see cref="LogLevel.Debug" />), a completed
+/// download with its observation count (<see cref="LogLevel.Information" />), each ingested observation
+/// (<see cref="LogLevel.Trace" />), a failed download (<see cref="LogLevel.Warning" />, then re-thrown), and a
+/// synchronous on-demand network fetch (<see cref="LogLevel.Warning" />). Every level is configurable through the
+/// corresponding <c>*LogLevel</c> property on <see cref="YahooExchangeRateOptions" />; omitting the logger selects
+/// <see cref="NullLogger.Instance" />, so logging is opt-in and free when unused.
+/// </para>
 /// </remarks>
 public sealed class YahooExchangeRateProvider
     : IDatedExchangeRateProvider, IExchangeRateProvider

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
@@ -5,6 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Financial.ExchangeRates.Yahoo;
 
@@ -83,17 +85,26 @@ public sealed class YahooExchangeRateProvider
     private volatile FixedDatedExchangeRateProvider _snapshot;
 
     /// <summary>
+    /// The logger that records chart downloads and on-demand network fetches.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="YahooExchangeRateProvider" /> class backed by the Yahoo Finance
     /// chart endpoint, queried with the supplied HTTP client.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to issue chart requests.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records chart downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    public YahooExchangeRateProvider(HttpClient httpClient, YahooExchangeRateOptions options)
-        : this(CreateSource(httpClient, options), options)
+    public YahooExchangeRateProvider(HttpClient httpClient, YahooExchangeRateOptions options, ILogger? logger = null)
+        : this(CreateSource(httpClient, options), options, logger)
     {
     }
 
@@ -103,11 +114,15 @@ public sealed class YahooExchangeRateProvider
     /// </summary>
     /// <param name="source">The chart source.</param>
     /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records chart downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
-    internal YahooExchangeRateProvider(IYahooExchangeRateChartSource source, YahooExchangeRateOptions options)
+    internal YahooExchangeRateProvider(IYahooExchangeRateChartSource source, YahooExchangeRateOptions options, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -115,6 +130,7 @@ public sealed class YahooExchangeRateProvider
 
         _source = source;
         _options = options;
+        _logger = logger ?? NullLogger.Instance;
         _book = _builder.ToBook();
         _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
@@ -161,7 +177,10 @@ public sealed class YahooExchangeRateProvider
             return true;
 
         if (_options.AllowSynchronousNetworkAccess && TryLoadPairForDate(fromIsoCode, toIsoCode, date))
+        {
+            Log.SynchronousNetworkFetch(_logger, date);
             return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
+        }
 
         result = default;
         return false;
@@ -212,13 +231,26 @@ public sealed class YahooExchangeRateProvider
 
         var symbol = _options.BuildSymbol(fromIsoCode, toIsoCode);
         YahooChartRequest request = new(pair, symbol, startDate, endDate);
-        YahooExchangeRateChart chart = await _source.GetChartAsync(request, cancellationToken).ConfigureAwait(false);
+
+        Log.PairLoadStarting(_logger, symbol);
+
+        YahooExchangeRateChart chart;
+        try
+        {
+            chart = await _source.GetChartAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.PairLoadFailed(_logger, symbol, ex);
+            throw;
+        }
 
         lock (_gate)
         {
-            Accumulate(chart);
+            var count = Accumulate(chart);
             ExtendCoveredRange(pair, startDate, endDate);
             RebuildSnapshot();
+            Log.PairLoaded(_logger, symbol, count);
         }
     }
 
@@ -302,13 +334,20 @@ public sealed class YahooExchangeRateProvider
     /// Upserts a fetched chart's observations and series metadata into the accumulator.
     /// </summary>
     /// <param name="chart">The parsed chart.</param>
-    private void Accumulate(YahooExchangeRateChart chart)
+    /// <returns>The number of rate observations upserted.</returns>
+    private int Accumulate(YahooExchangeRateChart chart)
     {
         YahooSeriesInfo info = chart.GetSeriesInfo();
         _series[info.Pair] = info;
 
+        var count = 0;
         foreach (ExchangeRate rate in chart.EnumerateRates())
+        {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            count++;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
@@ -178,7 +178,7 @@ public sealed class YahooExchangeRateProvider
 
         if (_options.AllowSynchronousNetworkAccess && TryLoadPairForDate(fromIsoCode, toIsoCode, date))
         {
-            Log.SynchronousNetworkFetch(_logger, date);
+            Log.SynchronousNetworkFetch(_logger, _options.SynchronousNetworkFetchLogLevel, date);
             return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
         }
 
@@ -232,7 +232,7 @@ public sealed class YahooExchangeRateProvider
         var symbol = _options.BuildSymbol(fromIsoCode, toIsoCode);
         YahooChartRequest request = new(pair, symbol, startDate, endDate);
 
-        Log.PairLoadStarting(_logger, symbol);
+        Log.PairLoadStarting(_logger, _options.DownloadStartingLogLevel, symbol);
 
         YahooExchangeRateChart chart;
         try
@@ -241,7 +241,7 @@ public sealed class YahooExchangeRateProvider
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            Log.PairLoadFailed(_logger, symbol, ex);
+            Log.PairLoadFailed(_logger, _options.DownloadFailedLogLevel, symbol, ex);
             throw;
         }
 
@@ -250,7 +250,7 @@ public sealed class YahooExchangeRateProvider
             var count = Accumulate(chart);
             ExtendCoveredRange(pair, startDate, endDate);
             RebuildSnapshot();
-            Log.PairLoaded(_logger, symbol, count);
+            Log.PairLoaded(_logger, _options.DownloadCompletedLogLevel, symbol, count);
         }
     }
 
@@ -344,7 +344,7 @@ public sealed class YahooExchangeRateProvider
         foreach (ExchangeRate rate in chart.EnumerateRates())
         {
             _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
             count++;
         }
 

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Bodu.Globalization.Calendar.DependencyInjection.csproj
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Bodu.Globalization.Calendar.DependencyInjection.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/NotableDateServiceCollectionExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/NotableDateServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@
 
 using Bodu;
 using Bodu.Globalization.Calendar;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -101,10 +102,13 @@ public static class NotableDateServiceCollectionExtensions
         ThrowHelper.ThrowIfNull(services);
         ThrowHelper.ThrowIfNull(initialResource);
 
-        MutableNotableDateResourceProvider provider = new(initialResource);
-        services.AddSingleton(provider);
-        services.AddSingleton<INotableDateResourceProvider>(provider);
-        services.AddSingleton<INotableDateService>(_ => new ReloadableNotableDateService(provider));
+        services.AddSingleton(sp => new MutableNotableDateResourceProvider(
+            initialResource,
+            sp.GetService<ILoggerFactory>()?.CreateLogger<MutableNotableDateResourceProvider>()));
+        services.AddSingleton<INotableDateResourceProvider>(sp => sp.GetRequiredService<MutableNotableDateResourceProvider>());
+        services.AddSingleton<INotableDateService>(sp => new ReloadableNotableDateService(
+            sp.GetRequiredService<MutableNotableDateResourceProvider>(),
+            sp.GetService<ILoggerFactory>()?.CreateLogger<ReloadableNotableDateService>()));
         return services;
     }
 }

--- a/Bodu.Globalization.Calendar.Plugins/src/Bodu.Globalization.Calendar.Plugins.csproj
+++ b/Bodu.Globalization.Calendar.Plugins/src/Bodu.Globalization.Calendar.Plugins.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar\src\Bodu.Globalization.Calendar.csproj" />
   </ItemGroup>
 

--- a/Bodu.Globalization.Calendar.Plugins/src/Log.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/Log.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar.Plugins;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted while loading and registering
+/// notable-date plugins.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that an assembly was rejected by the trust policy and will not be activated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="assembly">The display name of the rejected assembly.</param>
+    /// <param name="reason">The reason reported by the trust policy.</param>
+    [LoggerMessage(EventId = 2001, Level = LogLevel.Warning, Message = "Plugin assembly '{assembly}' rejected by trust policy: {reason}")]
+    public static partial void PluginTrustRejected(ILogger logger, string assembly, string reason);
+
+    /// <summary>
+    /// Logs that an assembly passed the trust policy and is eligible for activation.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="assembly">The display name of the trusted assembly.</param>
+    [LoggerMessage(EventId = 2002, Level = LogLevel.Debug, Message = "Plugin assembly '{assembly}' trusted; activating its entry point")]
+    public static partial void PluginTrusted(ILogger logger, string assembly);
+
+    /// <summary>
+    /// Logs that a plugin entry-point type was activated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="assembly">The display name of the declaring assembly.</param>
+    /// <param name="pluginType">The activated plugin entry-point type.</param>
+    [LoggerMessage(EventId = 2003, Level = LogLevel.Information, Message = "Activated notable-date plugin '{pluginType}' from assembly '{assembly}'")]
+    public static partial void PluginActivated(ILogger logger, string assembly, string pluginType);
+
+    /// <summary>
+    /// Logs the number of algorithms a plugin contributed to a registry.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="count">The number of algorithms registered.</param>
+    /// <param name="pluginType">The plugin that contributed the algorithms.</param>
+    [LoggerMessage(EventId = 2004, Level = LogLevel.Information, Message = "Registered {count} algorithm(s) contributed by plugin '{pluginType}'")]
+    public static partial void PluginAlgorithmsRegistered(ILogger logger, int count, string pluginType);
+}

--- a/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
@@ -30,6 +30,13 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// production-grade <see cref="IPluginTrustPolicy" /> — <see cref="AllowAllPluginTrustPolicy" /> is for development
 /// only.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> Each <c>LoadFrom</c> / <see cref="RegisterAlgorithms" /> overload accepts an optional
+/// <see cref="ILogger" /> (defaulting to <see cref="NullLogger.Instance" />, so logging is opt-in). When supplied it
+/// records a trust-policy rejection (<see cref="LogLevel.Warning" />), a passed trust check
+/// (<see cref="LogLevel.Debug" />), an activated plugin (<see cref="LogLevel.Information" />), and the number of
+/// algorithms a plugin contributed (<see cref="LogLevel.Information" />). These levels are fixed.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
@@ -8,6 +8,8 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Globalization.Calendar.Plugins;
 
@@ -55,6 +57,10 @@ public static class NotableDatePluginLoader
     /// </summary>
     /// <param name="assembly">The assembly declaring the plugin via <see cref="NotableDatePluginAttribute" />.</param>
     /// <param name="trustPolicy">The policy that must trust the assembly before its plugin is activated.</param>
+    /// <param name="logger">
+    /// The logger that receives diagnostics for the load. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The activated plugin.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="assembly" /> or <paramref name="trustPolicy" /> is <see langword="null" />.
@@ -64,10 +70,12 @@ public static class NotableDatePluginLoader
     /// <exception cref="PluginActivationException">
     /// The plugin type could not be activated or is not a plugin.
     /// </exception>
-    public static INotableDatePlugin LoadFrom(Assembly assembly, IPluginTrustPolicy trustPolicy)
+    public static INotableDatePlugin LoadFrom(Assembly assembly, IPluginTrustPolicy trustPolicy, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(assembly);
         ThrowHelper.ThrowIfNull(trustPolicy);
+
+        ILogger log = logger ?? NullLogger.Instance;
 
         AssemblyName assemblyName = assembly.GetName();
         var name = assemblyName.Name ?? assembly.FullName ?? "<unknown>";
@@ -78,17 +86,23 @@ public static class NotableDatePluginLoader
         PluginTrustResult trust = trustPolicy.Evaluate(new PluginTrustContext(name, path, hash, token));
         if (!trust.IsTrusted)
         {
+            Log.PluginTrustRejected(log, name, trust.Reason ?? string.Empty);
             throw new PluginNotTrustedException(
                 string.Format(CultureInfo.CurrentCulture, PluginsResourceStrings.Op_NotTrusted_Plugin, name, trust.Reason ?? string.Empty),
                 name,
                 trust.Reason);
         }
 
+        Log.PluginTrusted(log, name);
+
         NotableDatePluginAttribute? attribute = assembly.GetCustomAttribute<NotableDatePluginAttribute>() ?? throw new PluginMissingAttributeException(
                 string.Format(CultureInfo.CurrentCulture, PluginsResourceStrings.Op_Missing_PluginAttribute, name),
                 name);
 
-        return Activate(attribute.PluginType);
+        INotableDatePlugin plugin = Activate(attribute.PluginType);
+        Log.PluginActivated(log, name, attribute.PluginType.FullName ?? attribute.PluginType.Name);
+
+        return plugin;
     }
 
     /// <summary>
@@ -96,6 +110,10 @@ public static class NotableDatePluginLoader
     /// </summary>
     /// <param name="assemblyPath">The file path of the plugin assembly.</param>
     /// <param name="trustPolicy">The policy that must trust the assembly before its plugin is activated.</param>
+    /// <param name="logger">
+    /// The logger that receives diagnostics for the load. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The activated plugin.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="assemblyPath" /> or <paramref name="trustPolicy" /> is <see langword="null" />.
@@ -105,7 +123,7 @@ public static class NotableDatePluginLoader
     /// <exception cref="PluginActivationException">
     /// The plugin type could not be activated or is not a plugin.
     /// </exception>
-    public static INotableDatePlugin LoadFrom(string assemblyPath, IPluginTrustPolicy trustPolicy)
+    public static INotableDatePlugin LoadFrom(string assemblyPath, IPluginTrustPolicy trustPolicy, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(assemblyPath);
         ThrowHelper.ThrowIfNull(trustPolicy);
@@ -114,7 +132,7 @@ public static class NotableDatePluginLoader
         AssemblyLoadContext context = new($"NotableDatePlugin:{Path.GetFileNameWithoutExtension(fullPath)}", isCollectible: false);
         Assembly assembly = context.LoadFromAssemblyPath(fullPath);
 
-        return LoadFrom(assembly, trustPolicy);
+        return LoadFrom(assembly, trustPolicy, logger);
     }
 
     /// <summary>
@@ -122,11 +140,15 @@ public static class NotableDatePluginLoader
     /// </summary>
     /// <param name="plugin">The plugin whose algorithms are registered.</param>
     /// <param name="registry">The registry to populate.</param>
+    /// <param name="logger">
+    /// The logger that receives diagnostics for the registration. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The number of algorithms registered.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="plugin" /> or <paramref name="registry" /> is <see langword="null" />.
     /// </exception>
-    public static int RegisterAlgorithms(INotableDatePlugin plugin, NotableDateAlgorithmRegistry registry)
+    public static int RegisterAlgorithms(INotableDatePlugin plugin, NotableDateAlgorithmRegistry registry, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(plugin);
         ThrowHelper.ThrowIfNull(registry);
@@ -140,6 +162,8 @@ public static class NotableDatePluginLoader
             registry.Register(pair.Key, pair.Value);
             count++;
         }
+
+        Log.PluginAlgorithmsRegistered(logger ?? NullLogger.Instance, count, plugin.GetType().FullName ?? plugin.GetType().Name);
 
         return count;
     }

--- a/Bodu.Globalization.Calendar.Plugins/test/Globalization.Calendar.Plugins/CapturingLogger.cs
+++ b/Bodu.Globalization.Calendar.Plugins/test/Globalization.Calendar.Plugins/CapturingLogger.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CapturingLogger.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar.Plugins;
+
+/// <summary>
+/// A minimal <see cref="ILogger" /> that records the level, event id, and rendered message of every entry, used to
+/// assert that the plugin loader emits the expected diagnostics.
+/// </summary>
+internal sealed class CapturingLogger
+    : ILogger
+{
+    /// <summary>
+    /// Gets the recorded entries in emission order.
+    /// </summary>
+    public List<(LogLevel Level, EventId EventId, string Message)> Entries { get; } = new();
+
+    /// <inheritdoc />
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull =>
+        NullScope.Instance;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) =>
+        true;
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        Entries.Add((logLevel, eventId, formatter(state, exception)));
+    }
+
+    /// <summary>
+    /// A no-op scope returned by <see cref="BeginScope{TState}(TState)" />.
+    /// </summary>
+    private sealed class NullScope
+        : IDisposable
+    {
+        /// <summary>
+        /// Gets the shared instance.
+        /// </summary>
+        public static NullScope Instance { get; } = new();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Bodu.Globalization.Calendar.Plugins/test/Globalization.Calendar.Plugins/NotableDatePluginLoaderTests.Logging.cs
+++ b/Bodu.Globalization.Calendar.Plugins/test/Globalization.Calendar.Plugins/NotableDatePluginLoaderTests.Logging.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDatePluginLoaderTests.Logging.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar.Plugins;
+
+/// <summary>
+/// Verifies that <see cref="NotableDatePluginLoader" /> emits diagnostics through a supplied logger and remains silent
+/// and side-effect-free when no logger is supplied.
+/// </summary>
+public sealed partial class NotableDatePluginLoaderTests
+{
+    /// <summary>
+    /// Verifies that activating a trusted plugin emits an informational activation record through the supplied logger.
+    /// </summary>
+    [TestMethod]
+    public void LoadFrom_WhenLoggerSupplied_ShouldLogActivation()
+    {
+        CapturingLogger logger = new();
+
+        _ = NotableDatePluginLoader.LoadFrom(TestAssembly, new AllowAllPluginTrustPolicy(), logger);
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Information && e.EventId.Id == 2003));
+    }
+
+    /// <summary>
+    /// Verifies that a trust-policy rejection emits a warning record through the supplied logger before the loader
+    /// throws.
+    /// </summary>
+    [TestMethod]
+    public void LoadFrom_WhenTrustRejectedAndLoggerSupplied_ShouldLogWarning()
+    {
+        CapturingLogger logger = new();
+        IPluginTrustPolicy policy = new DelegatingPluginTrustPolicy(_ => PluginTrustResult.Rejected("blocked"));
+
+        _ = Assert.ThrowsExactly<PluginNotTrustedException>(() =>
+        {
+            _ = NotableDatePluginLoader.LoadFrom(TestAssembly, policy, logger);
+        });
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Warning && e.EventId.Id == 2001));
+    }
+
+    /// <summary>
+    /// Verifies that registering a plugin's algorithms emits an informational record reporting the registered count.
+    /// </summary>
+    [TestMethod]
+    public void RegisterAlgorithms_WhenLoggerSupplied_ShouldLogRegisteredCount()
+    {
+        CapturingLogger logger = new();
+        INotableDatePlugin plugin = NotableDatePluginLoader.LoadFrom(TestAssembly, new AllowAllPluginTrustPolicy());
+        NotableDateAlgorithmRegistry registry = new();
+
+        var count = NotableDatePluginLoader.RegisterAlgorithms(plugin, registry, logger);
+
+        Assert.AreEqual(1, count);
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Information && e.EventId.Id == 2004));
+    }
+
+    /// <summary>
+    /// Verifies that loading without a logger activates the plugin without throwing, confirming the default
+    /// <c>null</c> logger path is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void LoadFrom_WhenNoLoggerSupplied_ShouldActivateWithoutLogging()
+    {
+        INotableDatePlugin plugin = NotableDatePluginLoader.LoadFrom(TestAssembly, new AllowAllPluginTrustPolicy());
+
+        Assert.IsInstanceOfType<TestPlugin>(plugin);
+    }
+}

--- a/Bodu.Globalization.Calendar.Plugins/test/Globalization.Calendar.Plugins/NotableDatePluginLoaderTests.cs
+++ b/Bodu.Globalization.Calendar.Plugins/test/Globalization.Calendar.Plugins/NotableDatePluginLoaderTests.cs
@@ -44,7 +44,7 @@ public sealed class TestPlugin
 /// assemblies, and registers the plugin's algorithms for use by the resolver.
 /// </summary>
 [TestClass]
-public sealed class NotableDatePluginLoaderTests
+public sealed partial class NotableDatePluginLoaderTests
 {
     /// <summary>
     /// Gets the test assembly, which declares the plugin via an assembly attribute.
@@ -184,7 +184,7 @@ public sealed class NotableDatePluginLoaderTests
     }
 
     /// <summary>
-    /// Verifies that the file-path <see cref="NotableDatePluginLoader.LoadFrom(string, IPluginTrustPolicy)" /> overload
+    /// Verifies that the file-path <see cref="NotableDatePluginLoader.LoadFrom(string, IPluginTrustPolicy, Microsoft.Extensions.Logging.ILogger)" /> overload
     /// loads the assembly from disk and activates its plugin.
     /// </summary>
     [TestMethod]

--- a/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
+++ b/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
   </ItemGroup>
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/CommonNotableDateResources.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/CommonNotableDateResources.cs
@@ -19,7 +19,7 @@ namespace Bodu.Globalization.Calendar;
 /// A territory resource imports a common catalogue by name through an <c>Import</c> directive, then cherry-picks the
 /// concepts it observes and supplies its own territory and adjustment overrides. The <see cref="Resolver" /> delegate
 /// is the bridge: pass it to
-/// <see cref="NotableDateResourceLoader.Load(System.IO.Stream, System.Func{string, string})" /> so those imports
+/// <see cref="NotableDateResourceLoader.Load(System.IO.Stream, System.Func{string, string}, Microsoft.Extensions.Logging.ILogger)" /> so those imports
 /// resolve against the embedded catalogues.
 /// </para>
 /// <para>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Log.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Log.cs
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Log.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Provides the source-generated, allocation-free logging messages emitted while loading notable-date resources and
+/// reloading them at runtime.
+/// </summary>
+/// <remarks>
+/// The messages are produced by the <see cref="LoggerMessageAttribute" /> source generator, so a disabled or
+/// <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger" /> logger short-circuits before any argument is
+/// formatted.
+/// </remarks>
+internal static partial class Log
+{
+    /// <summary>
+    /// Logs that a notable-date resource was loaded and validated.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="resourceId">The identifier of the loaded resource.</param>
+    /// <param name="definitionCount">The number of notable-date definitions in the resource.</param>
+    /// <param name="policyCount">The number of adjustment policies in the resource.</param>
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Debug, Message = "Loaded notable-date resource '{resourceId}' with {definitionCount} definition(s) and {policyCount} adjustment policy(ies)")]
+    public static partial void ResourceLoaded(ILogger logger, string resourceId, int definitionCount, int policyCount);
+
+    /// <summary>
+    /// Logs that a notable-date document failed validation and the load will be rejected.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="errorCount">The number of error-severity diagnostics produced.</param>
+    [LoggerMessage(EventId = 3002, Level = LogLevel.Warning, Message = "Notable-date document validation failed with {errorCount} error diagnostic(s)")]
+    public static partial void ResourceValidationFailed(ILogger logger, int errorCount);
+
+    /// <summary>
+    /// Logs that the resource currently in effect was replaced at runtime.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="resourceId">The identifier of the resource that becomes current.</param>
+    [LoggerMessage(EventId = 3003, Level = LogLevel.Information, Message = "Reloaded notable-date resource; resource '{resourceId}' is now in effect")]
+    public static partial void ResourceReloaded(ILogger logger, string resourceId);
+
+    /// <summary>
+    /// Logs that a reloadable service rebuilt its resolution state after detecting a reloaded resource.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="resourceId">The identifier of the resource the resolution state was rebuilt from.</param>
+    [LoggerMessage(EventId = 3004, Level = LogLevel.Debug, Message = "Rebuilt notable-date resolution state from reloaded resource '{resourceId}'")]
+    public static partial void ResolutionStateRebuilt(ILogger logger, string resourceId);
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
@@ -20,6 +20,11 @@ namespace Bodu.Globalization.Calendar;
 /// override operations or refreshed data at runtime is performed by loading a fresh <see cref="NotableDateResource" />
 /// and passing it to <see cref="Reload" />.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> The constructor accepts an optional <see cref="ILogger" /> (defaulting to
+/// <see cref="NullLogger.Instance" />, so logging is opt-in). When supplied, <see cref="Reload" /> records the swap at
+/// <see cref="LogLevel.Information" />, naming the resource that becomes current. This level is fixed.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
@@ -4,6 +4,9 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
@@ -41,15 +44,24 @@ public sealed class MutableNotableDateResourceProvider
     private volatile NotableDateResource _current;
 
     /// <summary>
+    /// The logger that records resource reloads.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MutableNotableDateResourceProvider" /> class.
     /// </summary>
     /// <param name="resource">The initial resource.</param>
+    /// <param name="logger">
+    /// The logger that records resource reloads. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="resource" /> is <see langword="null" />.</exception>
-    public MutableNotableDateResourceProvider(NotableDateResource resource)
+    public MutableNotableDateResourceProvider(NotableDateResource resource, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(resource);
 
         _current = resource;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <inheritdoc />
@@ -66,5 +78,6 @@ public sealed class MutableNotableDateResourceProvider
         ThrowHelper.ThrowIfNull(resource);
 
         _current = resource;
+        Log.ResourceReloaded(_logger, resource.ResourceId);
     }
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
@@ -6,6 +6,8 @@
 
 using System.Globalization;
 using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bodu.Globalization.Calendar;
 
@@ -25,7 +27,7 @@ namespace Bodu.Globalization.Calendar;
 /// resolver overload, whose delegate maps a resource name to that resource's XML or JSON content.
 /// </para>
 /// <para>
-/// <strong>When to use.</strong> Call <see cref="Load(string)" /> / <see cref="LoadJson(string)" /> (or the
+/// <strong>When to use.</strong> Call <see cref="Load(string, ILogger)" /> / <see cref="LoadJson(string, ILogger)" /> (or the
 /// <see cref="Stream" /> overloads) for a self-contained document, and the resolver overloads when the document imports
 /// shared concepts or adjustment policies from other resources. For the bundled territory packs prefer the data-pack
 /// factories (for example the <c>AmericasCalendarData</c> bundle), which load and wire the embedded resources for you.
@@ -61,6 +63,9 @@ public static class NotableDateResourceLoader
     /// Loads and validates a notable-date document from its XML content.
     /// </summary>
     /// <param name="xml">The notable-date document XML content.</param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="xml" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException"><paramref name="xml" /> is empty or white-space.</exception>
@@ -68,8 +73,8 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource Load(string xml) =>
-        Load(xml, NoResolver);
+    public static NotableDateResource Load(string xml, ILogger? logger = null) =>
+        Load(xml, NoResolver, null, logger);
 
     /// <summary>
     /// Loads and validates a notable-date document from its XML content, resolving imports through the supplied
@@ -78,6 +83,9 @@ public static class NotableDateResourceLoader
     /// <param name="xml">The notable-date document XML content.</param>
     /// <param name="resourceResolver">
     /// A delegate mapping a resource name to its XML or JSON content, or <see langword="null" /> when missing.
+    /// </param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
     /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException">
@@ -88,8 +96,8 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource Load(string xml, Func<string, string?> resourceResolver) =>
-        Load(xml, resourceResolver, null);
+    public static NotableDateResource Load(string xml, Func<string, string?> resourceResolver, ILogger? logger = null) =>
+        Load(xml, resourceResolver, null, logger);
 
     /// <summary>
     /// Loads and validates a notable-date document from its XML content, resolving imports through the supplied
@@ -102,6 +110,9 @@ public static class NotableDateResourceLoader
     /// <param name="algorithms">
     /// A registry of custom algorithm keys to accept during validation, or <see langword="null" />.
     /// </param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="xml" /> or <paramref name="resourceResolver" /> is <see langword="null" />.
@@ -111,7 +122,7 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource Load(string xml, Func<string, string?> resourceResolver, INotableDateAlgorithmRegistry? algorithms)
+    public static NotableDateResource Load(string xml, Func<string, string?> resourceResolver, INotableDateAlgorithmRegistry? algorithms, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(xml);
         ThrowHelper.ThrowIfNull(resourceResolver);
@@ -120,13 +131,16 @@ public static class NotableDateResourceLoader
         List<NotableDateValidationDiagnostic> diagnostics = new();
         ParsedNotableDateDocument document = NotableDateDocumentParser.Parse(xml, diagnostics);
 
-        return Build(document, resourceResolver, algorithms, diagnostics);
+        return Build(document, resourceResolver, algorithms, diagnostics, logger);
     }
 
     /// <summary>
     /// Loads and validates a notable-date document from a stream of XML content.
     /// </summary>
     /// <param name="stream">The stream containing the notable-date document XML.</param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">The stream content is empty or white-space.</exception>
@@ -134,8 +148,8 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource Load(Stream stream) =>
-        Load(ReadToEnd(stream));
+    public static NotableDateResource Load(Stream stream, ILogger? logger = null) =>
+        Load(ReadToEnd(stream), NoResolver, null, logger);
 
     /// <summary>
     /// Loads and validates a notable-date document from a stream of XML content, resolving imports through the supplied
@@ -144,6 +158,9 @@ public static class NotableDateResourceLoader
     /// <param name="stream">The stream containing the notable-date document XML.</param>
     /// <param name="resourceResolver">
     /// A delegate mapping a resource name to its XML or JSON content, or <see langword="null" /> when missing.
+    /// </param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
     /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException">
@@ -154,13 +171,16 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource Load(Stream stream, Func<string, string?> resourceResolver) =>
-        Load(ReadToEnd(stream), resourceResolver);
+    public static NotableDateResource Load(Stream stream, Func<string, string?> resourceResolver, ILogger? logger = null) =>
+        Load(ReadToEnd(stream), resourceResolver, null, logger);
 
     /// <summary>
     /// Loads and validates a notable-date document from its JSON content.
     /// </summary>
     /// <param name="json">The notable-date document JSON content.</param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="json" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException"><paramref name="json" /> is empty or white-space.</exception>
@@ -168,8 +188,8 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource LoadJson(string json) =>
-        LoadJson(json, NoResolver);
+    public static NotableDateResource LoadJson(string json, ILogger? logger = null) =>
+        LoadJson(json, NoResolver, logger);
 
     /// <summary>
     /// Loads and validates a notable-date document from its JSON content, resolving imports through the supplied
@@ -178,6 +198,9 @@ public static class NotableDateResourceLoader
     /// <param name="json">The notable-date document JSON content.</param>
     /// <param name="resourceResolver">
     /// A delegate mapping a resource name to its XML or JSON content, or <see langword="null" /> when missing.
+    /// </param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
     /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException">
@@ -188,7 +211,7 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource LoadJson(string json, Func<string, string?> resourceResolver)
+    public static NotableDateResource LoadJson(string json, Func<string, string?> resourceResolver, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(json);
         ThrowHelper.ThrowIfNull(resourceResolver);
@@ -197,13 +220,16 @@ public static class NotableDateResourceLoader
         List<NotableDateValidationDiagnostic> diagnostics = new();
         ParsedNotableDateDocument document = NotableDateJsonDocumentParser.Parse(json, diagnostics);
 
-        return Build(document, resourceResolver, null, diagnostics);
+        return Build(document, resourceResolver, null, diagnostics, logger);
     }
 
     /// <summary>
     /// Loads and validates a notable-date document from a stream of JSON content.
     /// </summary>
     /// <param name="stream">The stream containing the notable-date document JSON.</param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics. <see langword="null" /> selects <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">The stream content is empty or white-space.</exception>
@@ -211,8 +237,8 @@ public static class NotableDateResourceLoader
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    public static NotableDateResource LoadJson(Stream stream) =>
-        LoadJson(ReadToEnd(stream));
+    public static NotableDateResource LoadJson(Stream stream, ILogger? logger = null) =>
+        LoadJson(ReadToEnd(stream), NoResolver, logger);
 
     /// <summary>
     /// Resolves imports, applies overrides, assembles the resource, runs semantic validation, and fails when any error
@@ -226,12 +252,17 @@ public static class NotableDateResourceLoader
     /// <param name="diagnostics">
     /// The diagnostics accumulated during parsing, extended by import resolution and validation.
     /// </param>
+    /// <param name="logger">
+    /// The logger that receives load diagnostics, or <see langword="null" /> for <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <returns>The validated <see cref="NotableDateResource" />.</returns>
     /// <exception cref="NotableDateValidationException">
     /// The notable-date document produced one or more error diagnostics.
     /// </exception>
-    private static NotableDateResource Build(ParsedNotableDateDocument document, Func<string, string?> resourceResolver, INotableDateAlgorithmRegistry? algorithms, List<NotableDateValidationDiagnostic> diagnostics)
+    private static NotableDateResource Build(ParsedNotableDateDocument document, Func<string, string?> resourceResolver, INotableDateAlgorithmRegistry? algorithms, List<NotableDateValidationDiagnostic> diagnostics, ILogger? logger)
     {
+        ILogger log = logger ?? NullLogger.Instance;
+
         (List<AdjustmentPolicy> policies, List<NotableDateDefinition> concepts) =
             ResolveImports(document, resourceResolver, new HashSet<string>(StringComparer.Ordinal), diagnostics);
 
@@ -249,10 +280,13 @@ public static class NotableDateResourceLoader
         var errorCount = diagnostics.Count(d => d.Severity == NotableDateValidationSeverity.Error);
         if (errorCount > 0)
         {
+            Log.ResourceValidationFailed(log, errorCount);
             throw new NotableDateValidationException(
                 string.Format(CultureInfo.CurrentCulture, CalendarResourceStrings.Op_Invalid_DocumentValidationFailed, errorCount),
                 diagnostics);
         }
+
+        Log.ResourceLoaded(log, resource.ResourceId, resource.NotableDates.Count, resource.AdjustmentPolicies.Count);
 
         return resource;
     }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
@@ -32,6 +32,13 @@ namespace Bodu.Globalization.Calendar;
 /// shared concepts or adjustment policies from other resources. For the bundled territory packs prefer the data-pack
 /// factories (for example the <c>AmericasCalendarData</c> bundle), which load and wire the embedded resources for you.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> Each <c>Load</c> / <c>LoadJson</c> overload accepts an optional <see cref="ILogger" />
+/// (defaulting to <see cref="NullLogger.Instance" />, so logging is opt-in). When supplied it records a successfully
+/// loaded resource with its definition and policy counts (<see cref="LogLevel.Debug" />) and a validation failure with
+/// its error-diagnostic count (<see cref="LogLevel.Warning" />, logged immediately before the
+/// <see cref="NotableDateValidationException" /> is thrown). These levels are fixed.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
@@ -4,6 +4,9 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
@@ -51,6 +54,11 @@ public sealed class ReloadableNotableDateService
     private readonly object _gate = new();
 
     /// <summary>
+    /// The logger that records resolution-state rebuilds after a reload.
+    /// </summary>
+    private readonly ILogger _logger;
+
+    /// <summary>
     /// The inner service resolving against <see cref="_builtFrom" />.
     /// </summary>
     private NotableDateService _inner;
@@ -64,9 +72,13 @@ public sealed class ReloadableNotableDateService
     /// Initializes a new instance of the <see cref="ReloadableNotableDateService" /> class.
     /// </summary>
     /// <param name="provider">The provider supplying the resource currently in effect.</param>
+    /// <param name="logger">
+    /// The logger that records resolution-state rebuilds. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="provider" /> is <see langword="null" />.</exception>
-    public ReloadableNotableDateService(INotableDateResourceProvider provider)
-        : this(provider, null)
+    public ReloadableNotableDateService(INotableDateResourceProvider provider, ILogger? logger = null)
+        : this(provider, null, logger)
     {
     }
 
@@ -79,13 +91,18 @@ public sealed class ReloadableNotableDateService
     /// The optional collaborators propagated to each rebuilt inner <see cref="NotableDateService" />, or
     /// <see langword="null" /> for built-ins only.
     /// </param>
+    /// <param name="logger">
+    /// The logger that records resolution-state rebuilds. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="provider" /> is <see langword="null" />.</exception>
-    public ReloadableNotableDateService(INotableDateResourceProvider provider, NotableDateServiceOptions? options)
+    public ReloadableNotableDateService(INotableDateResourceProvider provider, NotableDateServiceOptions? options, ILogger? logger = null)
     {
         ThrowHelper.ThrowIfNull(provider);
 
         _provider = provider;
         _options = options;
+        _logger = logger ?? NullLogger.Instance;
 
         _builtFrom = provider.Current;
         _inner = new NotableDateService(_builtFrom, options);
@@ -129,6 +146,7 @@ public sealed class ReloadableNotableDateService
             {
                 _inner = new NotableDateService(current, _options);
                 _builtFrom = current;
+                Log.ResolutionStateRebuilt(_logger, current.ResourceId);
             }
 
             return _inner;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
@@ -20,6 +20,11 @@ namespace Bodu.Globalization.Calendar;
 /// reads the provider's current resource; when it differs from the one the inner service was built from, a fresh inner
 /// service is constructed. Construction is cheap, so reloads are inexpensive.
 /// </para>
+/// <para>
+/// <strong>Logging.</strong> The constructors accept an optional <see cref="ILogger" /> (defaulting to
+/// <see cref="NullLogger.Instance" />, so logging is opt-in). When supplied, the service records each rebuild of its
+/// resolution state after observing a reloaded resource at <see cref="LogLevel.Debug" />. This level is fixed.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CapturingLogger.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CapturingLogger.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CapturingLogger.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// A minimal <see cref="ILogger" /> that records the level, event id, and rendered message of every entry, used to
+/// assert that notable-date loading and reloading emit the expected diagnostics.
+/// </summary>
+internal sealed class CapturingLogger
+    : ILogger
+{
+    /// <summary>
+    /// Gets the recorded entries in emission order.
+    /// </summary>
+    public List<(LogLevel Level, EventId EventId, string Message)> Entries { get; } = new();
+
+    /// <inheritdoc />
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull =>
+        NullScope.Instance;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) =>
+        true;
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        Entries.Add((logLevel, eventId, formatter(state, exception)));
+    }
+
+    /// <summary>
+    /// A no-op scope returned by <see cref="BeginScope{TState}(TState)" />.
+    /// </summary>
+    private sealed class NullScope
+        : IDisposable
+    {
+        /// <summary>
+        /// Gets the shared instance.
+        /// </summary>
+        public static NullScope Instance { get; } = new();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/JsonIngestionTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/JsonIngestionTests.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Verifies that <see cref="NotableDateResourceLoader.LoadJson(string)" /> ingests the JSON representation of a
+/// Verifies that <see cref="NotableDateResourceLoader.LoadJson(string, Microsoft.Extensions.Logging.ILogger)" /> ingests the JSON representation of a
 /// notable-date document, producing the same resolution behaviour as the XML form across fixed dates, nth-weekday and
 /// offset strategies, an algorithm, a non-Gregorian calendar, an adjustment policy, and an override.
 /// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateResourceLoaderTests.Logging.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateResourceLoaderTests.Logging.cs
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateResourceLoaderTests.Logging.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies that <see cref="NotableDateResourceLoader" /> emits load and validation diagnostics through a supplied
+/// logger and remains silent when no logger is supplied.
+/// </summary>
+public sealed partial class NotableDateResourceLoaderTests
+{
+    /// <summary>
+    /// A self-contained, valid notable-date document with a single fixed-date concept.
+    /// </summary>
+    private const string ValidLoggingXml = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.log">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <NotableDates>
+        <NotableDate id="x" displayName="X" category="PublicHoliday">
+          <Rules><Rule id="r"><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
+        </NotableDate>
+      </NotableDates>
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// A well-formed document whose import cannot be resolved by the default resolver, producing an error diagnostic.
+    /// </summary>
+    private const string UnresolvableImportXml = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.log.bad">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <Imports><Import resource="missing-resource" /></Imports>
+      <NotableDates>
+        <NotableDate id="x" displayName="X" category="PublicHoliday">
+          <Rules><Rule id="r"><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
+        </NotableDate>
+      </NotableDates>
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Verifies that a successful load emits a debug record reporting the loaded resource.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenLoggerSupplied_ShouldLogResourceLoaded()
+    {
+        CapturingLogger logger = new();
+
+        _ = NotableDateResourceLoader.Load(ValidLoggingXml, logger);
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Debug && e.EventId.Id == 3001));
+    }
+
+    /// <summary>
+    /// Verifies that a validation failure emits a warning record before the loader throws.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenValidationFailsAndLoggerSupplied_ShouldLogWarning()
+    {
+        CapturingLogger logger = new();
+
+        _ = Assert.ThrowsExactly<NotableDateValidationException>(() =>
+        {
+            _ = NotableDateResourceLoader.Load(UnresolvableImportXml, logger);
+        });
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Warning && e.EventId.Id == 3002));
+    }
+
+    /// <summary>
+    /// Verifies that loading without a logger succeeds, confirming the default <c>null</c> logger path is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenNoLoggerSupplied_ShouldLoadWithoutLogging()
+    {
+        NotableDateResource resource = NotableDateResourceLoader.Load(ValidLoggingXml);
+
+        Assert.AreEqual("data.log", resource.ResourceId);
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateResourceLoaderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateResourceLoaderTests.cs
@@ -10,7 +10,7 @@ namespace Bodu.Globalization.Calendar;
 /// Verifies the load and validation pipeline of <see cref="NotableDateResourceLoader" /> against the minimal notable-date document.
 /// </summary>
 [TestClass]
-public sealed class NotableDateResourceLoaderTests
+public sealed partial class NotableDateResourceLoaderTests
 {
     /// <summary>
     /// Verifies that loading the minimal notable-date document validates successfully and reports three notable-date concepts, five

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ReloadableNotableDateServiceTests.Logging.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ReloadableNotableDateServiceTests.Logging.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ReloadableNotableDateServiceTests.Logging.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies that <see cref="MutableNotableDateResourceProvider" /> and <see cref="ReloadableNotableDateService" /> emit
+/// diagnostics through a supplied logger and remain silent when no logger is supplied.
+/// </summary>
+public sealed partial class ReloadableNotableDateServiceTests
+{
+    /// <summary>
+    /// Verifies that reloading the provider with a logger emits an informational reload record.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenLoggerSupplied_ShouldLogReload()
+    {
+        CapturingLogger logger = new();
+        MutableNotableDateResourceProvider provider = new(NotableDateResourceLoader.Load(JanuaryXml), logger);
+
+        provider.Reload(NotableDateResourceLoader.Load(FebruaryXml));
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Information && e.EventId.Id == 3003));
+    }
+
+    /// <summary>
+    /// Verifies that the service logs a resolution-state rebuild the first time it observes a reloaded resource.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_AfterReloadWithLogger_ShouldLogResolutionRebuild()
+    {
+        CapturingLogger logger = new();
+        MutableNotableDateResourceProvider provider = new(NotableDateResourceLoader.Load(JanuaryXml));
+        ReloadableNotableDateService service = new(provider, logger);
+
+        _ = service.Resolve(Year2025, "XX");
+        provider.Reload(NotableDateResourceLoader.Load(FebruaryXml));
+        _ = service.Resolve(Year2025, "XX");
+
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Debug && e.EventId.Id == 3004));
+    }
+
+    /// <summary>
+    /// Verifies that a reloadable service constructed without a logger reflects a reload without throwing, confirming
+    /// the default <c>null</c> logger path is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_AfterReloadWithoutLogger_ShouldReflectReloadWithoutLogging()
+    {
+        MutableNotableDateResourceProvider provider = new(NotableDateResourceLoader.Load(JanuaryXml));
+        ReloadableNotableDateService service = new(provider);
+
+        provider.Reload(NotableDateResourceLoader.Load(FebruaryXml));
+        NotableDate match = service.Resolve(Year2025, "XX").Single(r => r.NotableDateId == "special-day");
+
+        Assert.AreEqual(new DateOnly(2025, 2, 1), match.Date);
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ReloadableNotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ReloadableNotableDateServiceTests.cs
@@ -11,7 +11,7 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="MutableNotableDateResourceProvider" />, including override changes applied by reloading.
 /// </summary>
 [TestClass]
-public sealed class ReloadableNotableDateServiceTests
+public sealed partial class ReloadableNotableDateServiceTests
 {
     /// <summary>
     /// A resource placing the special day on 1 January.


### PR DESCRIPTION
## Summary

Adds **opt-in, source-generated logging** to the I/O- and runtime-heavy *provider* types in the calendar and exchange-rate libraries, so operators get diagnostics (a feed that failed to download, a plugin rejected by trust policy, a cache miss, a resource hot-swap) without any behavioural change when no logger is supplied. Every logger is an **optional constructor/method parameter that defaults to `NullLogger.Instance`**, so existing (non-DI) construction is unchanged and disabled logging is allocation-free.

## Scope

In scope (the providers that do network/file I/O, parsing, trust-gating, caching, or runtime swaps):

- **Calendar** — `NotableDateResourceLoader` (static), `MutableNotableDateResourceProvider`, `ReloadableNotableDateService`
- **Calendar.Plugins** — `NotableDatePluginLoader` (static)
- **Exchange-rate feeds** — `EcbExchangeRateProvider`, `BoeExchangeRateProvider`, `RbaExchangeRateProvider`, `YahooExchangeRateProvider`
- **Exchange-rate caching** — `CachingExchangeRateProviderBase` / `CachingDatedExchangeRateProvider`

Deliberately **out of scope** (pure in-memory / pure-logic types, no logging added): `FixedDatedExchangeRateProvider`, `CompositeDatedExchangeRateProvider`, `DatedExchangeRateProviderAdapter`, the Core `IQuarter`/`IWeekend` definition providers, and the Text configuration providers.

## Design

- **Source-generated `[LoggerMessage]`** — each project has one `internal static partial class Log`; messages are allocation-free and short-circuit when the level is disabled / the logger is `NullLogger`.
- **Levels aligned to ecosystem convention** — verified against `Microsoft.Extensions.Http`, EF Core, `Azure.Core`, `MemoryCache`, CacheManager, and FusionCache:
  - successful external fetch (feed/era/pair *loaded with N observations*) → **Information** (matches HttpClient "end processing", EF "Executed DbCommand")
  - per-observation ingest → **Trace** (matches Azure content logging / CacheManager per-op)
  - per-lookup cache hit/miss → **Trace**; coarser range hit/refetch → **Debug** (matches MemoryCache/CacheManager)
  - download/validation failures and synchronous-network fetch → **Warning**
  - lifecycle (plugin activation, algorithm-registration count, resource reload) → **Information**
- **Per-concern configurable levels (FusionCache-style)** — each exchange-rate options object exposes `*LogLevel` properties whose defaults are the levels above, so consumers re-tune verbosity (or set `LogLevel.None` to suppress) without category-wide filters:
  - feed providers: `DownloadStartingLogLevel`, `DownloadCompletedLogLevel`, `DownloadFailedLogLevel`, `ObservationIngestedLogLevel` (ECB/Yahoo also `SynchronousNetworkFetchLogLevel`)
  - caching: `CacheHitLogLevel`, `CacheMissLogLevel`, `CacheRangeHitLogLevel`, `CacheRangeRefetchLogLevel`
  - the static calendar/plugin loaders have no options object, so their levels are fixed.
- **DI wiring** — each feed/caching/calendar DI registration resolves a category logger via `ILoggerFactory` and passes it through (`AddReloadableNotableDateService` switched to a factory registration so the logger can be resolved).
- **Event IDs** by component: plugins `2xxx`, calendar `3xxx`, exchange-rates `4xxx` (ECB `41xx`, BoE `42xx`, RBA `43xx`, Yahoo `44xx`, caching `45xx`).

## Documentation

- A **`## Logging` section** in each exchange-rate package README: the logger category, the `NullLogger` opt-in default, an event→default-level→option-property table, a configuration example, and verbosity guidance.
- A **"Logging" `<para>`** in each provider's and options class's XML `<remarks>` (and on the static calendar/plugin loaders, noting their fixed levels and the optional `ILogger`).

## Packages

Each affected production project gains a `Microsoft.Extensions.Logging.Abstractions` (8.0.2) reference; the `[LoggerMessage]` generator ships in that package (no extra analyzer).

## Tests

A lightweight `CapturingLogger` test double plus focused BVT logging tests per instrumented type — assert the expected record/level on the key path, confirm the default (no-logger) path is a silent no-op, and verify a configured non-default level is honoured.

## CI note

The one `build-test` red is a **pre-existing flaky concurrency test in `Bodu.Core`** (`CacheEnumerable<T>.MoveNext` race), which this PR does not touch — `Bodu.Core` is unchanged on the branch and the test passes 25/25 locally. It is tracked separately in #475; the re-run should clear the check.

https://claude.ai/code/session_01XUnAgkgF9GNk87nn1E3pzZ