### PR TITLE
Report over-deep/cycle TOML write failures cooperatively, not by throwing from depth

### DIFF
--- a/Bodu.Text.Toml/src/Text.Toml.Serialization.Converters/CollectionConverter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization.Converters/CollectionConverter.cs
@@ -94,11 +94,24 @@ internal sealed class CollectionConverter<TCollection, TElement>
     {
         ThrowHelper.ThrowIfNull(value);
 
-        if (!writer.TryEnterReference(value))
-            throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_CycleDetected, typeof(TCollection)));
+        TomlWriteStack? state = writer.WriteStack;
+        if (state is { HasFailure: true })
+            return;
+
+        if (state is not null && !state.TryEnterReference(value))
+        {
+            state.SetFailure(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_CycleDetected, typeof(TCollection)));
+            return;
+        }
 
         try
         {
+            if (state is not null && writer.Depth >= writer.EffectiveMaxDepth)
+            {
+                state.SetFailure(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, writer.EffectiveMaxDepth));
+                return;
+            }
+
             writer.WriteStartArray();
             var index = 0;
             foreach (TElement element in (IEnumerable<TElement>)value)
@@ -106,15 +119,11 @@ internal sealed class CollectionConverter<TCollection, TElement>
                 if (element is null)
                     throw new TomlSerializationException(TomlResourceStrings.Op_NotSupported_NullCollectionElement);
 
-                try
-                {
-                    _elementConverter.WriteAsObject(writer, element, options);
-                }
-                catch (TomlSerializationException ex)
-                {
-                    ex.Path = TomlSerializationException.CombinePath("[" + index.ToString(CultureInfo.InvariantCulture) + "]", ex.Path);
-                    throw;
-                }
+                state?.PushPath("[" + index.ToString(CultureInfo.InvariantCulture) + "]");
+                _elementConverter.WriteAsObject(writer, element, options);
+                if (state is { HasFailure: true })
+                    return;
+                state?.PopPath();
 
                 index++;
             }
@@ -123,7 +132,8 @@ internal sealed class CollectionConverter<TCollection, TElement>
         }
         finally
         {
-            writer.ExitReference(value);
+            if (state is not null)
+                state.ExitReference(value);
         }
     }
 

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization.Converters/DictionaryConverter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization.Converters/DictionaryConverter.cs
@@ -110,11 +110,24 @@ internal sealed class DictionaryConverter<TDictionary, TKey, TValue>
     {
         ThrowHelper.ThrowIfNull(value);
 
-        if (!writer.TryEnterReference(value))
-            throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_CycleDetected, typeof(TDictionary)));
+        TomlWriteStack? state = writer.WriteStack;
+        if (state is { HasFailure: true })
+            return;
+
+        if (state is not null && !state.TryEnterReference(value))
+        {
+            state.SetFailure(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_CycleDetected, typeof(TDictionary)));
+            return;
+        }
 
         try
         {
+            if (state is not null && writer.Depth >= writer.EffectiveMaxDepth)
+            {
+                state.SetFailure(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, writer.EffectiveMaxDepth));
+                return;
+            }
+
             writer.WriteStartTable();
             foreach (KeyValuePair<TKey, TValue> entry in (IEnumerable<KeyValuePair<TKey, TValue>>)value)
             {
@@ -123,22 +136,20 @@ internal sealed class DictionaryConverter<TDictionary, TKey, TValue>
 
                 var keyText = FormatKey(entry.Key);
                 writer.WritePropertyName(keyText);
-                try
-                {
-                    _valueConverter.WriteAsObject(writer, entry.Value, options);
-                }
-                catch (TomlSerializationException ex)
-                {
-                    ex.Path = TomlSerializationException.CombinePath(keyText, ex.Path);
-                    throw;
-                }
+
+                state?.PushPath(keyText);
+                _valueConverter.WriteAsObject(writer, entry.Value, options);
+                if (state is { HasFailure: true })
+                    return;
+                state?.PopPath();
             }
 
             writer.WriteEndTable();
         }
         finally
         {
-            writer.ExitReference(value);
+            if (state is not null)
+                state.ExitReference(value);
         }
     }
 

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization.Converters/ObjectConverter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization.Converters/ObjectConverter.cs
@@ -108,10 +108,17 @@ internal sealed class ObjectConverter<T>
         if (value is null)
             return;
 
