### PR TITLE
Enforce hard absolute nesting ceiling across serializers and parsers

### DIFF
--- a/Bodu.Text.Bencode/src/Text.Bencode.Document/BencodeDocument.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Document/BencodeDocument.cs
@@ -109,7 +109,9 @@ public sealed partial class BencodeDocument
     /// Thrown when the bytes are not a single, canonical Bencode value, or nest deeper than the configured maximum.
     /// </exception>
     /// <remarks>
-    /// A <see cref="BencodeDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="BencodeDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="BencodeLimits.AbsoluteMaxDepth" />; a document nested deeper than the
+    /// effective limit throws <see cref="BencodeFormatException" />.
     /// </remarks>
     public static BencodeDocument Parse(ReadOnlySpan<byte> data, BencodeDocumentOptions options) =>
         Parse(data, ToReaderOptions(options));
@@ -127,7 +129,9 @@ public sealed partial class BencodeDocument
     /// Thrown when the bytes are not a single, canonical Bencode value, or nest deeper than the configured maximum.
     /// </exception>
     /// <remarks>
-    /// A <see cref="BencodeDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="BencodeDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="BencodeLimits.AbsoluteMaxDepth" />; a document nested deeper than the
+    /// effective limit throws <see cref="BencodeFormatException" />.
     /// </remarks>
     public static BencodeDocument Parse(byte[] data, BencodeDocumentOptions options)
     {

--- a/Bodu.Text.Bencode/src/Text.Bencode.Document/BencodeDocumentOptions.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Document/BencodeDocumentOptions.cs
@@ -19,8 +19,13 @@ public struct BencodeDocumentOptions
     /// <summary>
     /// Gets or sets the maximum container nesting depth the parser will accept.
     /// </summary>
-    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 256.</value>
-    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 256.</returns>
+    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 64.</value>
+    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 64.</returns>
+    /// <remarks>
+    /// The effective depth is clamped to the hard ceiling <see cref="BencodeLimits.AbsoluteMaxDepth" />; a document
+    /// nested past the effective limit throws <see cref="BencodeFormatException" /> rather than risking a
+    /// <see cref="StackOverflowException" />.
+    /// </remarks>
     public int MaxDepth { get; set; }
 
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Reader/BencodeReaderOptions.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Reader/BencodeReaderOptions.cs
@@ -19,8 +19,13 @@ public struct BencodeReaderOptions
     /// <summary>
     /// Gets or sets the maximum container nesting depth the reader will accept.
     /// </summary>
-    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 256.</value>
-    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 256.</returns>
+    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 64.</value>
+    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 64.</returns>
+    /// <remarks>
+    /// The effective depth is clamped to the hard ceiling <see cref="BencodeLimits.AbsoluteMaxDepth" />; a document
+    /// nested past the effective limit throws <see cref="BencodeFormatException" /> rather than risking a
+    /// <see cref="StackOverflowException" />.
+    /// </remarks>
     public int MaxDepth { get; set; }
 
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Reader/Utf8BencodeReader.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Reader/Utf8BencodeReader.cs
@@ -111,12 +111,16 @@ public ref struct Utf8BencodeReader
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="maxDepth" /> is not positive.
     /// </exception>
-    public Utf8BencodeReader(ReadOnlySpan<byte> data, int maxDepth = 256)
+    /// <remarks>
+    /// The value is clamped to <see cref="BencodeLimits.AbsoluteMaxDepth" /> so that an unbounded configured value
+    /// cannot drive the reader into a <see cref="StackOverflowException" /> on a deeply nested document.
+    /// </remarks>
+    public Utf8BencodeReader(ReadOnlySpan<byte> data, int maxDepth = BencodeLimits.AbsoluteMaxDepth)
     {
         ThrowHelper.ThrowIfLessThanOrEqual(maxDepth, 0);
 
         _data = data;
-        _maxDepth = maxDepth;
+        _maxDepth = Math.Min(maxDepth, BencodeLimits.AbsoluteMaxDepth);
         _frames = [];
         _position = 0;
         _tokenType = BencodeTokenType.None;
@@ -129,10 +133,12 @@ public ref struct Utf8BencodeReader
     /// <param name="data">The Bencode source bytes.</param>
     /// <param name="options">The reader options controlling the maximum nesting depth and key leniency.</param>
     /// <remarks>
-    /// A <see cref="BencodeReaderOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="BencodeReaderOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="BencodeLimits.AbsoluteMaxDepth" />; a document nested deeper than the
+    /// effective limit throws <see cref="BencodeFormatException" />.
     /// </remarks>
     public Utf8BencodeReader(ReadOnlySpan<byte> data, BencodeReaderOptions options)
-        : this(data, options.MaxDepth <= 0 ? 256 : options.MaxDepth)
+        : this(data, options.MaxDepth <= 0 ? BencodeLimits.AbsoluteMaxDepth : options.MaxDepth)
     {
         _allowUnsortedKeys = options.AllowUnsortedKeys;
         _allowDuplicateKeys = options.AllowDuplicateKeys;

--- a/Bodu.Text.Bencode/src/Text.Bencode.Writer/BencodeWriterOptions.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Writer/BencodeWriterOptions.cs
@@ -18,8 +18,13 @@ public struct BencodeWriterOptions
     /// <summary>
     /// Gets or sets the maximum container nesting depth the writer will permit.
     /// </summary>
-    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 256.</value>
-    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 256.</returns>
+    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 64.</value>
+    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 64.</returns>
+    /// <remarks>
+    /// The effective depth is clamped to the hard ceiling <see cref="BencodeLimits.AbsoluteMaxDepth" />; a larger value
+    /// has no effect beyond it. Opening a list or dictionary nested past the effective limit throws
+    /// <see cref="BencodeSerializationException" /> rather than risking a <see cref="StackOverflowException" />.
+    /// </remarks>
     public int MaxDepth { get; set; }
 
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Writer/Utf8BencodeWriter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Writer/Utf8BencodeWriter.cs
@@ -85,7 +85,7 @@ public ref struct Utf8BencodeWriter
 
         _output = output;
         _frames = [];
-        _maxDepth = 256;
+        _maxDepth = BencodeLimits.AbsoluteMaxDepth;
         _allowMultipleRootValues = false;
         _root = new RootState();
     }
@@ -99,7 +99,10 @@ public ref struct Utf8BencodeWriter
     /// Thrown when <paramref name="output" /> is <see langword="null" />.
     /// </exception>
     /// <remarks>
-    /// A <see cref="BencodeWriterOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="BencodeWriterOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="BencodeLimits.AbsoluteMaxDepth" /> so that an unbounded configured value
+    /// cannot drive the writer into a <see cref="StackOverflowException" />. Opening a list or dictionary past that
+    /// depth throws <see cref="BencodeSerializationException" />.
     /// </remarks>
     public Utf8BencodeWriter(IBufferWriter<byte> output, BencodeWriterOptions options)
     {
@@ -107,7 +110,7 @@ public ref struct Utf8BencodeWriter
 
         _output = output;
         _frames = [];
-        _maxDepth = options.MaxDepth <= 0 ? 256 : options.MaxDepth;
+        _maxDepth = options.MaxDepth <= 0 ? BencodeLimits.AbsoluteMaxDepth : Math.Min(options.MaxDepth, BencodeLimits.AbsoluteMaxDepth);
         _allowMultipleRootValues = options.AllowMultipleRootValues;
         _root = new RootState();
     }

--- a/Bodu.Text.Bencode/src/Text.Bencode/BencodeLimits.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode/BencodeLimits.cs
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BencodeLimits.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Bencode;
+
+/// <summary>
+/// Defines hard, non-configurable limits that bound resource use while parsing and writing Bencode, independent of any
+/// caller-supplied option.
+/// </summary>
+internal static class BencodeLimits
+{
+    /// <summary>
+    /// The absolute maximum container nesting depth enforced while parsing or writing, applied even when a caller
+    /// configures a larger maximum depth.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A configurable maximum depth only bounds normal use; left unbounded, a caller could set an arbitrarily large
+    /// value and a deeply nested document or object graph would recurse until the process terminated with a
+    /// <see cref="StackOverflowException" />, which cannot be caught. Every caller-supplied maximum depth is therefore
+    /// clamped to this ceiling, so excessive nesting fails with a catchable <see cref="BencodeFormatException" /> (when
+    /// reading) or <see cref="BencodeSerializationException" /> (when writing) — essential when processing untrusted
+    /// input.
+    /// </para>
+    /// <para>
+    /// The serializer descends one native call-stack frame per nested container, so the ceiling must be reached before
+    /// the physical stack is exhausted; otherwise the recursion overflows first and the guarantee is lost. The value
+    /// therefore matches the <see cref="BencodeSerializerOptions.DefaultMaxDepth" /> of 64 — deep enough for any
+    /// realistic document, yet shallow enough that the bounded recursion stays well within a modest stack budget even
+    /// when much of the stack was already consumed before the call (for example under a deep asynchronous call chain).
+    /// Supporting depths beyond this safely would require replacing the recursive descent with an explicit stack-based
+    /// traversal; until then a low ceiling is the deliberate trade-off.
+    /// </para>
+    /// </remarks>
+    internal const int AbsoluteMaxDepth = BencodeSerializerOptions.DefaultMaxDepth;
+}

--- a/Bodu.Text.Bencode/src/Text.Bencode/BencodeSerializerOptions.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode/BencodeSerializerOptions.cs
@@ -352,15 +352,26 @@ public sealed class BencodeSerializerOptions
     }
 
     /// <summary>
-    /// Gets or sets the maximum nesting depth permitted while serializing or deserializing.
+    /// Gets or sets the maximum container nesting depth permitted while serializing or deserializing.
     /// </summary>
     /// <value>The maximum depth; <see cref="DefaultMaxDepth" /> when set to zero.</value>
     /// <returns>The configured maximum depth.</returns>
     /// <remarks>
-    /// The default of <see cref="DefaultMaxDepth" /> (64) is deliberately tighter than the default of 256 used by
-    /// <see cref="Reader.Utf8BencodeReader" />, <see cref="Writer.Utf8BencodeWriter" />, and
-    /// <see cref="Document.BencodeDocument" />: the serializer is the typical entry point for untrusted input, while
-    /// the lower-level surfaces favour permissiveness for callers that manage their own limits.
+    /// <para>
+    /// The limit bounds how deeply lists and dictionaries may nest. It is reached when serializing an object graph — or
+    /// deserializing a document — whose containers nest more levels deep than the effective limit, for example a chain
+    /// of objects each holding the next, a dictionary of dictionaries, or lists within lists. Crossing it is reported
+    /// as a catchable failure: <see cref="BencodeSerializationException" /> while serializing, or
+    /// <see cref="BencodeFormatException" /> while deserializing.
+    /// </para>
+    /// <para>
+    /// Although any non-negative value is accepted here, the <em>effective</em> limit is clamped to the hard ceiling,
+    /// <see cref="BencodeLimits.AbsoluteMaxDepth" /> (64); setting a larger value — even <see cref="int.MaxValue" /> —
+    /// does not raise it. The ceiling exists because the serializer recurses one call-stack frame per nested container,
+    /// so an unbounded depth on hostile or malformed input would exhaust the call stack and terminate the process with
+    /// an uncatchable <see cref="StackOverflowException" />. Clamping converts that into the catchable exceptions
+    /// above.
+    /// </para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the options are read-only.</exception>

--- a/Bodu.Text.Bencode/test/Text.Bencode/BencodeDocumentTests.Parse.cs
+++ b/Bodu.Text.Bencode/test/Text.Bencode/BencodeDocumentTests.Parse.cs
@@ -151,15 +151,16 @@ public partial class BencodeDocumentTests
     }
 
     /// <summary>
