### PR TITLE
Exclude benchmark projects from the Update-CodeStyleAnalyzer solution refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ artifacts/
 # so a fresh clone resolves it without an explicit pack step.
 !/local-packages/*.nupkg
 
+# Transient solution filter written by tools/Update-CodeStyleAnalyzer.ps1 when it excludes
+# benchmark projects; normally deleted at the end of the run, ignored in case a run is interrupted.
+_codestyle-refresh.slnf
+
 **/[Pp]ackages/*
 !**/[Pp]ackages/build/
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -80,7 +80,7 @@ If the script's output ever diverges from the KAT rows in the test project, eith
 | `Update-CodeStyleAnalyzer.ps1` | One-command refresh of the in-repo `Bodu.CodeStyle.XmlDocumentation` analyzer: packs it into `local-packages/` (delegating to `bld/pack-codestyle-analyzer.ps1`, which also evicts NuGet's global cache), force-restores a consumer, then builds it so Roslyn loads the new payload. Run it after changing anything under `Bodu.CodeStyle/`. |
 
 ```pwsh
-# Repack the analyzer, then force-restore + build the whole solution against it
+# Repack the analyzer, then force-restore + build the solution against it (benchmarks excluded)
 pwsh ./tools/Update-CodeStyleAnalyzer.ps1
 
 # Narrow the restore/build target for faster iteration
@@ -88,6 +88,11 @@ pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -Target Bodu.Core/src/Bodu.Core.csproj
 
 # Pack + force-restore only (skip the consumer build)
 pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -SkipBuild
+
+# Include benchmark projects too (no exclusions)
+pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -ExcludeProjectPattern @()
 ```
+
+When the target is a solution, the script drops projects that don't exercise the XML-documentation analyzer — by default any `/bench/` project — by generating a temporary solution filter (`.slnf`) listing only the kept projects and restoring/building that. `-ExcludeProjectPattern` takes one or more regexes tested against each project path; pass `@()` to build the whole solution unfiltered, or add patterns to skip more. The parameter is ignored when `-Target` is a single project.
 
 The analyzer is always packed in **Release** (the configuration committed to `local-packages/` and used by CI); `-Configuration` governs only the consumer restore/build. Packing runs under the SDK 8 pin in `Bodu.CodeStyle/global.json` while the consumer build runs under the repo-root SDK 10 pin — each `dotnet` invocation resolves its own SDK from its working directory. After a successful run, commit the regenerated `local-packages/Bodu.CodeStyle.XmlDocumentation.1.0.0.nupkg` alongside your source changes. See `Bodu.CodeStyle/README.md` for the full analyzer-authoring workflow.

--- a/tools/Update-CodeStyleAnalyzer.ps1
+++ b/tools/Update-CodeStyleAnalyzer.ps1
@@ -9,6 +9,10 @@
 #   2. Force-restore a consumer (solution or project) so it re-extracts the freshly-packed 1.0.0 payload.
 #   3. Build the consumer so Roslyn loads the new analyzer and reports against your source.
 #
+# When the target is a solution, benchmark projects (and anything else matching -ExcludeProjectPattern) are
+# dropped via a temporary solution filter (.slnf): they do not exercise the XML-documentation analyzer and only
+# slow the refresh. Pass -ExcludeProjectPattern @() to restore/build the whole solution unfiltered.
+#
 # The analyzer is always packed in Release (that is the configuration committed to local-packages/ and used by
 # CI); -Configuration governs only the consumer restore/build. The pack runs under the SDK 8 pin in
 # Bodu.CodeStyle/global.json, while the consumer build runs under the repo-root SDK 10 pin — each dotnet
@@ -18,6 +22,7 @@
 #   pwsh ./tools/Update-CodeStyleAnalyzer.ps1
 #   pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -Target Bodu.Core/src/Bodu.Core.csproj
 #   pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -SkipBuild
+#   pwsh ./tools/Update-CodeStyleAnalyzer.ps1 -ExcludeProjectPattern @()        # build everything, benchmarks included
 # ---------------------------------------------------------------------------------------------------------------
 
 [CmdletBinding()]
@@ -28,6 +33,11 @@ param(
 
     # Configuration used for the consumer restore/build. Does not affect the analyzer pack, which is always Release.
     [string] $Configuration = 'Release',
+
+    # Regex patterns tested against each project path when the target is a solution; matches are excluded from the
+    # restore/build via a temporary solution filter. Defaults to benchmark projects (any '/bench/' path segment).
+    # Ignored when the target is a single project. Pass @() to disable filtering.
+    [string[]] $ExcludeProjectPattern = @('[\\/]bench[\\/]'),
 
     # Pack and force-restore only; skip the consumer build. Useful for a fast refresh while iterating.
     [switch] $SkipBuild
@@ -58,23 +68,82 @@ catch {
 # the SDK 8 pin used while packing.
 Push-Location $repoRoot
 try {
-    # 2. Force-restore: the analyzer version is pinned at 1.0.0, and step 1 deleted its global-cache entry, so a
-    #    plain restore could reuse stale metadata. --force re-extracts the new payload.
-    Write-Host "==> [2/3] Restoring '$Target' (--force) ..." -ForegroundColor Cyan
-    dotnet restore $Target --force
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet restore '$Target' failed with exit code $LASTEXITCODE."
+    $resolvedTarget = (Resolve-Path -LiteralPath $Target -ErrorAction Stop).Path
+    $isSolution = $resolvedTarget -match '\.slnx?$'
+    $effectiveTarget = $resolvedTarget
+    $tempFilter = $null
+
+    # When targeting a solution, drop excluded projects (benchmarks by default) by generating a temporary solution
+    # filter alongside the solution. A .slnf restores/builds only the listed projects, so the analyzer refresh
+    # skips harnesses that never run it. Single-project targets need no filtering.
+    if ($isSolution -and $ExcludeProjectPattern -and @($ExcludeProjectPattern).Count -gt 0) {
+        $listOutput = dotnet sln $resolvedTarget list
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet sln '$Target' list failed with exit code $LASTEXITCODE."
+        }
+
+        $allProjects = @($listOutput | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '\.(cs|vb|fs)proj$' })
+        $kept = [System.Collections.Generic.List[string]]::new()
+        $excluded = [System.Collections.Generic.List[string]]::new()
+
+        foreach ($project in $allProjects) {
+            $isExcluded = $false
+            foreach ($pattern in $ExcludeProjectPattern) {
+                if ($project -match $pattern) {
+                    $isExcluded = $true
+                    break
+                }
+            }
+
+            if ($isExcluded) { $excluded.Add($project) } else { $kept.Add($project) }
+        }
+
+        if ($kept.Count -eq 0) {
+            throw "Every project in '$Target' matched -ExcludeProjectPattern; nothing left to restore or build."
+        }
+
+        if ($excluded.Count -gt 0) {
+            $solutionDir = Split-Path -Parent $resolvedTarget
+            $solutionLeaf = Split-Path -Leaf $resolvedTarget
+            $tempFilter = Join-Path $solutionDir '_codestyle-refresh.slnf'
+
+            $filter = [ordered]@{
+                solution = [ordered]@{
+                    path     = $solutionLeaf
+                    projects = @($kept)
+                }
+            }
+            $filter | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $tempFilter -Encoding utf8
+            $effectiveTarget = $tempFilter
+
+            Write-Host ("    Excluding {0} benchmark/excluded project(s); restoring + building {1} of {2} projects via a solution filter." -f $excluded.Count, $kept.Count, $allProjects.Count) -ForegroundColor DarkGray
+        }
     }
 
-    # 3. Build so Roslyn loads the new analyzer. --no-restore avoids a redundant restore after step 2.
-    if ($SkipBuild) {
-        Write-Host '==> [3/3] Skipping build (-SkipBuild).' -ForegroundColor Yellow
-    }
-    else {
-        Write-Host "==> [3/3] Building '$Target' ($Configuration) ..." -ForegroundColor Cyan
-        dotnet build $Target --configuration $Configuration --no-restore
+    try {
+        # 2. Force-restore: the analyzer version is pinned at 1.0.0, and step 1 deleted its global-cache entry, so a
+        #    plain restore could reuse stale metadata. --force re-extracts the new payload.
+        Write-Host "==> [2/3] Restoring '$Target' (--force) ..." -ForegroundColor Cyan
+        dotnet restore $effectiveTarget --force
         if ($LASTEXITCODE -ne 0) {
-            throw "dotnet build '$Target' failed with exit code $LASTEXITCODE."
+            throw "dotnet restore '$Target' failed with exit code $LASTEXITCODE."
+        }
+
+        # 3. Build so Roslyn loads the new analyzer. --no-restore avoids a redundant restore after step 2.
+        if ($SkipBuild) {
+            Write-Host '==> [3/3] Skipping build (-SkipBuild).' -ForegroundColor Yellow
+        }
+        else {
+            Write-Host "==> [3/3] Building '$Target' ($Configuration) ..." -ForegroundColor Cyan
+            dotnet build $effectiveTarget --configuration $Configuration --no-restore
+            if ($LASTEXITCODE -ne 0) {
+                throw "dotnet build '$Target' failed with exit code $LASTEXITCODE."
+            }
+        }
+    }
+    finally {
+        if ($tempFilter -and (Test-Path -LiteralPath $tempFilter)) {
+            Remove-Item -LiteralPath $tempFilter -Force
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #479. When `tools/Update-CodeStyleAnalyzer.ps1` refreshes the analyzer against a **solution**, it now skips projects that don't exercise the XML-documentation analyzer — benchmark harnesses by default — so the refresh doesn't waste time building them.

## What changed

- **New `-ExcludeProjectPattern` parameter** (`string[]` of regexes, default `@('[\\/]bench[\\/]')`), tested against each project path.
- For a **solution** target, the script enumerates projects via `dotnet sln list`, drops matches, writes a temporary **`.slnf` solution filter** listing only the kept projects, and restores/builds that. `dotnet` has no per-project exclude flag for a solution build, so a solution filter is the SDK-native way to build a subset.
- The temp filter (`_codestyle-refresh.slnf`) is deleted in a `finally`, and gitignored as a backstop against an interrupted run.
- **Single-project targets** (`-Target …csproj`) are unaffected — no filtering.
- **Escape hatch**: `-ExcludeProjectPattern @()` builds the whole solution, benchmarks included.
- `tools/README.md` updated with new examples and parameter docs.

## Why benchmarks only

The analyzer applies to test projects too (they carry XML-doc summaries), so those stay in the refresh — only benchmark projects are excluded by default. The pattern is configurable if more should be skipped later.

## Verification

- `dotnet sln list` and `.slnf` solution filters both confirmed working against the `.slnx` solution format.
- The default pattern matches exactly the 6 benchmark projects in `bodu.slnx`, with zero false positives (75 → 69 projects).
- A generated filter restored green (exit 0) with no `/bench/` project present.

https://claude.ai/code/session_013RJ2nqqchqqTgybQVw3C57

---
_Generated by [Claude Code](https://claude.ai/code/session_013RJ2nqqchqqTgybQVw3C57)_