+        TomlWriteStack? state = writer.WriteStack;
+        if (state is { HasFailure: true })
+            return;
+
         // A value type cannot participate in a reference cycle, so only reference instances are tracked.
         var tracked = !typeof(T).IsValueType;
-        if (tracked && !writer.TryEnterReference(value!))
-            throw new TomlSerializationException(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_CycleDetected, typeof(T)));
+        if (tracked && state is not null && !state.TryEnterReference(value!))
+        {
+            state.SetFailure(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_CycleDetected, typeof(T)));
+            return;
+        }
 
         try
         {
@@ -123,6 +130,14 @@ internal sealed class ObjectConverter<T>
             // serialization error rather than surfacing as a writer-level duplicate-key failure.
             HashSet<string>? emittedKeys = metadata.ExtensionData is null ? null : new HashSet<string>(StringComparer.Ordinal);
 
+            // Refuse to descend past the ceiling before opening the table, so the failure is recorded cooperatively and
+            // the recursion unwinds through returns rather than throwing from the deepest writer frame.
+            if (state is not null && writer.Depth >= writer.EffectiveMaxDepth)
+            {
+                state.SetFailure(string.Format(CultureInfo.CurrentCulture, TomlResourceStrings.Op_Invalid_WriterMaxDepthExceeded, writer.EffectiveMaxDepth));
+                return;
+            }
+
             writer.WriteStartTable();
             foreach (PropertyMetadata property in metadata.Properties)
             {
@@ -131,15 +146,12 @@ internal sealed class ObjectConverter<T>
                     continue;
 
                 writer.WritePropertyName(property.WireName);
-                try
-                {
-                    property.Converter.WriteAsObject(writer, memberValue, options);
-                }
-                catch (TomlSerializationException ex)
-                {
-                    ex.Path = TomlSerializationException.CombinePath(property.WireName, ex.Path);
-                    throw;
-                }
+
+                state?.PushPath(property.WireName);
+                property.Converter.WriteAsObject(writer, memberValue, options);
+                if (state is { HasFailure: true })
+                    return;
+                state?.PopPath();
 
                 _ = emittedKeys?.Add(property.WireName);
             }
@@ -152,8 +164,8 @@ internal sealed class ObjectConverter<T>
         }
         finally
         {
-            if (tracked)
-                writer.ExitReference(value!);
+            if (tracked && state is not null)
+                state.ExitReference(value!);
         }
     }
 

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterOfT.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterOfT.cs
@@ -68,6 +68,13 @@ public abstract class TomlConverter<T>
         Read(ref reader, typeToConvert, options);
 
     /// <inheritdoc />
-    internal sealed override void WriteAsObject(Utf8TomlWriter writer, object? value, TomlSerializerOptions options) =>
+    internal sealed override void WriteAsObject(Utf8TomlWriter writer, object? value, TomlSerializerOptions options)
+    {
+        // Once a failure has been recorded, stop dispatching so the recursion unwinds through normal returns rather
+        // than entering another converter on an exhausted stack.
+        if (writer.WriteStack is { HasFailure: true })
+            return;
+
         Write(writer, (T)value!, options);
+    }
 }

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlSerializerEngine.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlSerializerEngine.cs
@@ -35,8 +35,17 @@ internal static class TomlSerializerEngine
         ThrowHelper.ThrowIfNull(options);
 
         options.MakeReadOnly();
+
+        // Attach the serializer write state so the converters record an over-deep graph or a reference cycle
+        // cooperatively and unwind through returns; the single recorded failure is thrown once here, at the shallow
+        // root boundary, rather than from the deepest recursive frame.
+        var state = new TomlWriteStack();
+        writer.AttachWriteStack(state);
+
         TomlConverter converter = options.GetConverter(typeof(T));
         converter.WriteAsObject(writer, value, options);