-    /// Verifies that a document nested deeper than the default maximum depth of 256 throws
+    /// Verifies that a document nested deeper than the default maximum depth throws
     /// <see cref="BencodeFormatException" />, and that nesting exactly to the default is accepted.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
     public void Parse_WhenNestingExceedsDefaultMaxDepth_ShouldThrowBencodeFormatException()
     {
-        var atLimit = Bytes(new string('l', 256) + new string('e', 256));
-        var beyondLimit = Bytes(new string('l', 257) + new string('e', 257));
+        var atDepth = BencodeLimits.AbsoluteMaxDepth;
+        var atLimit = Bytes(new string('l', atDepth) + new string('e', atDepth));
+        var beyondLimit = Bytes(new string('l', atDepth + 1) + new string('e', atDepth + 1));
 
         using var document = BencodeDocument.Parse(atLimit);
         Assert.AreEqual(BencodeValueKind.Array, document.RootElement.ValueKind);

--- a/Bodu.Text.Bencode/test/Text.Bencode/BencodeSerializerTests.MaxDepth.cs
+++ b/Bodu.Text.Bencode/test/Text.Bencode/BencodeSerializerTests.MaxDepth.cs
@@ -34,6 +34,63 @@ public partial class BencodeSerializerTests
     }
 
     /// <summary>
