### PR TITLE
Add Update-CodeStyleAnalyzer.ps1 script for analyzer refresh

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -72,3 +72,22 @@ python3 tools/cipher-vectors/wide_serpent.py
 ```
 
 If the script's output ever diverges from the KAT rows in the test project, either the C# implementation has regressed or this port has, and the discrepancy must be investigated before changing either side.
+
+## CodeStyle analyzer (PowerShell 7+)
+
+| Script | Purpose |
+| --- | --- |
+| `Update-CodeStyleAnalyzer.ps1` | One-command refresh of the in-repo `Bodu.CodeStyle.XmlDocumentation` analyzer: packs it into `local-packages/` (delegating to `bld/pack-codestyle-analyzer.ps1`, which also evicts NuGet's global cache), force-restores a consumer, then builds it so Roslyn loads the new payload. Run it after changing anything under `Bodu.CodeStyle/`. |
+
+```pwsh
+# Repack the analyzer, then force-restore + build the whole solution against it
+pwsh ./tools/Update-CodeStyleAnalyzer.ps1
+
+# Narrow the restore/build target for faster iteration
+pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -Target Bodu.Core/src/Bodu.Core.csproj
+
+# Pack + force-restore only (skip the consumer build)
+pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -SkipBuild
+```
+
+The analyzer is always packed in **Release** (the configuration committed to `local-packages/` and used by CI); `-Configuration` governs only the consumer restore/build. Packing runs under the SDK 8 pin in `Bodu.CodeStyle/global.json` while the consumer build runs under the repo-root SDK 10 pin — each `dotnet` invocation resolves its own SDK from its working directory. After a successful run, commit the regenerated `local-packages/Bodu.CodeStyle.XmlDocumentation.1.0.0.nupkg` alongside your source changes. See `Bodu.CodeStyle/README.md` for the full analyzer-authoring workflow.

--- a/tools/Update-CodeStyleAnalyzer.ps1
+++ b/tools/Update-CodeStyleAnalyzer.ps1
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------------------------------------------
+# Update-CodeStyleAnalyzer.ps1
+#
+# Single-command refresh of the in-repo Bodu.CodeStyle.XmlDocumentation analyzer. Wraps the three steps you would
+# otherwise run by hand after changing anything under Bodu.CodeStyle/:
+#
+#   1. Pack the analyzer into ./local-packages and evict NuGet's global cache for it
+#      (delegated to bld/pack-codestyle-analyzer.ps1 — the same pack the bash + cmd entry points call).
+#   2. Force-restore a consumer (solution or project) so it re-extracts the freshly-packed 1.0.0 payload.
+#   3. Build the consumer so Roslyn loads the new analyzer and reports against your source.
+#
+# The analyzer is always packed in Release (that is the configuration committed to local-packages/ and used by
+# CI); -Configuration governs only the consumer restore/build. The pack runs under the SDK 8 pin in
+# Bodu.CodeStyle/global.json, while the consumer build runs under the repo-root SDK 10 pin — each dotnet
+# invocation resolves its own SDK from its working directory, so the two never collide.
+#
+# Examples:
+#   pwsh ./tools/Update-CodeStyleAnalyzer.ps1
+#   pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -Target Bodu.Core/src/Bodu.Core.csproj
+#   pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -SkipBuild
+# ---------------------------------------------------------------------------------------------------------------
+
+[CmdletBinding()]
+param(
+    # Solution or project to force-restore (and build) against the freshly-packed analyzer. Resolved relative to
+    # the repository root; defaults to the full solution so every consumer picks up the new payload.
+    [string] $Target = 'bodu.slnx',
+
+    # Configuration used for the consumer restore/build. Does not affect the analyzer pack, which is always Release.
+    [string] $Configuration = 'Release',
+
+    # Pack and force-restore only; skip the consumer build. Useful for a fast refresh while iterating.
+    [switch] $SkipBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repoRoot = Split-Path -Parent $scriptDir
+$packScript = Join-Path (Join-Path $repoRoot 'bld') 'pack-codestyle-analyzer.ps1'
+
+if (-not (Test-Path $packScript)) {
+    throw "Pack script not found at '$packScript'. Run this from a full repository checkout."
+}
+
+# 1. Pack the analyzer into local-packages/ and evict the NuGet global cache. The pack script throws on a pack
+#    failure, so a terminating error here propagates straight out; wrap it only to add call-site context.
+Write-Host '==> [1/3] Packing Bodu.CodeStyle.XmlDocumentation into local-packages/ ...' -ForegroundColor Cyan
+try {
+    & $packScript
+}
+catch {
+    throw "Packing the analyzer failed: $($_.Exception.Message)"
+}
+
+# Run the consumer steps from the repository root so the root global.json (SDK 10) governs them, independent of
+# the SDK 8 pin used while packing.
+Push-Location $repoRoot
+try {
+    # 2. Force-restore: the analyzer version is pinned at 1.0.0, and step 1 deleted its global-cache entry, so a
+    #    plain restore could reuse stale metadata. --force re-extracts the new payload.
+    Write-Host "==> [2/3] Restoring '$Target' (--force) ..." -ForegroundColor Cyan
+    dotnet restore $Target --force
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet restore '$Target' failed with exit code $LASTEXITCODE."
+    }
+
+    # 3. Build so Roslyn loads the new analyzer. --no-restore avoids a redundant restore after step 2.
+    if ($SkipBuild) {
+        Write-Host '==> [3/3] Skipping build (-SkipBuild).' -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "==> [3/3] Building '$Target' ($Configuration) ..." -ForegroundColor Cyan
+        dotnet build $Target --configuration $Configuration --no-restore
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet build '$Target' failed with exit code $LASTEXITCODE."
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host ''
+Write-Host 'Done. Bodu.CodeStyle.XmlDocumentation was repacked into local-packages/ and the target restored' -ForegroundColor Green
+Write-Host 'against it. Commit local-packages/Bodu.CodeStyle.XmlDocumentation.1.0.0.nupkg alongside your' -ForegroundColor Green
+Write-Host 'Bodu.CodeStyle/ source changes so a fresh clone restores the same analyzer.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

Adds a new PowerShell script (`Update-CodeStyleAnalyzer.ps1`) that streamlines the workflow for refreshing the in-repo `Bodu.CodeStyle.XmlDocumentation` analyzer during development. This script automates the three-step process of packing the analyzer, force-restoring a consumer project/solution, and rebuilding it so Roslyn loads the updated payload.

## Key Changes

- **New script**: `tools/Update-CodeStyleAnalyzer.ps1`
  - Wraps the existing `bld/pack-codestyle-analyzer.ps1` packing step
  - Performs a force-restore (`dotnet restore --force`) to re-extract the freshly-packed analyzer from `local-packages/`
  - Builds the consumer project/solution (`dotnet build`) so Roslyn loads the new analyzer
  - Supports `-Target` parameter to narrow the restore/build scope (defaults to `bodu.slnx`)
  - Supports `-Configuration` parameter for consumer build configuration (defaults to Release)
  - Supports `-SkipBuild` flag to pack and restore only, skipping the build step for faster iteration
  - Properly manages SDK versions: packing runs under SDK 8 (via `Bodu.CodeStyle/global.json`), consumer steps run under SDK 10 (via repo-root `global.json`)

- **Updated documentation**: `tools/README.md`
  - Added new "CodeStyle analyzer" section documenting the script's purpose and usage
  - Included three usage examples covering common workflows
  - Clarified the Release-only packing behavior and SDK version management
  - Noted the requirement to commit the regenerated `.nupkg` alongside source changes

## Implementation Details

The script uses `Push-Location`/`Pop-Location` to ensure consumer steps run from the repository root (so the correct SDK is resolved), while the pack script runs from its own directory. Error handling wraps both the pack and build steps with contextual error messages. The script enforces strict mode and stops on any error to fail fast during development iteration.

https://claude.ai/code/session_013RJ2nqqchqqTgybQVw3C57