### PR TITLE
Lower AbsoluteMaxDepth from 1024 to 256 and add stack-constrained test

### DIFF
--- a/Bodu.Text.Toml/src/Text.Toml/TomlLimits.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlLimits.cs
@@ -17,11 +17,22 @@ internal static class TomlLimits
     /// configures a larger maximum depth.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A configurable maximum depth only bounds normal use; left unbounded, a caller could set an arbitrarily large
     /// value and a deeply nested document or object graph would recurse until the process terminated with a
     /// <see cref="StackOverflowException" />, which cannot be caught. This ceiling guarantees that excessive nesting
     /// instead fails with a catchable <see cref="TomlFormatException" /> (when reading) or
     /// <see cref="TomlSerializationException" /> (when writing), which is essential when processing untrusted input.
+    /// </para>
+    /// <para>
+    /// The value must stay small enough that the ceiling is reached before the physical call stack is exhausted;
+    /// otherwise the recursive serializer overflows the stack first and the guarantee is lost. The serializer's
+    /// per-level recursion consumes roughly a kilobyte of stack, so a ceiling near a thousand sits at the edge of the
+    /// common 1 MB thread stack (the default on Windows) and overflows before the guard can throw. This value keeps
+    /// the bounded recursion comfortably within a modest stack budget — well under 1 MB — while remaining far deeper
+    /// than any realistic document: it is four times the 64-level serializer default and equal to the 256-level
+    /// ceiling the reader and writer already apply by default.
+    /// </para>
     /// </remarks>
-    internal const int AbsoluteMaxDepth = 1024;
+    internal const int AbsoluteMaxDepth = 256;
 }

--- a/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
@@ -33,6 +33,52 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
+    /// Verifies that serializing an object graph nested beyond the absolute depth ceiling throws a catchable
+    /// <see cref="TomlSerializationException" /> rather than overflowing the call stack, even when serialization runs
+    /// on a thread whose stack is constrained — pinning the requirement that the ceiling stays safe on a modest stack
+    /// budget rather than relying on the larger default stack of any particular platform.
+    /// </summary>
+    /// <remarks>
+    /// The absolute ceiling exists to convert unbounded nesting into a catchable failure. That guarantee only holds
+    /// when the ceiling is reached before the physical call stack is exhausted: a ceiling set above the stack budget
+    /// lets recursion overflow first, terminating the process with an uncatchable <see cref="StackOverflowException" />
+    /// that the default-stack <c>Serialize_WhenGraphExceedsAbsoluteCapDespiteLargeMaxDepth</c> test cannot observe
+    /// where the platform stack is large. Running on an explicit, constrained stack reproduces that condition on any
+    /// platform. The 512 KB budget sits well above what the bounded recursion requires yet well below what an
+    /// unbounded ceiling would consume.
+    /// </remarks>
+    [TestMethod]
+    public void Serialize_WhenGraphExceedsAbsoluteCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+
+        RecursiveModel deep = new();
+        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
+            deep = new RecursiveModel { Child = deep };
+
+        Exception? captured = null;
+        var worker = new Thread(
+            () =>
+            {
+                try
+                {
+                    _ = TomlSerializer.Serialize(deep, options);
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+            },
+            maxStackSize: 512 << 10);
+
+        worker.Start();
+        worker.Join();
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(TomlSerializationException), captured.GetType());
+    }
+
+    /// <summary>
     /// Verifies that a <see cref="TomlSerializerOptions.MaxDepth" /> larger than the absolute ceiling is still accepted
     /// by the property, confirming the ceiling is enforced while parsing or writing rather than at configuration time.
     /// </summary>


### PR DESCRIPTION
## Summary

Reduces the `TomlLimits.AbsoluteMaxDepth` constant from 1024 to 256 to ensure the depth ceiling is reached before the physical call stack is exhausted during serialization. This prevents unbounded recursion from causing an uncatchable `StackOverflowException` and guarantees a catchable `TomlSerializationException` instead.

## Key Changes

- **Lowered `AbsoluteMaxDepth` from 1024 to 256** in `TomlLimits.cs`
  - The per-level recursion in the serializer consumes roughly 1 KB of stack, making 1024 levels unsafe on a typical 1 MB default thread stack
  - 256 levels keeps bounded recursion well under 1 MB while remaining far deeper than any realistic document
  - Aligns with the 256-level ceiling already applied by the reader and writer by default

- **Enhanced documentation** in `TomlLimits.cs`
  - Added detailed remarks explaining why the ceiling must stay small enough to be reached before stack exhaustion
  - Clarified the stack budget implications and the rationale for the specific value

- **Added `Serialize_WhenGraphExceedsAbsoluteCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow` test**
  - New test in `TomlSerializerTests.DepthCap.cs` that verifies the guarantee holds even on a constrained stack
  - Runs serialization on a thread with an explicit 512 KB stack budget to reproduce the condition where unbounded recursion would overflow before the ceiling is reached
  - Confirms that `TomlSerializationException` is thrown rather than `StackOverflowException`
  - Includes comprehensive documentation explaining why this test is necessary and how it validates the platform-independent guarantee

## Implementation Details

The test creates a deeply nested object graph exceeding `AbsoluteMaxDepth + 2` levels and attempts serialization with `MaxDepth = int.MaxValue` on a constrained-stack thread. This ensures the absolute ceiling is enforced before physical stack exhaustion, validating that the constant value is safe across all platforms regardless of default stack size.

https://claude.ai/code/session_01XWARgTp2A1A9rrdo2XY1VR