+    /// Verifies that serializing an object graph nested beyond the absolute ceiling throws
+    /// <see cref="BencodeSerializationException" /> even when the configured maximum depth is far larger, confirming the
+    /// caller-supplied <see cref="BencodeSerializerOptions.MaxDepth" /> is clamped to the hard ceiling.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenGraphExceedsAbsoluteCapDespiteLargeMaxDepth_ShouldThrowBencodeSerializationException()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+
+        var deep = new RecursiveModel();
+        for (var i = 0; i < BencodeLimits.AbsoluteMaxDepth + 1; i++)
+            deep = new RecursiveModel { Child = deep };
+
+        Assert.ThrowsExactly<BencodeSerializationException>(() =>
+        {
+            _ = BencodeSerializer.Serialize(deep, options);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that serializing a graph nested far beyond the ceiling throws a catchable
+    /// <see cref="BencodeSerializationException" /> rather than overflowing the call stack, even on a thread whose stack
+    /// is deliberately constrained — pinning the requirement that the ceiling stays reachable before the physical stack
+    /// is exhausted on a modest stack budget.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenGraphFarExceedsCapOnConstrainedStack_ShouldThrowBencodeSerializationExceptionNotOverflow()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+
+        var deep = new RecursiveModel();
+        for (var i = 0; i < (BencodeLimits.AbsoluteMaxDepth * 32) + 1; i++)
+            deep = new RecursiveModel { Child = deep };
+
+        Exception? captured = null;
+        var worker = new Thread(
+            () =>
+            {
+                try
+                {
+                    _ = BencodeSerializer.Serialize(deep, options);
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+            },
+            maxStackSize: 256 << 10);
+
+        worker.Start();
+        worker.Join();
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(BencodeSerializationException), captured.GetType());
+    }
+
+    /// <summary>
     /// Verifies that serializing a POCO graph nested no deeper than <see cref="BencodeSerializerOptions.MaxDepth" />
     /// succeeds and emits canonical bytes.
     /// </summary>

--- a/Bodu.Text.Bencode/test/Text.Bencode/Utf8BencodeWriterTests.PropertyValuePairs.cs
+++ b/Bodu.Text.Bencode/test/Text.Bencode/Utf8BencodeWriterTests.PropertyValuePairs.cs
@@ -139,7 +139,7 @@ public partial class Utf8BencodeWriterTests
         var buffer = new ArrayBufferWriter<byte>();
 
         var defaulted = new Utf8BencodeWriter(buffer);
-        Assert.AreEqual(256, defaulted.Options.MaxDepth);
+        Assert.AreEqual(BencodeLimits.AbsoluteMaxDepth, defaulted.Options.MaxDepth);
         Assert.IsFalse(defaulted.Options.AllowMultipleRootValues);
 
         var configured = new Utf8BencodeWriter(buffer, new BencodeWriterOptions { MaxDepth = 8, AllowMultipleRootValues = true });

--- a/Bodu.Text.Toml/src/Text.Toml.Document/TomlDocument.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Document/TomlDocument.cs
@@ -18,16 +18,16 @@ namespace Bodu.Text.Toml.Document;
 /// <remarks>
 /// <para>
 /// A <see cref="TomlDocument" /> holds the flat row store produced directly by the structural parser, so parsing
-/// materializes neither an intermediate node tree nor a token list. Value-type scalars are decoded into the row, while a
-/// string scalar is decoded on demand from the UTF-8 source the document retains, so a string is materialized only when
-/// read. Every <see cref="TomlElement" />, enumerator, and <see cref="TomlProperty" /> obtained from a document is valid
-/// only until the document is disposed.
+/// materializes neither an intermediate node tree nor a token list. Value-type scalars are decoded into the row, while
+/// a string scalar is decoded on demand from the UTF-8 source the document retains, so a string is materialized only
+/// when read. Every <see cref="TomlElement" />, enumerator, and <see cref="TomlProperty" /> obtained from a document is
+/// valid only until the document is disposed.
 /// </para>
 /// <para>
 /// Call <see cref="Dispose" /> when finished to invalidate the document and the <see cref="TomlElement" /> views taken
 /// from it; after disposal, any operation on such an element throws <see cref="ObjectDisposedException" />. A parsed
-/// document rents its retained source from the shared array pool, so disposal returns that buffer as well as dropping the
-/// row store; neglecting to dispose leaks the buffer back to the garbage collector rather than the pool.
+/// document rents its retained source from the shared array pool, so disposal returns that buffer as well as dropping
+/// the row store; neglecting to dispose leaks the buffer back to the garbage collector rather than the pool.
 /// </para>
 /// <para>
 /// The root value of a TOML document is always a table, so for a document produced by <see cref="Parse(string)" /> or
@@ -52,9 +52,10 @@ public sealed partial class TomlDocument
     : IDisposable
 {
     /// <summary>
-    /// The default maximum container nesting depth applied when the configured depth is zero or less.
+    /// The default maximum container nesting depth applied when the configured depth is zero or less. It equals
+    /// <see cref="TomlLimits.AbsoluteMaxDepth" />, the hard ceiling any larger configured depth is clamped to.
     /// </summary>
-    private const int DefaultMaxDepth = 256;
+    private const int DefaultMaxDepth = TomlLimits.AbsoluteMaxDepth;
 
     /// <summary>
     /// The UTF-8 encoding used to encode the <see cref="string" /> overload of <see cref="Parse(string)" />; invalid
@@ -136,11 +137,13 @@ public sealed partial class TomlDocument
     /// Thrown when the bytes are not a valid TOML document, or nest deeper than the configured maximum.
     /// </exception>
     /// <remarks>
-    /// A <see cref="TomlDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="TomlDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="TomlLimits.AbsoluteMaxDepth" />; a document nested deeper than the
+    /// effective limit throws <see cref="TomlFormatException" />.
     /// </remarks>
     public static TomlDocument Parse(ReadOnlySpan<byte> utf8Toml, TomlDocumentOptions options)
     {
-        var maxDepth = options.MaxDepth <= 0 ? DefaultMaxDepth : options.MaxDepth;
+        var maxDepth = options.MaxDepth <= 0 ? DefaultMaxDepth : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
 
         // Retain a copy of the source so string scalars can be decoded on demand; rent it so the retention costs no
         // managed allocation across repeated parses, and return it on disposal.
@@ -194,7 +197,7 @@ public sealed partial class TomlDocument
     /// </exception>
     /// <remarks>
     /// The text is encoded to UTF-8 and parsed by <see cref="Parse(ReadOnlySpan{byte}, TomlDocumentOptions)" />. A
-    /// <see cref="TomlDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// <see cref="TomlDocumentOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64.
     /// </remarks>
     public static TomlDocument Parse(string toml, TomlDocumentOptions options)
     {
@@ -229,8 +232,8 @@ public sealed partial class TomlDocument
     /// </summary>
     /// <remarks>
     /// Disposal is idempotent: calling it more than once has no further effect. A parsed document returns its pooled
-    /// source buffer to the shared array pool; a subtree view shares a garbage-collected copy and returns nothing. After
-    /// disposal, every element, enumerator, and property obtained from the document throws
+    /// source buffer to the shared array pool; a subtree view shares a garbage-collected copy and returns nothing.
+    /// After disposal, every element, enumerator, and property obtained from the document throws
     /// <see cref="ObjectDisposedException" />.
     /// </remarks>
     public void Dispose()

--- a/Bodu.Text.Toml/src/Text.Toml.Document/TomlDocumentOptions.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Document/TomlDocumentOptions.cs
@@ -17,7 +17,9 @@ namespace Bodu.Text.Toml.Document;
 /// </para>
 /// <para>
 /// <see cref="MaxDepth" /> bounds the nesting of tables and arrays the parser will materialize, guarding against
-/// stack-exhausting input. A value of <c>0</c> selects the default of 256.
+/// stack-exhausting input. A value of <c>0</c> selects the default of 64, and a larger value is clamped to the hard
+/// ceiling <see cref="TomlLimits.AbsoluteMaxDepth" />; a document that nests deeper than the effective limit throws
+/// <see cref="TomlFormatException" /> rather than risking a <see cref="StackOverflowException" />.
 /// </para>
 /// </remarks>
 public struct TomlDocumentOptions
@@ -34,7 +36,10 @@ public struct TomlDocumentOptions
     /// <summary>
     /// Gets or sets the maximum nesting depth of tables and arrays the parser will accept.
     /// </summary>
-    /// <value>The maximum nesting depth; <c>0</c> selects the default of 256.</value>
-    /// <returns>The maximum nesting depth, where <c>0</c> selects the default of 256.</returns>
+    /// <value>
+    /// The maximum nesting depth; <c>0</c> selects the default of 64, clamped to
+    /// <see cref="TomlLimits.AbsoluteMaxDepth" />.
+    /// </value>
+    /// <returns>The maximum nesting depth, where <c>0</c> selects the default of 64.</returns>
     public int MaxDepth { get; set; }
 }

--- a/Bodu.Text.Toml/src/Text.Toml.Reader/TomlDocumentReader.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Reader/TomlDocumentReader.cs
@@ -54,16 +54,16 @@ public ref struct TomlDocumentReader
     private readonly List<TomlReaderRow> _rows;
 
     /// <summary>
-    /// The UTF-8 source bytes, retained so a string value can be decoded on demand and a token's byte offset mapped to a
-    /// line and column on a binding failure. Held as a span because the reader is a <see langword="ref struct" /> scoped
-    /// to a single read.
+    /// The UTF-8 source bytes, retained so a string value can be decoded on demand and a token's byte offset mapped to
+    /// a line and column on a binding failure. Held as a span because the reader is a <see langword="ref struct" />
+    /// scoped to a single read.
     /// </summary>
     private readonly ReadOnlySpan<byte> _source;
 
     /// <summary>
     /// A lazily created garbage-collected copy of <see cref="_source" />, materialized on the first
-    /// <see cref="GetOwnedSource" /> so that subtree documents from <c>TomlDocument.ParseValue</c> can retain the source
-    /// the reader holds only as a span. Every such document from one read shares this single copy.
+    /// <see cref="GetOwnedSource" /> so that subtree documents from <c>TomlDocument.ParseValue</c> can retain the
+    /// source the reader holds only as a span. Every such document from one read shares this single copy.
     /// </summary>
     private byte[]? _ownedSource;
 
@@ -127,11 +127,14 @@ public ref struct TomlDocumentReader
     /// </param>
     /// <exception cref="TomlFormatException">Thrown when the bytes are not a valid TOML document.</exception>
     /// <remarks>
-    /// A <see cref="TomlReaderOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="TomlReaderOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="TomlLimits.AbsoluteMaxDepth" /> so that an unbounded configured value
+    /// cannot drive the parser into a <see cref="StackOverflowException" />; a document nested deeper than the
+    /// effective limit throws <see cref="TomlFormatException" />.
     /// </remarks>
     public TomlDocumentReader(ReadOnlySpan<byte> utf8Toml, TomlReaderOptions options)
     {
-        var maxDepth = options.MaxDepth <= 0 ? 256 : options.MaxDepth;
+        var maxDepth = options.MaxDepth <= 0 ? TomlLimits.AbsoluteMaxDepth : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
 
         _rows = new TomlDocumentBuilder(options.SpecVersion, maxDepth).Parse(utf8Toml);
         _source = utf8Toml;

--- a/Bodu.Text.Toml/src/Text.Toml.Reader/TomlReaderOptions.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Reader/TomlReaderOptions.cs
@@ -17,7 +17,9 @@ namespace Bodu.Text.Toml.Reader;
 /// </para>
 /// <para>
 /// <see cref="MaxDepth" /> bounds the nesting of tables and arrays the reader will materialize, guarding against
-/// stack-exhausting input. A value of <c>0</c> selects the default of 256.
+/// stack-exhausting input. A value of <c>0</c> selects the default of 64, and a larger value is clamped to the hard
+/// ceiling <see cref="TomlLimits.AbsoluteMaxDepth" />; a document that nests deeper than the effective limit throws
+/// <see cref="TomlFormatException" /> rather than risking a <see cref="StackOverflowException" />.
 /// </para>
 /// </remarks>
 public struct TomlReaderOptions
@@ -34,7 +36,10 @@ public struct TomlReaderOptions
     /// <summary>
     /// Gets or sets the maximum nesting depth of tables and arrays the reader will accept.
     /// </summary>
-    /// <value>The maximum nesting depth; <c>0</c> selects the default of 256.</value>
-    /// <returns>The maximum nesting depth, where <c>0</c> selects the default of 256.</returns>
+    /// <value>
+    /// The maximum nesting depth; <c>0</c> selects the default of 64, clamped to
+    /// <see cref="TomlLimits.AbsoluteMaxDepth" />.
+    /// </value>
+    /// <returns>The maximum nesting depth, where <c>0</c> selects the default of 64.</returns>
     public int MaxDepth { get; set; }
 }

--- a/Bodu.Text.Toml/src/Text.Toml.Reader/Utf8TomlReader.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Reader/Utf8TomlReader.cs
@@ -232,7 +232,9 @@ public ref partial struct Utf8TomlReader
     /// The reader options controlling the specification version and maximum bracket nesting depth.
     /// </param>
     /// <remarks>
-    /// A <see cref="TomlReaderOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256.
+    /// A <see cref="TomlReaderOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
+    /// larger value is clamped to <see cref="TomlLimits.AbsoluteMaxDepth" />; input nested deeper than the effective
+    /// limit throws <see cref="TomlFormatException" />.
     /// </remarks>
     public Utf8TomlReader(ReadOnlySpan<byte> utf8Toml, TomlReaderOptions options)
         : this(utf8Toml, isFinalBlock: true, new TomlReaderState(options))
@@ -276,7 +278,7 @@ public ref partial struct Utf8TomlReader
         _source = utf8Toml;
         _isFinalBlock = isFinalBlock;
         _specVersion = state.Options.SpecVersion;
-        _maxDepth = state.Options.MaxDepth <= 0 ? 256 : state.Options.MaxDepth;
+        _maxDepth = state.Options.MaxDepth <= 0 ? TomlLimits.AbsoluteMaxDepth : Math.Min(state.Options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
         _state = state.ScanState;
         _containers = state.Containers;
         _containerCount = state.ContainerCount;
@@ -424,9 +426,12 @@ public ref partial struct Utf8TomlReader
     public readonly ReadOnlySpan<byte> ValueSpan => _source.Slice(_valueStart, _valueLength);
 
     /// <summary>
-    /// Gets the byte offset into the source at which the current token's raw text content begins, inside any delimiters.
+    /// Gets the byte offset into the source at which the current token's raw text content begins, inside any
+    /// delimiters.
     /// </summary>
-    /// <returns>The content start offset, paired with <see cref="ValueLength" /> to slice the source on demand.</returns>
+    /// <returns>
+    /// The content start offset, paired with <see cref="ValueLength" /> to slice the source on demand.
+    /// </returns>
     internal readonly int ValueStart => _valueStart;
 
     /// <summary>
@@ -1269,8 +1274,8 @@ public ref partial struct Utf8TomlReader
     /// and rejecting disallowed control characters.
     /// </summary>
     /// <remarks>
-    /// Both TOML v1.0.0 and v1.1.0 prohibit control characters other than tab (U+0000–U+0008, U+000A–U+001F,
-    /// U+007F) inside a comment, so the rule is applied unconditionally.
+    /// Both TOML v1.0.0 and v1.1.0 prohibit control characters other than tab (U+0000–U+0008, U+000A–U+001F, U+007F)
+    /// inside a comment, so the rule is applied unconditionally.
     /// </remarks>
     /// <returns>
     /// <see langword="true" /> when the comment was scanned; <see langword="false" /> when more data is required.

--- a/Bodu.Text.Toml/src/Text.Toml.Writer/TomlWriterOptions.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Writer/TomlWriterOptions.cs
@@ -19,7 +19,10 @@ namespace Bodu.Text.Toml.Writer;
 /// </para>
 /// <para>
 /// The writer always emits text that is valid under both TOML v1.0.0 and v1.1.0, so <see cref="SpecVersion" /> has no
-/// effect on output today; <see cref="MaxDepth" /> bounds container nesting.
+/// effect on output today; <see cref="MaxDepth" /> bounds container nesting, guarding against stack-exhausting graphs.
+/// A value of <c>0</c> selects the default of 64, and a larger value is clamped to the hard ceiling
+/// <see cref="TomlLimits.AbsoluteMaxDepth" />; opening a table or array deeper than the effective limit throws
+/// <see cref="TomlSerializationException" /> rather than risking a <see cref="StackOverflowException" />.
 /// </para>
 /// </remarks>
 public struct TomlWriterOptions
@@ -39,7 +42,10 @@ public struct TomlWriterOptions
     /// <summary>
     /// Gets or sets the maximum container nesting depth the writer will permit.
     /// </summary>
-    /// <value>The maximum container nesting depth; <c>0</c> selects the default of 256.</value>
-    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 256.</returns>
+    /// <value>
+    /// The maximum container nesting depth; <c>0</c> selects the default of 64, clamped to
+    /// <see cref="TomlLimits.AbsoluteMaxDepth" />.
+    /// </value>
+    /// <returns>The maximum container nesting depth, where <c>0</c> selects the default of 64.</returns>
     public int MaxDepth { get; set; }
 }

--- a/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.Streaming.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.Streaming.cs
@@ -52,7 +52,7 @@ public ref partial struct Utf8TomlWriter
         _output = _streamBuffer;
         _frames = [];
         _root = new TomlWriterNode?[1];
-        _maxDepth = options.MaxDepth <= 0 ? 256 : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
+        _maxDepth = options.MaxDepth <= 0 ? TomlLimits.AbsoluteMaxDepth : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
         _byteCounts = new long[2];
         _references = new HashSet<object>(ReferenceEqualityComparer.Instance);
     }

--- a/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.cs
@@ -6,6 +6,7 @@
 
 using System.Buffers;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace Bodu.Text.Toml.Writer;
 
@@ -180,7 +181,8 @@ public ref partial struct Utf8TomlWriter
     /// Writes the start of a table.
     /// </summary>
     /// <exception cref="TomlSerializationException">
-    /// Thrown when opening the table would exceed the configured maximum nesting depth.
+    /// Thrown when opening the table would exceed the configured maximum nesting depth, or when too little call stack
+    /// remains to safely descend a further nesting level.
     /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the document is already complete, or when the enclosing container is a table with no pending
@@ -190,6 +192,7 @@ public ref partial struct Utf8TomlWriter
     {
         ThrowIfComplete();
         ThrowIfValueNeedsPropertyName();
+        ThrowIfInsufficientStack();
         if (_frames.Count >= _maxDepth)
             throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, _maxDepth));
 
@@ -224,7 +227,8 @@ public ref partial struct Utf8TomlWriter
     /// Writes the start of an array.
     /// </summary>
     /// <exception cref="TomlSerializationException">
-    /// Thrown when opening the array would exceed the configured maximum nesting depth.
+    /// Thrown when opening the array would exceed the configured maximum nesting depth, or when too little call stack
+    /// remains to safely descend a further nesting level.
     /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the document is already complete, when the array would become the document root (the root of a TOML
@@ -236,6 +240,7 @@ public ref partial struct Utf8TomlWriter
         if (_frames.Count == 0)
             throw new InvalidOperationException(TomlResourceStrings.Op_Invalid_WriterRootMustBeTable);
         ThrowIfValueNeedsPropertyName();
+        ThrowIfInsufficientStack();
         if (_frames.Count >= _maxDepth)
             throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, _maxDepth));
 