+
+        state.ThrowIfFailed();
     }
 
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlWriteStack.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlWriteStack.cs
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="TomlWriteStack.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Toml.Serialization;
+
+/// <summary>
+/// Carries the serializer's traversal state across the recursive converter calls of a single write: the path to the
+/// value currently being written, the set of reference instances in progress (for cycle detection), and the first
+/// failure recorded while writing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The converters report an over-deep graph or a reference cycle by recording the failure here and returning, rather
+/// than throwing from deep in the recursion and rethrowing through every parent frame. The single recorded failure is
+/// thrown once by <see cref="TomlSerializerEngine.Serialize{T}" /> after control has returned to the root, so the call
+/// stack unwinds through normal returns and cannot exhaust a constrained stack while dispatching the exception.
+/// </para>
+/// <para>
+/// Depth is intentionally <em>not</em> tracked here. The writer is the single owner of container depth (
+/// <c>Utf8TomlWriter.Depth</c>); a converter consults it directly before opening a container, mirroring how
+/// <c>System.Text.Json</c>'s serializer reads <c>Utf8JsonWriter.CurrentDepth</c>. This avoids a second counter that
+/// could drift, and ensures pass-through converters that re-dispatch without opening a container do not consume a
+/// level.
+/// </para>
+/// </remarks>
+internal sealed class TomlWriteStack
+{
+    /// <summary>
+    /// The path segments for every open container level, innermost last. Each entry is a member or dictionary key, or
+    /// an array index of the form <c>[i]</c>.
+    /// </summary>
+    private readonly List<string> _path = [];
+
+    /// <summary>
+    /// The reference instances currently being written, used to detect an object cycle by reference identity.
+    /// </summary>
+    private readonly HashSet<object> _references = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// The first failure recorded during the write, or <see langword="null" /> while none has occurred.
+    /// </summary>
+    private TomlSerializationException? _failure;
+
+    /// <summary>
+    /// Gets a value indicating whether a failure has been recorded, after which converters cooperatively stop work and
+    /// unwind.
+    /// </summary>
+    /// <returns><see langword="true" /> when a failure has been recorded; otherwise <see langword="false" />.</returns>
+    internal bool HasFailure => _failure is not null;
+
+    /// <summary>
+    /// Pushes a path segment for a container the writer is about to descend into.
+    /// </summary>
+    /// <param name="segment">The member or dictionary key, or an array index of the form <c>[i]</c>.</param>
+    internal void PushPath(string segment) =>
+        _path.Add(segment);
+
+    /// <summary>
+    /// Pops the most recently pushed path segment after the corresponding value has been written successfully.
+    /// </summary>
+    internal void PopPath() =>
+        _path.RemoveAt(_path.Count - 1);
+
+    /// <summary>
+    /// Records that the specified reference-typed value is being written, reporting whether it was already in progress.
+    /// </summary>
+    /// <param name="value">The reference being entered.</param>
+    /// <returns>
+    /// <see langword="true" /> when the reference was newly recorded; <see langword="false" /> when it is already being
+    /// written, which indicates an object cycle.
+    /// </returns>
+    internal bool TryEnterReference(object value) =>
+        _references.Add(value);
+
+    /// <summary>
+    /// Removes the specified reference-typed value from the in-progress set once it has been fully written.
+    /// </summary>
+    /// <param name="value">The reference being exited.</param>
+    internal void ExitReference(object value) =>
+        _references.Remove(value);
+
+    /// <summary>
+    /// Records a failure, capturing the path to the value currently being written. Only the first failure is retained.
+    /// </summary>
+    /// <param name="message">The fully formatted, culture-aware failure message.</param>
+    /// <remarks>
+    /// The path is captured from the live segment stack at the instant of detection — the deepest point of the
+    /// traversal, before any parent has unwound — so it names the value where the failure occurred.
+    /// </remarks>
+    internal void SetFailure(string message) =>
+        _failure ??= new TomlSerializationException(message) { Path = BuildPath() };
+
+    /// <summary>
+    /// Throws the recorded failure, if any. Called once at the root of the write after control has safely returned.
+    /// </summary>
+    /// <exception cref="TomlSerializationException">Thrown when a failure was recorded during the write.</exception>
+    internal void ThrowIfFailed()
+    {
+        if (_failure is { } failure)
+            throw failure;
+    }
+
+    /// <summary>
+    /// Builds the dotted, index-aware path from the current segment stack using the same join rules as
+    /// <see cref="TomlSerializationException.CombinePath" />.
+    /// </summary>
+    /// <returns>The combined path, or <see langword="null" /> when the failure occurred at the document root.</returns>
+    private string? BuildPath()
+    {
+        if (_path.Count == 0)
+            return null;
+
+        string? path = null;
+        for (var i = _path.Count - 1; i >= 0; i--)
+            path = TomlSerializationException.CombinePath(_path[i], path);
+
+        return path;
+    }
+}