@@ -376,6 +381,27 @@ public ref partial struct Utf8TomlWriter
     {
         if (_frames.Count > 0 && _frames[^1] is TableFrame { PendingKey: null })
             throw new InvalidOperationException(TomlResourceStrings.Op_Invalid_WriterValueWithoutKey);
+    }
+
+    /// <summary>
+    /// Throws when too little call stack remains to safely open another container, converting an otherwise
+    /// process-terminating <see cref="StackOverflowException" /> into a catchable failure.
+    /// </summary>
+    /// <exception cref="TomlSerializationException">
+    /// Thrown when insufficient execution stack remains to descend a further nesting level.
+    /// </exception>
+    /// <remarks>
+    /// The serializer descends one native call-stack frame per nested container, so an object graph nested deeply enough
+    /// would exhaust the stack and terminate the process with an uncatchable <see cref="StackOverflowException" />. The
+    /// configured maximum depth bounds nesting logically, but the stack already consumed before a write call varies with
+    /// the surrounding context, so the same logical depth can leave very different amounts of stack and the logical bound
+    /// alone cannot guarantee the ceiling is reached before the physical stack is exhausted. Probing the actual remaining
+    /// stack closes that gap independently of platform, thread stack size, and call context.
+    /// </remarks>
+    private static void ThrowIfInsufficientStack()
+    {
+        if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            throw new TomlSerializationException(TomlResourceStrings.Op_Invalid_WriterStackTooDeep);
     }
 
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.cs
@@ -6,14 +6,13 @@
 
 using System.Buffers;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 
 namespace Bodu.Text.Toml.Writer;
 
 /// <summary>
-/// Provides an append-only writer that emits normalized TOML bytes to an <see cref="IBufferWriter{T}" />. Because TOML's
-/// surface layout is a whole-document property, the writer is not progressive: it buffers every value into an in-memory
-/// tree and serializes it when the root table is closed.
+/// Provides an append-only writer that emits normalized TOML bytes to an <see cref="IBufferWriter{T}" />. Because
+/// TOML's surface layout is a whole-document property, the writer is not progressive: it buffers every value into an
+/// in-memory tree and serializes it when the root table is closed.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -127,7 +126,7 @@ public ref partial struct Utf8TomlWriter
         _output = output;
         _frames = [];
         _root = new TomlWriterNode?[1];
-        _maxDepth = 256;
+        _maxDepth = TomlLimits.AbsoluteMaxDepth;
         _byteCounts = new long[2];
         _references = new HashSet<object>(ReferenceEqualityComparer.Instance);
     }
@@ -143,9 +142,10 @@ public ref partial struct Utf8TomlWriter
     /// Thrown when <paramref name="output" /> is <see langword="null" />.
     /// </exception>
     /// <remarks>
-    /// A <see cref="TomlWriterOptions.MaxDepth" /> of zero or less selects the default maximum depth of 256, and a
+    /// A <see cref="TomlWriterOptions.MaxDepth" /> of zero or less selects the default maximum depth of 64, and a
     /// larger value is clamped to <see cref="TomlLimits.AbsoluteMaxDepth" /> so that an unbounded configured value
-    /// cannot drive the writer into a <see cref="StackOverflowException" />.
+    /// cannot drive the writer into a <see cref="StackOverflowException" />. Opening a container past that depth — a
+    /// table or array nested deeper than the effective limit — throws <see cref="TomlSerializationException" />.
     /// </remarks>
     public Utf8TomlWriter(IBufferWriter<byte> output, TomlWriterOptions options)
     {
@@ -154,7 +154,7 @@ public ref partial struct Utf8TomlWriter
         _output = output;
         _frames = [];
         _root = new TomlWriterNode?[1];
-        _maxDepth = options.MaxDepth <= 0 ? 256 : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
+        _maxDepth = options.MaxDepth <= 0 ? TomlLimits.AbsoluteMaxDepth : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
         _byteCounts = new long[2];
         _references = new HashSet<object>(ReferenceEqualityComparer.Instance);
     }
@@ -181,8 +181,7 @@ public ref partial struct Utf8TomlWriter
     /// Writes the start of a table.
     /// </summary>
     /// <exception cref="TomlSerializationException">
-    /// Thrown when opening the table would exceed the configured maximum nesting depth, or when too little call stack
-    /// remains to safely descend a further nesting level.
+    /// Thrown when opening the table would exceed the effective maximum nesting depth.
     /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the document is already complete, or when the enclosing container is a table with no pending
@@ -192,7 +191,6 @@ public ref partial struct Utf8TomlWriter
     {
         ThrowIfComplete();
         ThrowIfValueNeedsPropertyName();
-        ThrowIfInsufficientStack();
         if (_frames.Count >= _maxDepth)
             throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, _maxDepth));
 
@@ -227,8 +225,7 @@ public ref partial struct Utf8TomlWriter
     /// Writes the start of an array.
     /// </summary>
     /// <exception cref="TomlSerializationException">
-    /// Thrown when opening the array would exceed the configured maximum nesting depth, or when too little call stack
-    /// remains to safely descend a further nesting level.
+    /// Thrown when opening the array would exceed the effective maximum nesting depth.
     /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the document is already complete, when the array would become the document root (the root of a TOML
@@ -240,7 +237,6 @@ public ref partial struct Utf8TomlWriter
         if (_frames.Count == 0)
             throw new InvalidOperationException(TomlResourceStrings.Op_Invalid_WriterRootMustBeTable);
         ThrowIfValueNeedsPropertyName();
-        ThrowIfInsufficientStack();
         if (_frames.Count >= _maxDepth)
             throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, _maxDepth));
 
@@ -381,27 +377,6 @@ public ref partial struct Utf8TomlWriter
     {
         if (_frames.Count > 0 && _frames[^1] is TableFrame { PendingKey: null })
             throw new InvalidOperationException(TomlResourceStrings.Op_Invalid_WriterValueWithoutKey);
-    }
-
-    /// <summary>
-    /// Throws when too little call stack remains to safely open another container, converting an otherwise
-    /// process-terminating <see cref="StackOverflowException" /> into a catchable failure.
-    /// </summary>
-    /// <exception cref="TomlSerializationException">
-    /// Thrown when insufficient execution stack remains to descend a further nesting level.
-    /// </exception>
-    /// <remarks>
-    /// The serializer descends one native call-stack frame per nested container, so an object graph nested deeply enough
-    /// would exhaust the stack and terminate the process with an uncatchable <see cref="StackOverflowException" />. The
-    /// configured maximum depth bounds nesting logically, but the stack already consumed before a write call varies with
-    /// the surrounding context, so the same logical depth can leave very different amounts of stack and the logical bound
-    /// alone cannot guarantee the ceiling is reached before the physical stack is exhausted. Probing the actual remaining
-    /// stack closes that gap independently of platform, thread stack size, and call context.
-    /// </remarks>
-    private static void ThrowIfInsufficientStack()
-    {
-        if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
-            throw new TomlSerializationException(TomlResourceStrings.Op_Invalid_WriterStackTooDeep);
     }
 
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml/TomlLimits.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlLimits.cs
@@ -20,18 +20,19 @@ internal static class TomlLimits
     /// <para>
     /// A configurable maximum depth only bounds normal use; left unbounded, a caller could set an arbitrarily large
     /// value and a deeply nested document or object graph would recurse until the process terminated with a
-    /// <see cref="StackOverflowException" />, which cannot be caught. This ceiling guarantees that excessive nesting
-    /// instead fails with a catchable <see cref="TomlFormatException" /> (when reading) or
+    /// <see cref="StackOverflowException" />, which cannot be caught. This ceiling caps the configured depth so excessive
+    /// nesting fails with a catchable <see cref="TomlFormatException" /> (when reading) or
     /// <see cref="TomlSerializationException" /> (when writing), which is essential when processing untrusted input.
     /// </para>
     /// <para>
-    /// The value must stay small enough that the ceiling is reached before the physical call stack is exhausted;
-    /// otherwise the recursive serializer overflows the stack first and the guarantee is lost. The serializer's
-    /// per-level recursion consumes roughly a kilobyte of stack, so a ceiling near a thousand sits at the edge of the
-    /// common 1 MB thread stack (the default on Windows) and overflows before the guard can throw. This value keeps
-    /// the bounded recursion comfortably within a modest stack budget — well under 1 MB — while remaining far deeper
-    /// than any realistic document: it is four times the 64-level serializer default and equal to the 256-level
-    /// ceiling the reader and writer already apply by default.
+    /// This constant is a <em>logical</em> bound only; it is not what guarantees the process survives. The amount of
+    /// stack already consumed before serialization begins varies with the call context, so no fixed level count can be
+    /// chosen that is always reached before the physical stack is exhausted — a depth that is safe on a fresh thread can
+    /// overflow under a deep asynchronous call chain. The physical guarantee instead comes from probing the actual
+    /// remaining call stack on each descent (see the writer's stack guard), which converts impending exhaustion into a
+    /// catchable exception regardless of platform, thread stack size, or call context. This value sits far deeper than
+    /// any realistic document — four times the 64-level serializer default, and equal to the 256-level ceiling the reader
+    /// and writer apply by default — so it bounds pathological configured depths without constraining legitimate use.
     /// </para>
     /// </remarks>
     internal const int AbsoluteMaxDepth = 256;

--- a/Bodu.Text.Toml/src/Text.Toml/TomlLimits.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlLimits.cs
@@ -20,20 +20,20 @@ internal static class TomlLimits
     /// <para>
     /// A configurable maximum depth only bounds normal use; left unbounded, a caller could set an arbitrarily large
     /// value and a deeply nested document or object graph would recurse until the process terminated with a
-    /// <see cref="StackOverflowException" />, which cannot be caught. This ceiling caps the configured depth so excessive
-    /// nesting fails with a catchable <see cref="TomlFormatException" /> (when reading) or
-    /// <see cref="TomlSerializationException" /> (when writing), which is essential when processing untrusted input.
+    /// <see cref="StackOverflowException" />, which cannot be caught. Every caller-supplied maximum depth is therefore
+    /// clamped to this ceiling, so excessive nesting fails with a catchable <see cref="TomlFormatException" /> (when
+    /// reading) or <see cref="TomlSerializationException" /> (when writing) — essential when processing untrusted
+    /// input.
     /// </para>
     /// <para>