--- a/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.Streaming.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.Streaming.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Buffers;
+using Bodu.Text.Toml.Serialization;
 
 namespace Bodu.Text.Toml.Writer;
 
@@ -54,7 +55,7 @@ public ref partial struct Utf8TomlWriter
         _root = new TomlWriterNode?[1];
         _maxDepth = options.MaxDepth <= 0 ? TomlLimits.AbsoluteMaxDepth : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
         _byteCounts = new long[2];
-        _references = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        _writeStack = new TomlWriteStack?[1];
     }
 
     /// <summary>
@@ -120,6 +121,7 @@ public ref partial struct Utf8TomlWriter
     {
         _frames.Clear();
         _root[0] = null;
+        _writeStack[0] = null;
         _streamBuffer?.Clear();
         _byteCounts[0] = 0;
         _byteCounts[1] = 0;

--- a/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Writer/Utf8TomlWriter.cs
@@ -6,6 +6,7 @@
 
 using System.Buffers;
 using System.Globalization;
+using Bodu.Text.Toml.Serialization;
 
 namespace Bodu.Text.Toml.Writer;
 
@@ -107,10 +108,15 @@ public ref partial struct Utf8TomlWriter
     private readonly long[] _byteCounts;
 
     /// <summary>
-    /// The set of reference-typed values currently being written, used by the serializer to detect object cycles. Held
-    /// in a shared managed object so it survives a by-value copy of the writer, as <see cref="_frames" /> does.
+    /// The single-element holder for the serializer's write state, when the writer is driven by the serializer.
     /// </summary>
-    private readonly HashSet<object> _references;
+    /// <remarks>
+    /// The holder is a shared managed object so the attached state survives a by-value copy of the writer, just as
+    /// <see cref="_frames" /> and <see cref="_root" /> do. It is <see langword="null" /> for direct, imperative, or DOM
+    /// writing, where the serializer's cooperative depth and cycle tracking is inactive and the writer's own depth
+    /// guard applies.
+    /// </remarks>
+    private readonly TomlWriteStack?[] _writeStack;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Utf8TomlWriter" /> struct.
@@ -128,7 +134,7 @@ public ref partial struct Utf8TomlWriter
         _root = new TomlWriterNode?[1];
         _maxDepth = TomlLimits.AbsoluteMaxDepth;
         _byteCounts = new long[2];
-        _references = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        _writeStack = new TomlWriteStack?[1];
     }
 
     /// <summary>
@@ -156,26 +162,39 @@ public ref partial struct Utf8TomlWriter
         _root = new TomlWriterNode?[1];
         _maxDepth = options.MaxDepth <= 0 ? TomlLimits.AbsoluteMaxDepth : Math.Min(options.MaxDepth, TomlLimits.AbsoluteMaxDepth);
         _byteCounts = new long[2];
-        _references = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        _writeStack = new TomlWriteStack?[1];
     }
 
     /// <summary>
-    /// Records that the specified reference-typed value is being written, reporting whether it was already in progress.
+    /// Gets the serializer write state attached to this writer, or <see langword="null" /> when the writer is used
+    /// directly rather than by the serializer.
     /// </summary>
-    /// <param name="value">The reference being entered.</param>
-    /// <returns>
-    /// <see langword="true" /> when the reference was newly recorded; <see langword="false" /> when it is already being
-    /// written, which indicates an object cycle.
-    /// </returns>
-    internal bool TryEnterReference(object value) =>
-        _references.Add(value);
+    /// <returns>The attached <see cref="TomlWriteStack" />, or <see langword="null" />.</returns>
+    internal readonly TomlWriteStack? WriteStack =>
+        _writeStack[0];
 
     /// <summary>