-    /// This constant is a <em>logical</em> bound only; it is not what guarantees the process survives. The amount of
-    /// stack already consumed before serialization begins varies with the call context, so no fixed level count can be
-    /// chosen that is always reached before the physical stack is exhausted — a depth that is safe on a fresh thread can
-    /// overflow under a deep asynchronous call chain. The physical guarantee instead comes from probing the actual
-    /// remaining call stack on each descent (see the writer's stack guard), which converts impending exhaustion into a
-    /// catchable exception regardless of platform, thread stack size, or call context. This value sits far deeper than
-    /// any realistic document — four times the 64-level serializer default, and equal to the 256-level ceiling the reader
-    /// and writer apply by default — so it bounds pathological configured depths without constraining legitimate use.
+    /// The reader, writer, and serializer descend one native call-stack frame per nested container, so the ceiling must
+    /// be reached before the physical stack is exhausted; otherwise the recursion overflows first and the guarantee is
+    /// lost. The value therefore matches the <see cref="TomlSerializerOptions.DefaultMaxDepth" /> of 64 — deep enough
+    /// for any realistic document, yet shallow enough that the bounded recursion stays well within a modest stack
+    /// budget even when much of the stack was already consumed before the call (for example under a deep asynchronous
+    /// call chain). Supporting depths beyond this safely would require replacing the recursive descent with an explicit
+    /// stack-based traversal; until then a low ceiling is the deliberate trade-off.
     /// </para>
     /// </remarks>
-    internal const int AbsoluteMaxDepth = 256;
+    internal const int AbsoluteMaxDepth = TomlSerializerOptions.DefaultMaxDepth;
 }

--- a/Bodu.Text.Toml/src/Text.Toml/TomlSerializerOptions.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlSerializerOptions.cs
@@ -47,7 +47,10 @@ namespace Bodu.Text.Toml;
 public sealed partial class TomlSerializerOptions
 {
     /// <summary>
-    /// The default maximum nesting depth.
+    /// The default maximum container nesting depth applied when <see cref="MaxDepth" /> is left at zero. It is also the
+    /// library's hard ceiling (<see cref="TomlLimits.AbsoluteMaxDepth" />): a configured depth is never effective
+    /// beyond this value, because the recursive reader, writer, and serializer must stay within a safe call-stack
+    /// budget.
     /// </summary>
     public const int DefaultMaxDepth = 64;
 
@@ -310,12 +313,32 @@ public sealed partial class TomlSerializerOptions
     }
 
     /// <summary>
-    /// Gets or sets the maximum nesting depth permitted while serializing or deserializing.
+    /// Gets or sets the maximum container nesting depth permitted while serializing or deserializing.
     /// </summary>
     /// <value>The maximum depth; <see cref="DefaultMaxDepth" /> when set to zero.</value>
     /// <returns>The configured maximum depth.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the options are read-only.</exception>
+    /// <remarks>
+    /// <para>
+    /// The limit bounds how deeply tables and arrays may nest. It is reached when serializing an object graph — or
+    /// deserializing a document — whose containers nest more levels deep than the effective limit, for example a chain
+    /// of objects each holding the next, a dictionary of dictionaries, or arrays within arrays. Crossing it is reported
+    /// as a catchable failure: <see cref="TomlSerializationException" /> while serializing, or
+    /// <see cref="TomlFormatException" /> while deserializing. A reference cycle (an object reachable from itself) is a
+    /// distinct condition reported separately as a <see cref="TomlSerializationException" /> identifying the cycle, not
+    /// as a depth-limit failure.
+    /// </para>
+    /// <para>
+    /// Although any non-negative value is accepted here, the <em>effective</em> limit is clamped to the library's hard
+    /// ceiling, <see cref="TomlLimits.AbsoluteMaxDepth" /> (64); setting a larger value — even
+    /// <see cref="int.MaxValue" /> — does not raise it. The ceiling exists because the serializer and parser recurse
+    /// one call-stack frame per nested container, so an unbounded depth on hostile or malformed input would exhaust the
+    /// call stack and terminate the process with an uncatchable <see cref="StackOverflowException" />. Clamping
+    /// converts that into the catchable exceptions above. Lowering this value below the default tightens the limit;
+    /// raising it has no effect beyond the ceiling.
+    /// </para>
+    /// </remarks>
     public int MaxDepth
     {
         get => _maxDepth;

--- a/Bodu.Text.Toml/src/TomlResourceStrings.Designer.cs
+++ b/Bodu.Text.Toml/src/TomlResourceStrings.Designer.cs
@@ -308,15 +308,6 @@ namespace Bodu {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The object graph is nested too deeply to serialize without exhausting the call stack..
-        /// </summary>
-        internal static string Op_Invalid_WriterStackTooDeep {
-            get {
-                return ResourceManager.GetString("Op_Invalid_WriterStackTooDeep", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to The key '{0}' has already been written to the current table..
         /// </summary>
         internal static string Op_Invalid_WriterDuplicateKey {

--- a/Bodu.Text.Toml/src/TomlResourceStrings.Designer.cs
+++ b/Bodu.Text.Toml/src/TomlResourceStrings.Designer.cs
@@ -308,6 +308,15 @@ namespace Bodu {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The object graph is nested too deeply to serialize without exhausting the call stack..
+        /// </summary>
+        internal static string Op_Invalid_WriterStackTooDeep {
+            get {
+                return ResourceManager.GetString("Op_Invalid_WriterStackTooDeep", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The key '{0}' has already been written to the current table..
         /// </summary>
         internal static string Op_Invalid_WriterDuplicateKey {

--- a/Bodu.Text.Toml/src/TomlResourceStrings.resx
+++ b/Bodu.Text.Toml/src/TomlResourceStrings.resx
@@ -46,6 +46,7 @@
   <data name="Format_Invalid_TomlUnterminatedString" xml:space="preserve"><value>The string is not terminated.</value></data>
   <data name="Format_Invalid_TomlUnterminatedTable" xml:space="preserve"><value>The table header is not terminated.</value></data>
   <data name="Op_Invalid_WriterMaxDepthExceeded" xml:space="preserve"><value>The maximum write depth of {0} has been exceeded.</value></data>
+  <data name="Op_Invalid_WriterStackTooDeep" xml:space="preserve"><value>The object graph is nested too deeply to serialize without exhausting the call stack.</value></data>
   <data name="Op_Invalid_WriterDuplicateKey" xml:space="preserve"><value>The key '{0}' has already been written to the current table.</value></data>
   <data name="Op_Invalid_WriterValueWithoutKey" xml:space="preserve"><value>A value cannot be written to a table before a property name is written.</value></data>
   <data name="Op_Invalid_WriterPropertyNameOutsideTable" xml:space="preserve"><value>A property name can only be written when the current container is a table.</value></data>

--- a/Bodu.Text.Toml/src/TomlResourceStrings.resx
+++ b/Bodu.Text.Toml/src/TomlResourceStrings.resx
@@ -46,7 +46,6 @@
   <data name="Format_Invalid_TomlUnterminatedString" xml:space="preserve"><value>The string is not terminated.</value></data>
   <data name="Format_Invalid_TomlUnterminatedTable" xml:space="preserve"><value>The table header is not terminated.</value></data>
   <data name="Op_Invalid_WriterMaxDepthExceeded" xml:space="preserve"><value>The maximum write depth of {0} has been exceeded.</value></data>
-  <data name="Op_Invalid_WriterStackTooDeep" xml:space="preserve"><value>The object graph is nested too deeply to serialize without exhausting the call stack.</value></data>
   <data name="Op_Invalid_WriterDuplicateKey" xml:space="preserve"><value>The key '{0}' has already been written to the current table.</value></data>
   <data name="Op_Invalid_WriterValueWithoutKey" xml:space="preserve"><value>A value cannot be written to a table before a property name is written.</value></data>
   <data name="Op_Invalid_WriterPropertyNameOutsideTable" xml:space="preserve"><value>A property name can only be written when the current container is a table.</value></data>

--- a/Bodu.Text.Toml/test/Text.Toml/TomlDocumentTests.Parse.cs
+++ b/Bodu.Text.Toml/test/Text.Toml/TomlDocumentTests.Parse.cs
@@ -197,13 +197,14 @@ public partial class TomlDocumentTests
     }
 
     /// <summary>
-    /// Verifies that inline arrays nested exactly to the default maximum depth of 256 are accepted.
+    /// Verifies that inline arrays nested exactly to the default maximum depth are accepted.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
     public void Parse_WhenNestingAtDefaultMaxDepth_ShouldParseDocument()
     {
-        var atLimit = "a = " + new string('[', 256) + "1" + new string(']', 256) + "\n";
+        var depth = TomlLimits.AbsoluteMaxDepth;
+        var atLimit = "a = " + new string('[', depth) + "1" + new string(']', depth) + "\n";
 
         using var document = TomlDocument.Parse(atLimit);
 
@@ -211,14 +212,15 @@ public partial class TomlDocumentTests
     }
 
     /// <summary>
-    /// Verifies that inline arrays nested one level beyond the default maximum depth of 256 throw
+    /// Verifies that inline arrays nested one level beyond the default maximum depth throw
     /// <see cref="TomlFormatException" />.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
     public void Parse_WhenNestingExceedsDefaultMaxDepth_ShouldThrowTomlFormatException()
     {
-        var beyondLimit = "a = " + new string('[', 257) + "1" + new string(']', 257) + "\n";
+        var depth = TomlLimits.AbsoluteMaxDepth + 1;
+        var beyondLimit = "a = " + new string('[', depth) + "1" + new string(']', depth) + "\n";
 
         _ = Assert.ThrowsExactly<TomlFormatException>(() =>
         {

--- a/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
@@ -96,6 +96,57 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
+    /// Verifies that serializing dictionaries nested beyond the ceiling throws
+    /// <see cref="TomlSerializationException" />, confirming the depth guard covers the dictionary converter path and not
+    /// only object property chains.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenNestedDictionariesExceedCap_ShouldThrowTomlSerializationException()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+
+        var root = new Dictionary<string, object>();
+        var current = root;
+        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
+        {
+            var next = new Dictionary<string, object>();
+            current["child"] = next;
+            current = next;
+        }
+
+        Assert.ThrowsExactly<TomlSerializationException>(() =>
+        {
+            _ = TomlSerializer.Serialize(root, options);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that serializing arrays nested beyond the ceiling throws <see cref="TomlSerializationException" />,
+    /// confirming the depth guard covers the collection converter path and not only object property chains.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenNestedArraysExceedCap_ShouldThrowTomlSerializationException()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+
+        var inner = new List<object>();
+        var current = inner;
+        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
+        {
+            var next = new List<object>();
+            current.Add(next);
+            current = next;
+        }
+
+        var root = new Dictionary<string, object> { ["values"] = inner };
+
+        Assert.ThrowsExactly<TomlSerializationException>(() =>
+        {
+            _ = TomlSerializer.Serialize(root, options);
+        });
+    }
+
+    /// <summary>
     /// Verifies that a <see cref="TomlSerializerOptions.MaxDepth" /> larger than the absolute ceiling is still accepted
     /// by the property, confirming the ceiling is enforced while parsing or writing rather than at configuration time.
     /// </summary>

--- a/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
@@ -7,15 +7,16 @@
 namespace Bodu.Text.Toml;
 
 /// <summary>
-/// Verifies that the serializer enforces an absolute nesting ceiling that bounds resource use even when the caller
-/// configures an arbitrarily large <see cref="TomlSerializerOptions.MaxDepth" />, so untrusted input cannot drive the
-/// writer into a process-terminating <see cref="StackOverflowException" />.
+/// Verifies that the serializer and parser enforce the hard absolute nesting ceiling that bounds call-stack use even
+/// when the caller configures an arbitrarily large <see cref="TomlSerializerOptions.MaxDepth" />, so untrusted input
+/// cannot drive either into a process-terminating <see cref="StackOverflowException" />.
 /// </summary>
 public partial class TomlSerializerTests
 {
     /// <summary>
-    /// Verifies that serializing an object graph nested beyond the absolute depth ceiling throws
-    /// <see cref="TomlSerializationException" /> even when the configured maximum depth is far larger.
+    /// Verifies that serializing an object graph nested beyond the absolute ceiling throws
+    /// <see cref="TomlSerializationException" /> even when the configured maximum depth is far larger, confirming the
+    /// caller-supplied <see cref="TomlSerializerOptions.MaxDepth" /> is clamped to the hard ceiling.
     /// </summary>
     [TestMethod]
     public void Serialize_WhenGraphExceedsAbsoluteCapDespiteLargeMaxDepth_ShouldThrowTomlSerializationException()
@@ -23,7 +24,7 @@ public partial class TomlSerializerTests
         var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
 
         RecursiveModel deep = new();
-        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
+        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 1; i++)
             deep = new RecursiveModel { Child = deep };
 
         Assert.ThrowsExactly<TomlSerializationException>(() =>
@@ -33,72 +34,43 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
-    /// Verifies that serializing an object graph nested beyond the absolute depth ceiling throws a catchable
-    /// <see cref="TomlSerializationException" /> rather than overflowing the call stack, even when serialization runs
-    /// on a thread whose stack is constrained — pinning the requirement that the ceiling stays safe on a modest stack
-    /// budget rather than relying on the larger default stack of any particular platform.
+    /// Verifies that deserializing a document nested beyond the absolute ceiling throws <see cref="TomlFormatException" />
+    /// even when the configured maximum depth is far larger, confirming the reader clamps the caller-supplied
+    /// <see cref="TomlSerializerOptions.MaxDepth" /> to the hard ceiling.
     /// </summary>
-    /// <remarks>
-    /// The absolute ceiling exists to convert unbounded nesting into a catchable failure. That guarantee only holds
-    /// when the ceiling is reached before the physical call stack is exhausted: a ceiling set above the stack budget
-    /// lets recursion overflow first, terminating the process with an uncatchable <see cref="StackOverflowException" />
-    /// that the default-stack <c>Serialize_WhenGraphExceedsAbsoluteCapDespiteLargeMaxDepth</c> test cannot observe
-    /// where the platform stack is large. Running on an explicit, constrained stack reproduces that condition on any
-    /// platform. The 512 KB budget sits well above what the bounded recursion requires yet well below what an
-    /// unbounded ceiling would consume.
-    /// </remarks>
     [TestMethod]
-    public void Serialize_WhenGraphExceedsAbsoluteCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow()
+    public void Deserialize_WhenDocumentExceedsAbsoluteCapDespiteLargeMaxDepth_ShouldThrowTomlFormatException()
     {
         var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+        var toml = BuildNestedInlineTableDocument(TomlLimits.AbsoluteMaxDepth + 1);
 
-        RecursiveModel deep = new();
-        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
-            deep = new RecursiveModel { Child = deep };
-
-        Exception? captured = null;
-        var worker = new Thread(
-            () =>
-            {
-                try
-                {
-                    _ = TomlSerializer.Serialize(deep, options);
-                }
-                catch (Exception ex)
-                {
-                    captured = ex;
-                }
-            },
-            maxStackSize: 512 << 10);
-
-        worker.Start();
-        worker.Join();
-
-        Assert.IsNotNull(captured);
-        Assert.AreEqual(typeof(TomlSerializationException), captured.GetType());
+        Assert.ThrowsExactly<TomlFormatException>(() =>
+        {
+            _ = TomlSerializer.Deserialize<RecursiveModel>(toml, options);
+        });
     }
 
     /// <summary>
-    /// Verifies that the serializer survives an over-deep graph even when the available stack is too small to reach the
-    /// logical depth ceiling, by serializing on a stack that cannot hold <see cref="TomlLimits.AbsoluteMaxDepth" />
-    /// levels of recursion and asserting a catchable <see cref="TomlSerializationException" /> is thrown rather than the
-    /// process overflowing.
+    /// Verifies that serializing a graph nested far beyond the ceiling throws a catchable
+    /// <see cref="TomlSerializationException" /> rather than overflowing the call stack, even when serialization runs on
+    /// a thread whose stack is deliberately constrained — pinning the requirement that the ceiling stays low enough to
+    /// be reached before the physical stack is exhausted on a modest stack budget.
     /// </summary>
     /// <remarks>
-    /// A 256 KB stack cannot hold <see cref="TomlLimits.AbsoluteMaxDepth" /> levels of serializer recursion, so the
-    /// logical ceiling is unreachable on it: a guard expressed purely as a fixed level count set to the absolute maximum
-    /// would overflow the stack before it could throw. Only a guard that measures the actual remaining stack on each
-    /// descent converts the impending overflow into a catchable failure here, so this pins the runtime stack probe
-    /// specifically, complementing the 512 KB test above where the logical ceiling may still be reached first on a
-    /// platform with small stack frames.
+    /// The serializer descends one native call-stack frame per nested container, so the absolute ceiling only converts
+    /// unbounded nesting into a catchable failure while it is reached before the stack is exhausted. A ceiling raised
+    /// above the stack budget would let the recursion overflow first, terminating the process with an uncatchable
+    /// <see cref="StackOverflowException" /> that aborts the whole test run. Running on an explicit 256 KB stack with a
+    /// graph many times deeper than the ceiling makes that regression observable on any platform: it throws here only
+    /// because the ceiling is stack-safe.
     /// </remarks>
     [TestMethod]
-    public void Serialize_WhenGraphExceedsStackBudgetBelowDepthCeiling_ShouldThrowTomlSerializationExceptionNotOverflow()
+    public void Serialize_WhenGraphFarExceedsCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow()
     {
         var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
 
         RecursiveModel deep = new();
-        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
+        for (var i = 0; i < (TomlLimits.AbsoluteMaxDepth * 32) + 1; i++)
             deep = new RecursiveModel { Child = deep };
 
         Exception? captured = null;
@@ -133,5 +105,23 @@ public partial class TomlSerializerTests
         var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
 
         Assert.AreEqual(int.MaxValue, options.MaxDepth);
+    }
+
+    /// <summary>
+    /// Builds a TOML document of <paramref name="depth" /> nested inline tables under a single recurring key, used to
+    /// drive the parser to a controlled nesting depth.
+    /// </summary>
+    /// <param name="depth">The number of nested inline tables to emit.</param>
+    /// <returns>The TOML source text.</returns>
+    private static string BuildNestedInlineTableDocument(int depth)
+    {
+        var builder = new System.Text.StringBuilder();
+        for (var i = 0; i < depth; i++)
+            builder.Append("Child = { ");
+        for (var i = 0; i < depth; i++)
+            builder.Append('}');
+        builder.Append('\n');
+
+        return builder.ToString();
     }
 }

--- a/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
@@ -79,6 +79,51 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
+    /// Verifies that the serializer survives an over-deep graph even when the available stack is too small to reach the
+    /// logical depth ceiling, by serializing on a stack that cannot hold <see cref="TomlLimits.AbsoluteMaxDepth" />
+    /// levels of recursion and asserting a catchable <see cref="TomlSerializationException" /> is thrown rather than the
+    /// process overflowing.
+    /// </summary>
+    /// <remarks>
+    /// A 256 KB stack cannot hold <see cref="TomlLimits.AbsoluteMaxDepth" /> levels of serializer recursion, so the
+    /// logical ceiling is unreachable on it: a guard expressed purely as a fixed level count set to the absolute maximum
+    /// would overflow the stack before it could throw. Only a guard that measures the actual remaining stack on each
+    /// descent converts the impending overflow into a catchable failure here, so this pins the runtime stack probe
+    /// specifically, complementing the 512 KB test above where the logical ceiling may still be reached first on a
+    /// platform with small stack frames.
+    /// </remarks>
+    [TestMethod]
+    public void Serialize_WhenGraphExceedsStackBudgetBelowDepthCeiling_ShouldThrowTomlSerializationExceptionNotOverflow()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+
+        RecursiveModel deep = new();
+        for (var i = 0; i < TomlLimits.AbsoluteMaxDepth + 2; i++)
+            deep = new RecursiveModel { Child = deep };
+
+        Exception? captured = null;
+        var worker = new Thread(
+            () =>
+            {
+                try
+                {
+                    _ = TomlSerializer.Serialize(deep, options);
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+            },
+            maxStackSize: 256 << 10);
+
+        worker.Start();
+        worker.Join();
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(TomlSerializationException), captured.GetType());
+    }
+
+    /// <summary>
     /// Verifies that a <see cref="TomlSerializerOptions.MaxDepth" /> larger than the absolute ceiling is still accepted
     /// by the property, confirming the ceiling is enforced while parsing or writing rather than at configuration time.
     /// </summary>

--- a/Bodu.Text.Toml/test/TomlSerializerTests.Diagnostics.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.Diagnostics.cs
@@ -34,6 +34,28 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
+    /// Verifies that serializing an object graph with an indirect reference cycle — a parent reachable from itself
+    /// through a child's back-reference — throws <see cref="TomlSerializationException" /> identifying the cycle rather
+    /// than recursing until the stack is exhausted.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenObjectGraphHasIndirectCycle_ShouldThrowWithCyclePath()
+    {
+        var parent = new TreeNode();
+        var child = new TreeNode();
+        parent.Child = child;
+        child.Parent = parent;
+
+        var ex = Assert.ThrowsExactly<TomlSerializationException>(() =>
+        {
+            _ = TomlSerializer.Serialize(parent);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("cycle", StringComparison.OrdinalIgnoreCase));
+        Assert.AreEqual("Child.Parent", ex.Path);
+    }
+
+    /// <summary>
     /// Verifies that a binding failure on a nested member reports the dotted path from the document root to the
     /// offending member.
     /// </summary>
@@ -126,5 +148,23 @@ public partial class TomlSerializerTests
         /// </summary>
         /// <returns>The values, or <see langword="null" />.</returns>
         public List<int>? Values { get; set; }
+    }
+
+    /// <summary>
+    /// A node with both a child and a parent back-reference, used to build an indirect reference cycle.
+    /// </summary>
+    private sealed class TreeNode
+    {
+        /// <summary>
+        /// Gets or sets the child node.
+        /// </summary>
+        /// <returns>The child, or <see langword="null" />.</returns>
+        public TreeNode? Child { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent node.
+        /// </summary>
+        /// <returns>The parent, or <see langword="null" />.</returns>
+        public TreeNode? Parent { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

This change establishes and enforces a hard absolute nesting ceiling across all serializers, parsers, readers, and writers in both the TOML and Bencode libraries. The ceiling is set to match the default maximum depth (64) and is applied uniformly, ensuring that caller-supplied `MaxDepth` values cannot exceed it. This prevents unbounded recursion from causing `StackOverflowException` when processing untrusted input.

## Key Changes

- **New `BencodeLimits` class**: Introduced `BencodeLimits.AbsoluteMaxDepth` constant (64) to define the hard ceiling for Bencode, mirroring the existing `TomlLimits.AbsoluteMaxDepth`.

- **Unified ceiling enforcement**: Updated all reader, writer, and serializer constructors to clamp configured `MaxDepth` values to the absolute ceiling using `Math.Min()`:
  - `Utf8TomlReader`, `Utf8TomlWriter`, `TomlDocument`
  - `Utf8BencodeReader`, `Utf8BencodeWriter`, `BencodeDocument`
  - `BencodeSerializer` and `TomlSerializer` options

- **Documentation improvements**: Clarified remarks across all `MaxDepth` properties and constructor documentation to explain:
  - The distinction between configured depth and effective (clamped) depth
  - Why the ceiling exists (stack safety on modest budgets)
  - That the ceiling is reached before physical stack exhaustion
  - The specific exception types thrown when limits are exceeded

- **Expanded test coverage**:
  - Added `Deserialize_WhenDocumentExceedsAbsoluteCapDespiteLargeMaxDepth` test for TOML parser
  - Added `Serialize_WhenGraphExceedsAbsoluteCapDespiteLargeMaxDepth` test for Bencode serializer
  - Added `Serialize_WhenGraphFarExceedsCapOnConstrainedStack` tests (both TOML and Bencode) with 256 KB constrained stacks to verify the ceiling prevents overflow
  - Added `Serialize_WhenNestedDictionariesExceedCap` and `Serialize_WhenNestedArraysExceedCap` tests to verify coverage of dictionary and collection converter paths
  - Added `Serialize_WhenObjectGraphHasIndirectCycle` test for cycle detection with back-references
  - Added `BuildNestedInlineTableDocument` helper to construct deeply nested TOML for parser testing

- **Default depth alignment**: Ensured all default `MaxDepth` values (in options, readers, writers) are set to or reference the absolute ceiling constant (64), replacing hardcoded 256 values where they appeared.

## Notable Implementation Details

- The ceiling is enforced at initialization time in all reader/writer/serializer constructors, not at configuration time, allowing callers to set arbitrarily large values without error while the effective limit remains safe.
- The constrained-stack tests use 256 KB stacks and create graphs 32× deeper than the ceiling to ensure the regression is observable on any platform.
- Cycle detection (for indirect cycles via back-references) is now tested alongside depth limits to confirm both protections work independently.
- All documentation now consistently refers to "hard ceiling" and "effective limit" to distinguish between the absolute bound and the caller-configured value.

https://claude.ai/code/session_013cV8PGGMx6Q9cQx5CNXteK