-    /// Removes the specified reference-typed value from the in-progress set once it has been fully written.
+    /// Gets the current container nesting depth — the number of open tables and arrays.
     /// </summary>
-    /// <param name="value">The reference being exited.</param>
-    internal void ExitReference(object value) =>
-        _references.Remove(value);
+    /// <returns>The number of containers currently open.</returns>
+    internal readonly int Depth =>
+        _frames.Count;
+
+    /// <summary>
+    /// Gets the effective maximum container nesting depth this writer enforces, after clamping to
+    /// <see cref="TomlLimits.AbsoluteMaxDepth" />.
+    /// </summary>
+    /// <returns>The effective maximum depth.</returns>
+    internal readonly int EffectiveMaxDepth =>
+        _maxDepth;
+
+    /// <summary>
+    /// Attaches the serializer write state to this writer so the converters can record depth and cycle failures
+    /// cooperatively instead of throwing from deep in the recursion.
+    /// </summary>
+    /// <param name="state">The write state to attach.</param>
+    internal readonly void AttachWriteStack(TomlWriteStack state) =>
+        _writeStack[0] = state;
 
     /// <summary>
     /// Writes the start of a table.

--- a/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.DepthCap.cs
@@ -53,16 +53,14 @@ public partial class TomlSerializerTests
     /// <summary>
     /// Verifies that serializing a graph nested far beyond the ceiling throws a catchable
     /// <see cref="TomlSerializationException" /> rather than overflowing the call stack, even when serialization runs on
-    /// a thread whose stack is deliberately constrained — pinning the requirement that the ceiling stays low enough to
-    /// be reached before the physical stack is exhausted on a modest stack budget.
+    /// a thread whose stack is deliberately constrained.
     /// </summary>
     /// <remarks>
-    /// The serializer descends one native call-stack frame per nested container, so the absolute ceiling only converts
-    /// unbounded nesting into a catchable failure while it is reached before the stack is exhausted. A ceiling raised
-    /// above the stack budget would let the recursion overflow first, terminating the process with an uncatchable
-    /// <see cref="StackOverflowException" /> that aborts the whole test run. Running on an explicit 256 KB stack with a
-    /// graph many times deeper than the ceiling makes that regression observable on any platform: it throws here only
-    /// because the ceiling is stack-safe.
+    /// The serializer detects the ceiling cooperatively before opening the over-deep container and unwinds through
+    /// normal returns, throwing once at the root. A graph many times deeper than the ceiling on an explicit 256 KB
+    /// stack therefore never builds the deep frames: a regression to throwing from the deepest frame (which needs stack
+    /// reserve to dispatch on a near-exhausted stack) would terminate the process with an uncatchable
+    /// <see cref="StackOverflowException" />, so a catchable result here proves detection stays shallow.
     /// </remarks>
     [TestMethod]
     public void Serialize_WhenGraphFarExceedsCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow()
@@ -73,23 +71,7 @@ public partial class TomlSerializerTests
         for (var i = 0; i < (TomlLimits.AbsoluteMaxDepth * 32) + 1; i++)
             deep = new RecursiveModel { Child = deep };
 
-        Exception? captured = null;
-        var worker = new Thread(
-            () =>
-            {
-                try
-                {
-                    _ = TomlSerializer.Serialize(deep, options);
-                }
-                catch (Exception ex)
-                {
-                    captured = ex;
-                }
-            },
-            maxStackSize: 256 << 10);
-
-        worker.Start();
-        worker.Join();
+        var captured = SerializeOnConstrainedStack(deep, options);
 
         Assert.IsNotNull(captured);
         Assert.AreEqual(typeof(TomlSerializationException), captured.GetType());
@@ -147,6 +129,58 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
+    /// Verifies that serializing arrays nested far beyond the ceiling on a constrained stack throws a catchable
+    /// <see cref="TomlSerializationException" /> rather than overflowing, confirming the collection converter detects the
+    /// ceiling cooperatively and unwinds through returns before the deep frames are entered.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenNestedArraysFarExceedCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+
+        var inner = new List<object>();
+        var current = inner;
+        for (var i = 0; i < (TomlLimits.AbsoluteMaxDepth * 32) + 1; i++)
+        {
+            var next = new List<object>();
+            current.Add(next);
+            current = next;
+        }
+
+        var root = new Dictionary<string, object> { ["values"] = inner };
+
+        var captured = SerializeOnConstrainedStack(root, options);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(TomlSerializationException), captured.GetType());
+    }
+
+    /// <summary>
+    /// Verifies that serializing dictionaries nested far beyond the ceiling on a constrained stack throws a catchable
+    /// <see cref="TomlSerializationException" /> rather than overflowing, confirming the dictionary converter detects the
+    /// ceiling cooperatively and unwinds through returns before the deep frames are entered.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenNestedDictionariesFarExceedCapOnConstrainedStack_ShouldThrowTomlSerializationExceptionNotOverflow()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
+
+        var root = new Dictionary<string, object>();
+        var current = root;
+        for (var i = 0; i < (TomlLimits.AbsoluteMaxDepth * 32) + 1; i++)
+        {
+            var next = new Dictionary<string, object>();
+            current["child"] = next;
+            current = next;
+        }
+
+        var captured = SerializeOnConstrainedStack(root, options);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(TomlSerializationException), captured.GetType());
+    }
+
+    /// <summary>
     /// Verifies that a <see cref="TomlSerializerOptions.MaxDepth" /> larger than the absolute ceiling is still accepted
     /// by the property, confirming the ceiling is enforced while parsing or writing rather than at configuration time.
     /// </summary>
@@ -156,6 +190,39 @@ public partial class TomlSerializerTests
         var options = new TomlSerializerOptions { MaxDepth = int.MaxValue };
 
         Assert.AreEqual(int.MaxValue, options.MaxDepth);
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value" /> on a deliberately constrained 256 KB thread stack, returning the exception
+    /// it threw, or <see langword="null" /> when it completed. A process-terminating
+    /// <see cref="StackOverflowException" /> cannot be captured, so a non-null catchable result confirms the serializer
+    /// stayed within the stack budget.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The captured exception, or <see langword="null" /> when serialization completed.</returns>
+    private static Exception? SerializeOnConstrainedStack<T>(T value, TomlSerializerOptions options)
+    {
+        Exception? captured = null;
+        var worker = new Thread(
+            () =>
+            {
+                try
+                {
+                    _ = TomlSerializer.Serialize(value, options);
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+            },
+            maxStackSize: 256 << 10);
+
+        worker.Start();
+        worker.Join();
+
+        return captured;
     }
 
     /// <summary>

--- a/Bodu.Text.Toml/test/TomlSerializerTests.Diagnostics.cs
+++ b/Bodu.Text.Toml/test/TomlSerializerTests.Diagnostics.cs
@@ -56,6 +56,45 @@ public partial class TomlSerializerTests
     }
 
     /// <summary>
+    /// Verifies that a reference cycle through a collection element is reported as a cycle whose path combines the
+    /// containing dictionary key and the array index, confirming the cooperative path is built from the serializer state
+    /// across the dictionary and collection converters.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenCollectionContainsItself_ShouldThrowWithIndexedCyclePath()
+    {
+        var items = new List<object>();
+        items.Add(items);
+        var root = new Dictionary<string, object> { ["items"] = items };
+
+        var ex = Assert.ThrowsExactly<TomlSerializationException>(() =>
+        {
+            _ = TomlSerializer.Serialize(root);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("cycle", StringComparison.OrdinalIgnoreCase));
+        Assert.AreEqual("items[0]", ex.Path);
+    }
+
+    /// <summary>
+    /// Verifies that exceeding the configured maximum depth reports the dotted path to the level at which the limit was
+    /// reached, confirming the cooperative depth failure captures the path from the serializer state.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenGraphExceedsMaxDepth_ShouldReportPathToFailingLevel()
+    {
+        var options = new TomlSerializerOptions { MaxDepth = 3 };
+        var deep = new RecursiveModel { Child = new RecursiveModel { Child = new RecursiveModel { Child = new RecursiveModel { Child = new RecursiveModel() } } } };
+
+        var ex = Assert.ThrowsExactly<TomlSerializationException>(() =>
+        {
+            _ = TomlSerializer.Serialize(deep, options);
+        });
+
+        Assert.AreEqual("Child.Child.Child", ex.Path);
+    }
+
+    /// <summary>
     /// Verifies that a binding failure on a nested member reports the dotted path from the document root to the
     /// offending member.
     /// </summary>


### PR DESCRIPTION
## Summary

Builds on the hard-ceiling work in #482. That change made an over-deep TOML graph fail with a catchable `TomlSerializationException` by lowering the depth ceiling, but the serializer still **reported** the failure by throwing from the deepest writer frame and rethrowing it through every parent `ObjectConverter<T>.Write` frame to build the path. On a constrained thread stack that still overflows: dispatching and unwinding an exception from a near-exhausted stack needs reserve the recursion already consumed, so the process dies with an uncatchable `StackOverflowException` — the depth was detected correctly, but *reporting* it crashed the host.

This PR replaces exception-driven unwinding with **cooperative failure propagation**, modeled on `System.Text.Json`. The low-level `Utf8TomlWriter` keeps its immediate depth throw as a backstop for direct/imperative/DOM use, while the serializer reads the **writer's** current depth, records the first failure in a serializer-owned write state, and returns through the stack — throwing the single failure once at the root.

## What changed

- **New internal `TomlWriteStack`** — holds the path-segment stack, the in-progress reference set (cycle detection), and one pending failure. It has **no depth counter**: converters read `Utf8TomlWriter.Depth` directly, exactly as S.T.J's serializer reads `Utf8JsonWriter.CurrentDepth`, so pass-through converters (`Nullable`/`ObjectType`) can't miscount.
- **`Utf8TomlWriter`** gains an internal write-state holder (`AttachWriteStack` / `WriteStack`), plus `Depth` and `EffectiveMaxDepth`; the `_references` cycle set and `TryEnterReference`/`ExitReference` move to `TomlWriteStack`. The `WriteStartTable`/`WriteStartArray` depth throws remain as the backstop.
- **`ObjectConverter` / `CollectionConverter` / `DictionaryConverter`** check the ceiling **before** opening their container and record depth/cycle failures into the state instead of throwing. They push the path segment, recurse, short-circuit on `HasFailure`, and pop only on success, so the live segment chain yields the exact path at the deepest point. `TomlConverter<T>.WriteAsObject` short-circuits once a failure is recorded, which also bounds custom converters.
- **`TomlSerializerEngine.Serialize`** attaches the state and throws `ThrowIfFailed()` at the shallow root boundary.

No public API changes. Same exception type, message, and `Path` as before (cycle `"Child"` / `"Child.Parent"`, depth and collection paths preserved).

## Why the constrained-stack test now passes for the right reason

On a 256 KB stack the serializer detects the ceiling at depth 64 **before building the deep frames**, unwinds via normal returns, and throws at the root. No throw from a near-exhausted stack, so no `StackOverflowException`.

## Tests

- All existing depth, cycle, and diagnostics tests pass unchanged.
- The constrained 256 KB-stack tests now pass by cooperative unwind; **added** constrained-stack variants for the collection and dictionary paths.
- **Added** a cycle-through-collection path test (`items[0]`) and a depth-failure path-accuracy test (`Child.Child.Child`), confirming the cooperative path-from-state matches the old rethrow chain across all three converters.
- **3304 TOML tests pass** (full regression); full solution builds clean.

## Out of scope (follow-ups)
- **Bencode**: mirror the cooperative depth handling (smaller — it has no per-frame rethrow amplifier and no `Path`/cycle state; depth-only, no cycle detection).
- **DOM `TomlNode.WriteTo`** / direct imperative writer / extension-data subtrees stay on the writer's cap-64 backstop.
- **Deserialize/read** catch-rethrow remains, bounded by the iterative parser's depth cap.

https://claude.ai/code/session_013cV8PGGMx6Q9cQx5CNXteK

---
_Generated by [Claude Code](https://claude.ai/code/session_013cV8PGGMx6Q9cQx5CNXteK)_