### PR TITLE
Add cancellation-aware overloads to SingleFlightCoordinator

### DIFF
--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
@@ -252,8 +252,10 @@ public sealed class BoeExchangeRateProvider
                 return Task.CompletedTask;
         }
 
-        // Coalesce concurrent loads of the same window so only one download is in flight; joiners await that task.
-        return _loadCoordinator.RunAsync((startDate, endDate), () => LoadRangeCoreAsync(startDate, endDate, cancellationToken));
+        // Coalesce concurrent loads of the same window so only one download is in flight; joiners await that task. The
+        // shared fetch runs under a token decoupled from any caller, so one caller's cancellation cannot fault the
+        // others; cancellationToken only abandons this caller's wait.
+        return _loadCoordinator.RunAsync((startDate, endDate), ct => LoadRangeCoreAsync(startDate, endDate, ct), cancellationToken);
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.SingleFlight.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.SingleFlight.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using Bodu.Test;
+
 namespace Bodu.Financial.ExchangeRates.Boe;
 
 public partial class BoeExchangeRateProviderTests
@@ -51,6 +53,37 @@ public partial class BoeExchangeRateProviderTests
         source.Release();
         await provider.LoadRangeAsync(start, end);
         await provider.LoadRangeAsync(start, end);
+
+        Assert.AreEqual(1, source.CallCount);
+    }
+
+    /// <summary>
+    /// Verifies that when one of several concurrent loads of the same range cancels its token, only that caller faults
+    /// while the range still loads for the remaining callers from the single shared fetch.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategories.Regression)]
+    public async Task LoadRangeAsync_WhenOneConcurrentCallerCancels_ShouldStillLoadForOthersAndFetchOnce()
+    {
+        BoeExchangeRateOptions options = new() { EnableDiskCache = false };
+        GatedBoeExchangeRateTableSource source = new(options);
+        BoeExchangeRateProvider provider = new(source, options);
+        DateOnly start = new(2023, 1, 1);
+        DateOnly end = new(2023, 12, 31);
+
+        using CancellationTokenSource cancellingCts = new();
+
+        Task cancelling = provider.LoadRangeAsync(start, end, cancellingCts.Token);
+        Task survivor1 = provider.LoadRangeAsync(start, end);
+        Task survivor2 = provider.LoadRangeAsync(start, end);
+
+        await source.Entered;
+        cancellingCts.Cancel();
+        source.Release();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await cancelling);
+        await survivor1;
+        await survivor2;
 
         Assert.AreEqual(1, source.CallCount);
     }

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed/README.md
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed/README.md
@@ -23,12 +23,32 @@ Because it depends only on the `IDistributedCache` abstraction it is fully unit-
 
 * Expiry is by caching duration: stale and semantically invalid rows are filtered on read and pruned on write; stale
   coverage windows are pruned when coverage is recorded, so the entry self-cleans.
-* The two halves of a pair's state are written independently — storing rates never drops coverage, and recording
-  coverage never drops rows — by read-modify-writing the per-pair blob.
-* Best-effort: an `IDistributedCache` offers no atomic read-modify-write, so the per-pair blob is read, modified, and
-  written back. Same-process races are prevented by a per-pair in-process lock; **cross-process** concurrent writes to
-  the same pair are last-write-wins. A backing-store failure or a corrupt blob degrades to an empty read or skipped
-  write rather than throwing.
+* The two **independent** half-writes preserve the other half: `Store` writes rate rows without dropping coverage, and
+  `RecordCoverage` writes coverage windows without dropping rows — each by read-modify-writing the per-pair blob.
+* `StoreFetchedRange` — the path the `CachingExchangeRateProvider` decorator uses after a range fetch — writes **both**
+  halves together as one atomic blob set: the pair's rate rows and the fetched coverage window are merged and persisted
+  in a single `Set`, all-or-nothing. A reader (even in another process) therefore never observes coverage without its
+  rows, so a range lookup cannot report a false hit and return incomplete data as if complete. The write returns an
+  `ExchangeRateCacheWriteStatus` (`Stored` when both halves were persisted, `Failed` when a backing-store error was
+  swallowed and nothing was persisted, `Skipped` for a no-op cache), which the decorator logs and, on `Failed`, treats
+  as a miss so the next lookup refetches rather than trusting partial coverage.
+* An empty-but-fetched range still records coverage: a successful fetch that returned no observation (a weekend, a
+  holiday, a true gap) marks the window covered, so it is served from the cache on a later lookup rather than being
+  perpetually re-fetched.
+* Consistency is best-effort. An `IDistributedCache` offers no cross-process atomic read-modify-write, so each write
+  reads the per-pair blob, modifies it, and writes it back. Same-process races are prevented by a per-pair in-process
+  lock. **Cross-process**, the independent `Store` / `RecordCoverage` half-writes are last-write-wins, while the
+  decorator's `StoreFetchedRange` blob set is atomic per write (each writer persists a self-consistent rows-plus-coverage
+  blob, so a concurrent overwrite loses an update but never tears a half into another writer's blob). A backing-store
+  failure or a corrupt blob degrades to an empty read or skipped write rather than throwing.
+
+## When to use
+
+Reach for this distributed (Redis-backed) cache when several application instances or processes share one rate cache,
+so a fetch by one instance warms the others. For a single process, prefer the SQLite, file (TOML), or in-memory caches
+in `Bodu.Financial.ExchangeRates.Caching` (and `…Caching.Sqlite`): they offer stronger local atomicity — the per-pair
+lock for the in-memory and file caches, and one transaction for SQLite — for every write path, including the independent
+`Store` / `RecordCoverage` halves.
 
 ## Usage
 

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite/README.md
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite/README.md
@@ -19,8 +19,11 @@ coverage, and validation semantics — and is validated against the same shared 
 
 * Expiry is by caching duration: stale and semantically invalid rows are filtered on read and pruned on write; stale
   coverage windows are pruned when coverage is recorded, so the database self-cleans.
-* The two halves of a pair's state are written independently — storing rates never drops coverage, and recording
-  coverage never drops rows.
+* The independent half-writes preserve the other half — `Store` never drops coverage, and `RecordCoverage` never drops
+  rows — while `StoreFetchedRange` (the path the `CachingExchangeRateProvider` decorator uses) rewrites both the `rates`
+  and `coverage` tables for the pair in **one transaction**, so a reader never observes coverage without its rows. An
+  empty-but-fetched range still records its coverage window so it is not perpetually re-fetched. The write reports an
+  `ExchangeRateCacheWriteStatus` (`Stored` / `Failed` / `Skipped`).
 * Single-process best-effort: same-pair writes are serialized under a per-pair lock and run in a transaction. A storage
   failure (`SqliteException` / `IOException`) degrades to an empty read or skipped write rather than throwing.
 

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateOptions.cs
@@ -22,6 +22,8 @@ namespace Bodu.Financial.ExchangeRates.Caching;
 /// The <c>Cache*LogLevel</c> members set the <see cref="LogLevel" /> at which each cache diagnostic is logged, so
 /// consumers can re-tune verbosity per concern without category-wide log filters. The per-lookup hit and miss events
 /// default to <see cref="LogLevel.Trace" /> because they run on the read hot path; the range events default to
+/// <see cref="LogLevel.Debug" />. The per-serve <see cref="RateProvenanceLogLevel" /> records the lineage of every
+/// served rate — live versus cache hit, the backend identity, and the served data's age — and also defaults to
 /// <see cref="LogLevel.Debug" />. Set any member to <see cref="LogLevel.None" /> to suppress that event entirely.
 /// </para>
 /// </remarks>
@@ -95,6 +97,17 @@ public sealed class CachingExchangeRateOptions
     public LogLevel CacheRangeRefetchLogLevel { get; set; } = LogLevel.Debug;
 
     /// <summary>
+    /// Gets or sets the level at which the provenance of every served rate is logged.
+    /// </summary>
+    /// <value>The log level; defaults to <see cref="LogLevel.Debug" />.</value>
+    /// <remarks>
+    /// This per-serve diagnostic records the lineage of each result — whether it was resolved live or from the cache,
+    /// the cache backend that served it, and the served data's age — and so is richer than the per-concern hit and miss
+    /// events on the read hot path. Set it to <see cref="LogLevel.None" /> to suppress provenance entirely.
+    /// </remarks>
+    public LogLevel RateProvenanceLogLevel { get; set; } = LogLevel.Debug;
+
+    /// <summary>
     /// Gets or sets the lookup options applied by the timeless
     /// <see cref="IExchangeRateProvider.GetRate(string, string)" /> surface, which resolves the rate for the current
     /// UTC date.
@@ -118,8 +131,8 @@ public sealed class CachingExchangeRateOptions
     /// </summary>
     /// <exception cref="ArgumentException">
     /// Thrown when <see cref="DefaultExpiry" /> or any <see cref="ProviderExpiry" /> entry is not strictly positive,
-    /// when <see cref="ProviderExpiry" /> or <see cref="DefaultLookupOptions" /> is <see langword="null" />, or when any
-    /// <c>Cache*LogLevel</c> is not a defined <see cref="LogLevel" />.
+    /// when <see cref="ProviderExpiry" /> or <see cref="DefaultLookupOptions" /> is <see langword="null" />, or when
+    /// any <c>Cache*LogLevel</c> or <see cref="RateProvenanceLogLevel" /> is not a defined <see cref="LogLevel" />.
     /// </exception>
     /// <remarks>
     /// This throwing form preserves the <c>ParamName</c> of the offending option, which callers rely on. The
@@ -207,14 +220,16 @@ public sealed class CachingExchangeRateOptions
     }
 
     /// <summary>
-    /// Reports whether every configurable cache log level is a defined <see cref="LogLevel" /> value.
+    /// Reports whether every configurable log level is a defined <see cref="LogLevel" /> value.
     /// </summary>
     /// <returns>
-    /// <see langword="true" /> when every <c>Cache*LogLevel</c> property is defined; otherwise <see langword="false" />.
+    /// <see langword="true" /> when every <c>Cache*LogLevel</c> property and <see cref="RateProvenanceLogLevel" /> is
+    /// defined; otherwise <see langword="false" />.
     /// </returns>
     private bool AreLogLevelsDefined() =>
         Enum.IsDefined(CacheHitLogLevel)
         && Enum.IsDefined(CacheMissLogLevel)
         && Enum.IsDefined(CacheRangeHitLogLevel)
-        && Enum.IsDefined(CacheRangeRefetchLogLevel);
+        && Enum.IsDefined(CacheRangeRefetchLogLevel)
+        && Enum.IsDefined(RateProvenanceLogLevel);
 }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
@@ -31,9 +31,15 @@ namespace Bodu.Financial.ExchangeRates.Caching;
 /// actually fetched and is still fresh — so an interior day that was never fetched forces a refetch rather than being
 /// served from a sparse set of rows. On a miss the whole range is refetched from the inner provider and written back
 /// through a single atomic <see cref="IExchangeRateCache.StoreFetchedRange" /> that merges the rows and records the
-/// covered window together, even when the fetch returned no rows, so an empty-but-fetched window is not refetched on the
-/// next lookup. To group several sources behind one entry point, wrap each in its own caching provider and compose them
-/// with an <see cref="AggregatingExchangeRateProvider" />.
+/// covered window together, even when the fetch returned no rows, so an empty-but-fetched window is not refetched on
+/// the next lookup. To group several sources behind one entry point, wrap each in its own caching provider and compose
+/// them with an <see cref="AggregatingExchangeRateProvider" />.
+/// </para>
+/// <para>
+/// Each of the four serve points additionally emits a provenance record alongside its hit/miss diagnostic, recording
+/// whether the rate was resolved live or from the cache, the cache backend that served it, and — for a cache serve —
+/// the age of the served data. The provenance event is logged at
+/// <see cref="CachingExchangeRateOptions.RateProvenanceLogLevel" />.
 /// </para>
 /// </remarks>
 public abstract class CachingExchangeRateProviderBase
@@ -58,6 +64,12 @@ public abstract class CachingExchangeRateProviderBase
     /// The logger that records cache hits, misses, and refetches.
     /// </summary>
     private readonly ILogger _logger;
+
+    /// <summary>
+    /// The runtime identity of the cache backend, captured once at construction to avoid recomputing it on the serve
+    /// path. It is reported as the backend of every provenance record this provider emits.
+    /// </summary>
+    private readonly string _backend;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CachingExchangeRateProviderBase" /> class.
@@ -86,6 +98,7 @@ public abstract class CachingExchangeRateProviderBase
         _options = options;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _logger = logger ?? NullLogger.Instance;
+        _backend = cache.GetType().Name;
     }
 
     /// <summary>
@@ -109,9 +122,10 @@ public abstract class CachingExchangeRateProviderBase
         var now = _timeProvider.GetUtcNow();
         var duration = _options.GetExpiry(_cache.Provider);
 
-        if (TryServeFromCache(duration, fromIsoCode, toIsoCode, date, options, now, out result))
+        if (TryServeFromCache(duration, fromIsoCode, toIsoCode, date, options, now, out result, out DateTimeOffset? servedCachedAtUtc))
         {
             Log.CacheHit(_logger, _options.CacheHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode, date);
+            EmitProvenance(ExchangeRateProvenance.FromCache(_cache.Provider, _backend, servedCachedAtUtc, now), fromIsoCode, toIsoCode);
             return true;
         }
 
@@ -119,6 +133,7 @@ public abstract class CachingExchangeRateProviderBase
         {
             StoreResult(duration, fromIsoCode, toIsoCode, result, now);
             Log.CacheMissStored(_logger, _options.CacheMissLogLevel, _cache.Provider, fromIsoCode, toIsoCode, date);
+            EmitProvenance(ExchangeRateProvenance.Live(_cache.Provider, _backend), fromIsoCode, toIsoCode);
             return true;
         }
 
@@ -141,9 +156,10 @@ public abstract class CachingExchangeRateProviderBase
         var now = _timeProvider.GetUtcNow();
         var duration = _options.GetExpiry(_cache.Provider);
 
-        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
+        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached, out DateTimeOffset? oldestCachedAtUtc))
         {
             Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
+            EmitProvenance(ExchangeRateProvenance.FromCache(_cache.Provider, _backend, oldestCachedAtUtc, now), fromIsoCode, toIsoCode);
             return cached;
         }
 
@@ -156,6 +172,7 @@ public abstract class CachingExchangeRateProviderBase
         ExchangeRateCacheWriteStatus status = StoreFetchedRange(duration, pair, fetched, startDate, endDate, now);
 
         Log.RangeRefetched(_logger, _options.CacheRangeRefetchLogLevel, _cache.Provider, fromIsoCode, toIsoCode, fetched.Count, status);
+        EmitProvenance(ExchangeRateProvenance.Live(_cache.Provider, _backend), fromIsoCode, toIsoCode);
         return fetched;
     }
 
@@ -178,10 +195,16 @@ public abstract class CachingExchangeRateProviderBase
     /// <param name="options">The lookup rules to apply.</param>
     /// <param name="now">The instant against which cached rows are evaluated for freshness.</param>
     /// <param name="result">When this method returns <see langword="true" />, the resolved result.</param>
+    /// <param name="servedCachedAtUtc">
+    /// When this method returns <see langword="true" />, the cache instant representing the served data: the
+    /// <see cref="CachedExchangeRate.CachedAtUtc" /> of the row whose date matches the resolved result, or the oldest
+    /// instant among the fresh candidate rows when no exact match is found. <see langword="null" /> when this method
+    /// returns <see langword="false" />.
+    /// </param>
     /// <returns>
     /// <see langword="true" /> when the request was satisfied from the cache; otherwise <see langword="false" />.
     /// </returns>
-    private bool TryServeFromCache(TimeSpan duration, string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, DateTimeOffset now, out ExchangeRateLookupResult result)
+    private bool TryServeFromCache(TimeSpan duration, string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, DateTimeOffset now, out ExchangeRateLookupResult result, out DateTimeOffset? servedCachedAtUtc)
     {
         ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
 
@@ -195,6 +218,7 @@ public abstract class CachingExchangeRateProviderBase
         if (direct.Count == 0 && inverse.Count == 0)
         {
             result = default;
+            servedCachedAtUtc = null;
             return false;
         }
 
@@ -206,7 +230,14 @@ public abstract class CachingExchangeRateProviderBase
             rates.Add(new ExchangeRate(toIsoCode, fromIsoCode, rate.Date, rate.Rate, provider));
 
         FixedDatedExchangeRateProvider snapshot = new(rates);
-        return snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
+        if (!snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
+        {
+            servedCachedAtUtc = null;
+            return false;
+        }
+
+        servedCachedAtUtc = ResolveServedInstant(direct, inverse, result.Rate.Date);
+        return true;
     }
 
     /// <summary>
@@ -220,28 +251,40 @@ public abstract class CachingExchangeRateProviderBase
     /// <param name="endDate">The inclusive end of the range.</param>
     /// <param name="now">The instant against which cached rows and coverage are evaluated for freshness.</param>
     /// <param name="result">When this method returns <see langword="true" />, the rates within the range.</param>
+    /// <param name="oldestCachedAtUtc">
+    /// When this method returns <see langword="true" />, the oldest <see cref="CachedExchangeRate.CachedAtUtc" /> among
+    /// the in-window rows added to <paramref name="result" />, or <see langword="null" /> when the covered window
+    /// yields no rows. <see langword="null" /> when this method returns <see langword="false" />.
+    /// </param>
     /// <returns>
     /// <see langword="true" /> when the range was satisfied from the cache; otherwise <see langword="false" />.
     /// </returns>
-    private bool TryServeRangeFromCache(TimeSpan duration, ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, DateTimeOffset now, out IReadOnlyList<ExchangeRate> result)
+    private bool TryServeRangeFromCache(TimeSpan duration, ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, DateTimeOffset now, out IReadOnlyList<ExchangeRate> result, out DateTimeOffset? oldestCachedAtUtc)
     {
         // The fresh coverage, not the span of the rate rows, decides whether the whole window was actually fetched.
         if (!_cache.GetCoverage(pair, duration, now).Contains(startDate, endDate))
         {
             result = Array.Empty<ExchangeRate>();
+            oldestCachedAtUtc = null;
             return false;
         }
 
         var provider = _cache.Provider;
         IReadOnlyList<CachedExchangeRate> fresh = _cache.GetRates(pair, duration, now);
         List<ExchangeRate> rates = new();
+        DateTimeOffset? oldest = null;
         foreach (CachedExchangeRate rate in fresh)
         {
             if (rate.Date >= startDate && rate.Date <= endDate)
+            {
                 rates.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, rate.Date, rate.Rate, provider));
+                if (oldest is not { } current || rate.CachedAtUtc < current)
+                    oldest = rate.CachedAtUtc;
+            }
         }
 
         result = rates;
+        oldestCachedAtUtc = oldest;
         return true;
     }
 
@@ -285,4 +328,66 @@ public abstract class CachingExchangeRateProviderBase
 
         return _cache.StoreFetchedRange(pair, rows, startDate, endDate, duration, now);
     }
+
+    /// <summary>
+    /// Resolves the cache instant that represents a single-date serve: the cache instant of the candidate row whose
+    /// date matches the resolved result, or the oldest instant among all candidate rows when no row matches that date.
+    /// </summary>
+    /// <param name="direct">The fresh candidate rows for the requested pair.</param>
+    /// <param name="inverse">The fresh candidate rows for the inverse pair, empty when inversion is disallowed.</param>
+    /// <param name="resolvedDate">The observation date of the resolved result.</param>
+    /// <returns>
+    /// The cache instant of the row dated <paramref name="resolvedDate" /> when one exists, otherwise the oldest cache
+    /// instant among the candidate rows, or <see langword="null" /> when no candidate rows are present.
+    /// </returns>
+    /// <remarks>
+    /// A nearest-date or inverse serve has no row dated exactly <paramref name="resolvedDate" />, so the oldest
+    /// candidate instant is reported as a stable, lower-bound representative of the data backing the serve.
+    /// </remarks>
+    private static DateTimeOffset? ResolveServedInstant(IReadOnlyList<CachedExchangeRate> direct, IReadOnlyList<CachedExchangeRate> inverse, DateOnly resolvedDate)
+    {
+        DateTimeOffset? oldest = null;
+
+        foreach (CachedExchangeRate row in direct)
+        {
+            if (row.Date == resolvedDate)
+                return row.CachedAtUtc;
+
+            if (oldest is not { } current || row.CachedAtUtc < current)
+                oldest = row.CachedAtUtc;
+        }
+
+        foreach (CachedExchangeRate row in inverse)
+        {
+            if (row.Date == resolvedDate)
+                return row.CachedAtUtc;
+
+            if (oldest is not { } current || row.CachedAtUtc < current)
+                oldest = row.CachedAtUtc;
+        }
+
+        return oldest;
+    }
+
+    /// <summary>
+    /// Emits the provenance of a served rate through the source-generated provenance log message at the configured
+    /// level.
+    /// </summary>
+    /// <param name="provenance">The lineage of the served rate.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <remarks>
+    /// The call is unconditional: the <see cref="LoggerMessageAttribute" /> source generator short-circuits before any
+    /// argument is formatted when <see cref="CachingExchangeRateOptions.RateProvenanceLogLevel" /> is disabled.
+    /// </remarks>
+    private void EmitProvenance(ExchangeRateProvenance provenance, string fromIsoCode, string toIsoCode) =>
+        Log.RateProvenance(
+            _logger,
+            _options.RateProvenanceLogLevel,
+            provenance.Provider,
+            fromIsoCode,
+            toIsoCode,
+            provenance.Origin,
+            provenance.Backend,
+            provenance.Age);
 }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/ExchangeRateOrigin.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/ExchangeRateOrigin.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateOrigin.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial.ExchangeRates.Caching;
+
+/// <summary>
+/// Identifies where a served exchange rate was resolved from, distinguishing a live fetch through the wrapped inner
+/// provider from a serve out of the cache.
+/// </summary>
+internal enum ExchangeRateOrigin
+{
+    /// <summary>
+    /// The rate was resolved fresh from the wrapped inner provider on a cache miss.
+    /// </summary>
+    Live,
+
+    /// <summary>
+    /// The rate was served from the cache without consulting the wrapped inner provider.
+    /// </summary>
+    Cache,
+}

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/ExchangeRateProvenance.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/ExchangeRateProvenance.cs
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateProvenance.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial.ExchangeRates.Caching;
+
+/// <summary>
+/// Captures the lineage of a single served exchange-rate result: the source it was cached under, whether it was a live
+/// fetch or a cache serve, the cache backend that served it, and — for a cache serve — the instant the served data was
+/// cached and the derived age at the time of the lookup.
+/// </summary>
+/// <param name="Provider">The provider name the served rows are cached under.</param>
+/// <param name="Origin">Whether the rate was resolved live from the inner provider or served from the cache.</param>
+/// <param name="Backend">The runtime identity of the cache backend that served the request.</param>
+/// <param name="CachedAtUtc">
+/// The UTC instant the served rows were cached, or <see langword="null" /> for a live serve.
+/// </param>
+/// <param name="Age">
+/// The elapsed time between <paramref name="CachedAtUtc" /> and the lookup instant, or <see langword="null" /> for a
+/// live serve or when no row backs the serve.
+/// </param>
+/// <remarks>
+/// This type is an internal diagnostic carrier produced at each serve point of
+/// <see cref="CachingExchangeRateProviderBase" />; it does not form part of any public surface. Construct instances
+/// through <see cref="Live" /> and <see cref="FromCache" /> rather than the positional constructor so the
+/// origin-specific invariants — a live serve carries neither a cache instant nor an age — are applied consistently.
+/// </remarks>
+internal readonly record struct ExchangeRateProvenance(
+    string Provider,
+    ExchangeRateOrigin Origin,
+    string Backend,
+    DateTimeOffset? CachedAtUtc,
+    TimeSpan? Age)
+{
+    /// <summary>
+    /// Creates provenance for a rate resolved live from the wrapped inner provider, leaving the cache instant and age
+    /// unset.
+    /// </summary>
+    /// <param name="provider">The provider name the rate is cached under.</param>
+    /// <param name="backend">The runtime identity of the cache backend.</param>
+    /// <returns>
+    /// An <see cref="ExchangeRateProvenance" /> with <see cref="Origin" /> set to
+    /// <see cref="ExchangeRateOrigin.Live" /> and no cache instant or age.
+    /// </returns>
+    public static ExchangeRateProvenance Live(string provider, string backend) =>
+        new(provider, ExchangeRateOrigin.Live, backend, CachedAtUtc: null, Age: null);
+
+    /// <summary>
+    /// Creates provenance for a rate served from the cache, deriving its age from the served instant and the lookup
+    /// instant.
+    /// </summary>
+    /// <param name="provider">The provider name the rate is cached under.</param>
+    /// <param name="backend">The runtime identity of the cache backend that served the request.</param>
+    /// <param name="cachedAtUtc">
+    /// The UTC instant the served rows were cached, or <see langword="null" /> when no row backs the serve.
+    /// </param>
+    /// <param name="asOf">The lookup instant against which the age is derived.</param>
+    /// <returns>
+    /// An <see cref="ExchangeRateProvenance" /> with <see cref="Origin" /> set to
+    /// <see cref="ExchangeRateOrigin.Cache" />, carrying <paramref name="cachedAtUtc" /> and the derived age, or no age
+    /// when <paramref name="cachedAtUtc" /> is <see langword="null" />.
+    /// </returns>
+    public static ExchangeRateProvenance FromCache(string provider, string backend, DateTimeOffset? cachedAtUtc, DateTimeOffset asOf) =>
+        new(provider, ExchangeRateOrigin.Cache, backend, cachedAtUtc, cachedAtUtc is { } c ? asOf - c : null);
+}

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/Log.cs
@@ -67,4 +67,21 @@ internal static partial class Log
     /// <param name="status">The outcome of the atomic rows-and-coverage cache write.</param>
     [LoggerMessage(EventId = 4504, Message = "Refetched {count} {fromIsoCode}->{toIsoCode} rate(s) from source '{source}'; cache write {status}")]
     public static partial void RangeRefetched(ILogger logger, LogLevel level, string source, string fromIsoCode, string toIsoCode, int count, ExchangeRateCacheWriteStatus status);
+
+    /// <summary>
+    /// Logs the provenance of a served rate, recording whether it came from a wrapped source or the cache, the cache
+    /// backend that served it, and — for a cache serve — the age of the served data.
+    /// </summary>
+    /// <param name="logger">The logger that receives the message.</param>
+    /// <param name="level">The level at which to log the message.</param>
+    /// <param name="source">The source name the served rows are cached under.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="origin">Whether the rate was resolved live from a source or served from the cache.</param>
+    /// <param name="backend">The runtime identity of the cache backend that served the request.</param>
+    /// <param name="age">
+    /// The age of the served data, or <see langword="null" /> for a live serve or when no row backs the serve.
+    /// </param>
+    [LoggerMessage(EventId = 4505, Message = "Resolved {fromIsoCode}->{toIsoCode} for source '{source}' from {origin} (backend '{backend}', age {age})")]
+    public static partial void RateProvenance(ILogger logger, LogLevel level, string source, string fromIsoCode, string toIsoCode, ExchangeRateOrigin origin, string backend, TimeSpan? age);
 }

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingExchangeRateProviderTests.Provenance.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingExchangeRateProviderTests.Provenance.cs
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CachingExchangeRateProviderTests.Provenance.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Bodu.Financial.ExchangeRates.Caching;
+
+/// <summary>
+/// Verifies that <see cref="CachingExchangeRateProvider" /> emits a provenance diagnostic at each serve point that
+/// records whether the rate was resolved live or from the cache, the cache backend that served it, and the served
+/// data's age.
+/// </summary>
+public sealed partial class CachingExchangeRateProviderTests
+{
+    /// <summary>
+    /// The runtime identity of the in-memory cache the tests run against, as reported by the provenance message.
+    /// </summary>
+    private const string Backend = nameof(InMemoryExchangeRateCache);
+
+    /// <summary>
+    /// The event id of the provenance diagnostic.
+    /// </summary>
+    private const int ProvenanceEventId = 4505;
+
+    /// <summary>
+    /// Verifies that a single-date cache hit emits the provenance event with a <c>Cache</c> origin, the in-memory cache
+    /// backend, and an age equal to the elapsed time since the served row was cached.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenCacheHit_ShouldLogProvenanceWithCacheOriginAndAge()
+    {
+        CapturingLogger logger = new();
+        SeedCache(new ExchangeRatePair("AUD", "USD"), (new DateOnly(2023, 1, 3), 0.5m));
+        CachingExchangeRateProvider sut = new(InnerWith(), _cache, _options, _clock, logger);
+
+        _clock.Advance(TimeSpan.FromHours(1));
+        _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        (LogLevel Level, EventId EventId, string Message) entry = logger.Entries.Single(e => e.EventId.Id == ProvenanceEventId);
+        Assert.AreEqual(LogLevel.Debug, entry.Level);
+        Assert.IsTrue(entry.Message.Contains("from Cache", StringComparison.Ordinal), entry.Message);
+        Assert.IsTrue(entry.Message.Contains($"backend '{Backend}'", StringComparison.Ordinal), entry.Message);
+        Assert.IsTrue(entry.Message.Contains("age 01:00:00", StringComparison.Ordinal), entry.Message);
+    }
+
+    /// <summary>
+    /// Verifies that a single-date cache miss resolved from the inner source emits the provenance event with a
+    /// <c>Live</c> origin and no age.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenCacheMiss_ShouldLogProvenanceWithLiveOriginAndNoAge()
+    {
+        CapturingLogger logger = new();
+        CountingDatedExchangeRateProvider inner = InnerWith(("AUD", "USD", new DateOnly(2023, 1, 3), 0.5m));
+        CachingExchangeRateProvider sut = new(inner, _cache, _options, _clock, logger);
+
+        _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        (LogLevel Level, EventId EventId, string Message) entry = logger.Entries.Single(e => e.EventId.Id == ProvenanceEventId);
+        Assert.AreEqual(LogLevel.Debug, entry.Level);
+        Assert.IsTrue(entry.Message.Contains("from Live", StringComparison.Ordinal), entry.Message);
+        Assert.IsTrue(entry.Message.Contains("age )", StringComparison.Ordinal), entry.Message);
+    }
+
+    /// <summary>
+    /// Verifies that a range lookup served entirely from the cache emits the provenance event with a <c>Cache</c>
+    /// origin and the in-memory cache backend.
+    /// </summary>
+    [TestMethod]
+    public async Task GetRatesAsync_WhenCacheHit_ShouldLogProvenanceWithCacheOrigin()
+    {
+        CapturingLogger logger = new();
+        ExchangeRatePair pair = new("AUD", "USD");
+        SeedCache(pair, (new DateOnly(2023, 1, 3), 0.5m), (new DateOnly(2023, 1, 6), 0.51m));
+        SeedCoverage(pair, new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+        CachingExchangeRateProvider sut = new(InnerWith(), _cache, _options, _clock, logger);
+
+        _clock.Advance(TimeSpan.FromHours(1));
+        _ = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+
+        (LogLevel Level, EventId EventId, string Message) entry = logger.Entries.Single(e => e.EventId.Id == ProvenanceEventId);
+        Assert.AreEqual(LogLevel.Debug, entry.Level);
+        Assert.IsTrue(entry.Message.Contains("from Cache", StringComparison.Ordinal), entry.Message);
+        Assert.IsTrue(entry.Message.Contains($"backend '{Backend}'", StringComparison.Ordinal), entry.Message);
+    }
+
+    /// <summary>
+    /// Verifies that a range lookup refetched from the inner source emits the provenance event with a <c>Live</c>
+    /// origin and no age.
+    /// </summary>
+    [TestMethod]
+    public async Task GetRatesAsync_WhenRefetch_ShouldLogProvenanceWithLiveOrigin()
+    {
+        CapturingLogger logger = new();
+        CountingDatedExchangeRateProvider inner = InnerWith(
+            ("AUD", "USD", new DateOnly(2023, 1, 3), 0.5m),
+            ("AUD", "USD", new DateOnly(2023, 1, 6), 0.51m));
+        CachingExchangeRateProvider sut = new(inner, _cache, _options, _clock, logger);
+
+        _ = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+
+        (LogLevel Level, EventId EventId, string Message) entry = logger.Entries.Single(e => e.EventId.Id == ProvenanceEventId);
+        Assert.AreEqual(LogLevel.Debug, entry.Level);
+        Assert.IsTrue(entry.Message.Contains("from Live", StringComparison.Ordinal), entry.Message);
+        Assert.IsTrue(entry.Message.Contains("age )", StringComparison.Ordinal), entry.Message);
+    }
+
+    /// <summary>
+    /// Verifies that setting <see cref="CachingExchangeRateOptions.RateProvenanceLogLevel" /> to
+    /// <see cref="LogLevel.None" /> suppresses the provenance event while the cache-hit event still emits at its own
+    /// level.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenRateProvenanceLogLevelNone_ShouldSuppressProvenanceButStillLogHit()
+    {
+        CapturingLogger logger = new();
+        _options.RateProvenanceLogLevel = LogLevel.None;
+        SeedCache(new ExchangeRatePair("AUD", "USD"), (new DateOnly(2023, 1, 3), 0.5m));
+        CachingExchangeRateProvider sut = new(InnerWith(), _cache, _options, _clock, logger);
+
+        _ = sut.GetRate("AUD", "USD", new DateOnly(2023, 1, 3), ExchangeRateLookupOptions.Exact);
+
+        Assert.IsFalse(logger.Entries.Any(e => e.EventId.Id == ProvenanceEventId));
+        Assert.IsTrue(logger.Entries.Any(e => e.Level == LogLevel.Trace && e.EventId.Id == 4501));
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CapturingLogger.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CapturingLogger.cs
@@ -27,7 +27,7 @@ internal sealed class CapturingLogger
 
     /// <inheritdoc />
     public bool IsEnabled(LogLevel logLevel) =>
-        true;
+        logLevel != LogLevel.None;
 
     /// <inheritdoc />
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
@@ -269,7 +269,9 @@ public sealed class EcbExchangeRateProvider
         }
 
         // Coalesce concurrent loads of the same feed so only one download is in flight; joiners await that shared task.
-        return _loadCoordinator.RunAsync(feed.Name, () => LoadFeedCoreAsync(feed, cancellationToken));
+        // The shared fetch runs under a token decoupled from any caller, so one caller's cancellation cannot fault the
+        // others; cancellationToken only abandons this caller's wait.
+        return _loadCoordinator.RunAsync(feed.Name, ct => LoadFeedCoreAsync(feed, ct), cancellationToken);
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.SingleFlight.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.SingleFlight.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using Bodu.Test;
+
 namespace Bodu.Financial.ExchangeRates.Ecb;
 
 public partial class EcbExchangeRateProviderTests
@@ -49,6 +51,36 @@ public partial class EcbExchangeRateProviderTests
         source.Release();
         await provider.LoadFeedAsync(feed);
         await provider.LoadFeedAsync(feed);
+
+        Assert.AreEqual(1, source.CallCount);
+    }
+
+    /// <summary>
+    /// Verifies that when one of several concurrent loads of the same feed cancels its token, only that caller faults
+    /// while the feed still loads for the remaining callers from the single shared fetch.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategories.Regression)]
+    public async Task LoadFeedAsync_WhenOneConcurrentCallerCancels_ShouldStillLoadForOthersAndFetchOnce()
+    {
+        EcbExchangeRateOptions options = new() { EnableDiskCache = false };
+        GatedEcbExchangeRateTableSource source = new(options);
+        EcbExchangeRateProvider provider = new(source, options);
+        EcbExchangeRateFeed feed = new("hist", "eurofxref-hist.xml", null);
+
+        using CancellationTokenSource cancellingCts = new();
+
+        Task cancelling = provider.LoadFeedAsync(feed, cancellingCts.Token);
+        Task survivor1 = provider.LoadFeedAsync(feed);
+        Task survivor2 = provider.LoadFeedAsync(feed);
+
+        await source.Entered;
+        cancellingCts.Cancel();
+        source.Release();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await cancelling);
+        await survivor1;
+        await survivor2;
 
         Assert.AreEqual(1, source.CallCount);
     }

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
@@ -262,7 +262,9 @@ public sealed class RbaExchangeRateProvider
         }
 
         // Coalesce concurrent loads of the same era so only one download is in flight; joiners await that shared task.
-        return _loadCoordinator.RunAsync(era.Label, () => LoadEraCoreAsync(era, cancellationToken));
+        // The shared fetch runs under a token decoupled from any caller, so one caller's cancellation cannot fault the
+        // others; cancellationToken only abandons this caller's wait.
+        return _loadCoordinator.RunAsync(era.Label, ct => LoadEraCoreAsync(era, ct), cancellationToken);
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.SingleFlight.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.SingleFlight.cs
@@ -52,4 +52,36 @@ public partial class RbaExchangeRateProviderTests
 
         Assert.AreEqual(1, source.CallCount);
     }
+
+    /// <summary>
+    /// Verifies that when one of several concurrent loads of the same era cancels its token, only that caller faults
+    /// while the era still loads for the remaining callers from the single shared fetch.
+    /// </summary>
+    [TestMethod]
+    public async Task LoadEraAsync_WhenOneConcurrentCallerCancels_ShouldStillLoadForOthersAndFetchOnce()
+    {
+        RbaExchangeRateOptions options = new() { EnableDiskCache = false };
+        GatedRbaExchangeRateTableSource source = new(options);
+        RbaExchangeRateProvider provider = new(source, options);
+        RbaEra era = new("2023-current", new DateOnly(2023, 1, 1), null);
+
+        using CancellationTokenSource cancellingCts = new();
+
+        // One caller cancels its wait; the other two await the same shared fetch under uncancellable tokens.
+        Task cancelling = provider.LoadEraAsync(era, cancellingCts.Token);
+        Task survivor1 = provider.LoadEraAsync(era);
+        Task survivor2 = provider.LoadEraAsync(era);
+
+        // Let the race form, cancel one caller's wait, then release the shared fetch so the survivors complete.
+        await source.Entered;
+        cancellingCts.Cancel();
+        source.Release();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await cancelling);
+        await survivor1;
+        await survivor2;
+
+        Assert.AreEqual(1, source.CallCount);
+        Assert.IsTrue(provider.TryGetRate("AUD", "USD", new DateOnly(2023, 1, 3), null, out _));
+    }
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
@@ -260,10 +260,13 @@ public sealed partial class YahooExchangeRateProvider
                 return Task.CompletedTask;
         }
 
-        // Coalesce concurrent fetches of the same pair-and-window so only one chart request is in flight.
+        // Coalesce concurrent fetches of the same pair-and-window so only one chart request is in flight. The shared
+        // fetch runs under a token decoupled from any caller, so one caller's cancellation cannot fault the others;
+        // cancellationToken only abandons this caller's wait.
         return _loadCoordinator.RunAsync(
             new PairWindow(pair, startDate, endDate),
-            () => LoadPairCoreAsync(pair, fromIsoCode, toIsoCode, startDate, endDate, cancellationToken));
+            ct => LoadPairCoreAsync(pair, fromIsoCode, toIsoCode, startDate, endDate, ct),
+            cancellationToken);
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.SingleFlight.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.SingleFlight.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using Bodu.Test;
+
 namespace Bodu.Financial.ExchangeRates.Yahoo;
 
 public partial class YahooExchangeRateProviderTests
@@ -51,6 +53,37 @@ public partial class YahooExchangeRateProviderTests
         source.Release();
         await provider.LoadPairAsync("AUD", "USD", start, end);
         await provider.LoadPairAsync("AUD", "USD", start, end);
+
+        Assert.AreEqual(1, source.CallCount);
+    }
+
+    /// <summary>
+    /// Verifies that when one of several concurrent loads of the same pair and window cancels its token, only that
+    /// caller faults while the window still loads for the remaining callers from the single shared fetch.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategories.Regression)]
+    public async Task LoadPairAsync_WhenOneConcurrentCallerCancels_ShouldStillLoadForOthersAndFetchOnce()
+    {
+        YahooExchangeRateOptions options = new();
+        GatedYahooExchangeRateChartSource source = new(options);
+        YahooExchangeRateProvider provider = new(source, options);
+        DateOnly start = new(2023, 1, 1);
+        DateOnly end = new(2023, 1, 31);
+
+        using CancellationTokenSource cancellingCts = new();
+
+        Task cancelling = provider.LoadPairAsync("AUD", "USD", start, end, cancellingCts.Token);
+        Task survivor1 = provider.LoadPairAsync("AUD", "USD", start, end);
+        Task survivor2 = provider.LoadPairAsync("AUD", "USD", start, end);
+
+        await source.Entered;
+        cancellingCts.Cancel();
+        source.Release();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await cancelling);
+        await survivor1;
+        await survivor2;
 
         Assert.AreEqual(1, source.CallCount);
     }

--- a/Bodu.Financial/src/Financial/SingleFlightCoordinator.cs
+++ b/Bodu.Financial/src/Financial/SingleFlightCoordinator.cs
@@ -17,9 +17,21 @@ namespace Bodu.Financial;
 /// <para>
 /// This is the classic single-flight (request-coalescing) pattern: when several callers request the same key while a
 /// fetch is already running, they join the running task instead of starting duplicate work. The in-flight entry is
-/// removed as soon as the task completes — including when it faults or is cancelled — so a failure never poisons the
-/// key and the next caller starts a fresh attempt. Callers that join an in-flight operation observe its outcome,
-/// including its exception.
+/// removed as soon as the operation completes — including when it faults — so a failure never poisons the key and the
+/// next caller starts a fresh attempt. Callers that join an in-flight operation observe its outcome, including its
+/// exception.
+/// </para>
+/// <para>
+/// <strong>Cancellation.</strong> The cancellation-aware overloads decouple the shared operation's lifetime from any
+/// single caller's token. Once started, the operation runs to completion and fulfills the shared promise even if every
+/// caller abandons its wait; the operation itself is invoked with <see cref="CancellationToken.None" /> because its
+/// result populates shared state for the next caller. A caller's <c>cancellationToken</c> governs only that caller's
+/// wait: when it is signalled the caller observes <see cref="OperationCanceledException" /> for itself and stops
+/// waiting, without cancelling the shared operation or affecting any other caller. This makes the coalesced work safe
+/// for idempotent cache-warming fetches, where one caller's cancellation must never fault the other joiners. A
+/// reference-counted variant that cancels the shared operation only once <em>all</em> participants have cancelled is a
+/// deliberate non-goal here. The token-less overloads carry no caller token into the operation and never cancel a
+/// caller's wait.
 /// </para>
 /// <para>
 /// A given key must always be used with the same result type. Instances are safe for concurrent use.
@@ -50,7 +62,33 @@ public sealed class SingleFlightCoordinator<TKey>
     {
         ThrowHelper.ThrowIfNull(operation);
 
-        return RunCoreAsync(key, operation);
+        return RunCoreAsync(key, _ => operation(), CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="operation" /> for <paramref name="key" />, or joins the operation already in flight for
+    /// that key, then awaits its completion, abandoning this caller's wait when <paramref name="cancellationToken" /> is
+    /// signalled.
+    /// </summary>
+    /// <param name="key">The key that identifies the operation.</param>
+    /// <param name="operation">
+    /// The asynchronous operation to run when none is in flight for <paramref name="key" />, invoked with a token
+    /// decoupled from any caller.
+    /// </param>
+    /// <param name="cancellationToken">A token that abandons this caller's wait on the shared result.</param>
+    /// <returns>A task that completes when the operation for <paramref name="key" /> completes.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="operation" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken" /> is signalled before the shared operation completes; the shared
+    /// operation continues regardless.
+    /// </exception>
+    public Task RunAsync(TKey key, Func<CancellationToken, Task> operation, CancellationToken cancellationToken)
+    {
+        ThrowHelper.ThrowIfNull(operation);
+
+        return RunCoreAsync(key, operation, cancellationToken);
     }
 
     /// <summary>
@@ -70,38 +108,121 @@ public sealed class SingleFlightCoordinator<TKey>
     {
         ThrowHelper.ThrowIfNull(operation);
 
-        return RunCoreAsync(key, operation);
+        return RunCoreAsync(key, _ => operation(), CancellationToken.None);
     }
 
     /// <summary>
-    /// Registers and runs the operation for <paramref name="key" /> when no operation is in flight, or joins and awaits
-    /// the in-flight operation otherwise.
+    /// Runs <paramref name="operation" /> for <paramref name="key" />, or joins the operation already in flight for
+    /// that key, then awaits and returns its result, abandoning this caller's wait when
+    /// <paramref name="cancellationToken" /> is signalled.
+    /// </summary>
+    /// <typeparam name="TResult">The result produced by the operation.</typeparam>
+    /// <param name="key">The key that identifies the operation.</param>
+    /// <param name="operation">
+    /// The asynchronous operation to run when none is in flight for <paramref name="key" />, invoked with a token
+    /// decoupled from any caller.
+    /// </param>
+    /// <param name="cancellationToken">A token that abandons this caller's wait on the shared result.</param>
+    /// <returns>A task that yields the result of the operation for <paramref name="key" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="operation" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when <paramref name="cancellationToken" /> is signalled before the shared operation completes; the shared
+    /// operation continues regardless.
+    /// </exception>
+    public Task<TResult> RunAsync<TResult>(TKey key, Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken)
+    {
+        ThrowHelper.ThrowIfNull(operation);
+
+        return RunCoreAsync(key, operation, cancellationToken);
+    }
+
+    /// <summary>
+    /// Registers and drives the operation for <paramref name="key" /> when no operation is in flight, or joins the
+    /// in-flight operation otherwise, then awaits the shared result under this caller's token.
     /// </summary>
     /// <param name="key">The key that identifies the operation.</param>
     /// <param name="operation">The asynchronous operation to run when this caller wins registration.</param>
-    /// <returns>A task that completes when the operation for <paramref name="key" /> completes.</returns>
-    private async Task RunCoreAsync(TKey key, Func<Task> operation)
+    /// <param name="cancellationToken">A token that abandons this caller's wait on the shared result.</param>
+    /// <returns>A task that completes when the operation for <paramref name="key" /> completes for this caller.</returns>
+    /// <remarks>
+    /// The winner starts a detached fulfillment task that runs <paramref name="operation" /> with
+    /// <see cref="CancellationToken.None" />, completes the shared promise, and removes the in-flight entry, so the
+    /// operation reaches completion for every joiner even when the winner abandons its own wait. Every caller awaits the
+    /// shared promise through <see cref="Task.WaitAsync(CancellationToken)" /> so cancellation is observed per caller and
+    /// never propagates to the shared operation.
+    /// </remarks>
+    private Task RunCoreAsync(TKey key, Func<CancellationToken, Task> operation, CancellationToken cancellationToken)
     {
         var promise = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         Task inFlight = _inFlight.GetOrAdd(key, promise.Task);
 
-        if (!ReferenceEquals(inFlight, promise.Task))
+        if (ReferenceEquals(inFlight, promise.Task))
         {
-            // Another caller registered first; join its operation and observe the shared outcome.
-            await inFlight.ConfigureAwait(false);
-            return;
+            // This caller won registration; drive the operation independently of any caller's wait so it always
+            // completes and fulfills the promise for joiners, even if every caller abandons its wait.
+            _ = FulfillAsync(key, operation, promise);
         }
 
-        // This caller won registration and owns running the operation and fulfilling the promise.
+        // Every caller — winner and joiner alike — observes only its own cancellation while awaiting the shared result.
+        return inFlight.WaitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Registers and drives the result-producing operation for <paramref name="key" /> when no operation is in flight,
+    /// or joins the in-flight operation otherwise, then awaits the shared result under this caller's token.
+    /// </summary>
+    /// <typeparam name="TResult">The result produced by the operation.</typeparam>
+    /// <param name="key">The key that identifies the operation.</param>
+    /// <param name="operation">The asynchronous operation to run when this caller wins registration.</param>
+    /// <param name="cancellationToken">A token that abandons this caller's wait on the shared result.</param>
+    /// <returns>A task that yields the result of the operation for <paramref name="key" /> for this caller.</returns>
+    /// <remarks>
+    /// The winner starts a detached fulfillment task that runs <paramref name="operation" /> with
+    /// <see cref="CancellationToken.None" />, completes the shared promise, and removes the in-flight entry, so the
+    /// operation reaches completion for every joiner even when the winner abandons its own wait. Every caller awaits the
+    /// shared promise through <see cref="Task{TResult}.WaitAsync(CancellationToken)" /> so cancellation is observed per
+    /// caller and never propagates to the shared operation. The key is bound to a single result type by contract.
+    /// </remarks>
+    private Task<TResult> RunCoreAsync<TResult>(TKey key, Func<CancellationToken, Task<TResult>> operation, CancellationToken cancellationToken)
+    {
+        var promise = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task inFlight = _inFlight.GetOrAdd(key, promise.Task);
+
+        if (ReferenceEquals(inFlight, promise.Task))
+        {
+            // This caller won registration; drive the operation independently of any caller's wait so it always
+            // completes and fulfills the promise for joiners, even if every caller abandons its wait.
+            _ = FulfillAsync(key, operation, promise);
+        }
+
+        // Every caller — winner and joiner alike — observes only its own cancellation while awaiting the shared result.
+        return ((Task<TResult>)inFlight).WaitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the operation to completion, fulfills the shared promise with its outcome, and releases the key.
+    /// </summary>
+    /// <param name="key">The key whose in-flight entry is released once the operation completes.</param>
+    /// <param name="operation">The asynchronous operation to run, invoked with <see cref="CancellationToken.None" />.</param>
+    /// <param name="promise">The shared promise every current and future joiner for the key awaits.</param>
+    /// <returns>A task that completes when the operation has completed and the promise has been fulfilled.</returns>
+    /// <remarks>
+    /// Runs detached from the winning caller's wait. The operation receives <see cref="CancellationToken.None" /> so it
+    /// runs to completion regardless of which caller cancels, and the in-flight entry is removed in the
+    /// <see langword="finally" /> block so a later call for the key starts a fresh attempt.
+    /// </remarks>
+    private async Task FulfillAsync(TKey key, Func<CancellationToken, Task> operation, TaskCompletionSource promise)
+    {
         try
         {
-            await operation().ConfigureAwait(false);
+            await operation(CancellationToken.None).ConfigureAwait(false);
             promise.SetResult();
         }
         catch (Exception ex)
         {
             promise.SetException(ex);
-            throw;
         }
         finally
         {
@@ -110,35 +231,29 @@ public sealed class SingleFlightCoordinator<TKey>
     }
 
     /// <summary>
-    /// Registers and runs the result-producing operation for <paramref name="key" /> when no operation is in flight, or
-    /// joins and awaits the in-flight operation otherwise.
+    /// Runs the result-producing operation to completion, fulfills the shared promise with its outcome, and releases
+    /// the key.
     /// </summary>
     /// <typeparam name="TResult">The result produced by the operation.</typeparam>
-    /// <param name="key">The key that identifies the operation.</param>
-    /// <param name="operation">The asynchronous operation to run when this caller wins registration.</param>
-    /// <returns>A task that yields the result of the operation for <paramref name="key" />.</returns>
-    private async Task<TResult> RunCoreAsync<TResult>(TKey key, Func<Task<TResult>> operation)
+    /// <param name="key">The key whose in-flight entry is released once the operation completes.</param>
+    /// <param name="operation">The asynchronous operation to run, invoked with <see cref="CancellationToken.None" />.</param>
+    /// <param name="promise">The shared promise every current and future joiner for the key awaits.</param>
+    /// <returns>A task that completes when the operation has completed and the promise has been fulfilled.</returns>
+    /// <remarks>
+    /// Runs detached from the winning caller's wait. The operation receives <see cref="CancellationToken.None" /> so it
+    /// runs to completion regardless of which caller cancels, and the in-flight entry is removed in the
+    /// <see langword="finally" /> block so a later call for the key starts a fresh attempt.
+    /// </remarks>
+    private async Task FulfillAsync<TResult>(TKey key, Func<CancellationToken, Task<TResult>> operation, TaskCompletionSource<TResult> promise)
     {
-        var promise = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Task inFlight = _inFlight.GetOrAdd(key, promise.Task);
-
-        if (!ReferenceEquals(inFlight, promise.Task))
-        {
-            // Another caller registered first; join its operation. The key is bound to a single result type by contract.
-            return await ((Task<TResult>)inFlight).ConfigureAwait(false);
-        }
-
-        // This caller won registration and owns running the operation and fulfilling the promise.
         try
         {
-            TResult result = await operation().ConfigureAwait(false);
+            TResult result = await operation(CancellationToken.None).ConfigureAwait(false);
             promise.SetResult(result);
-            return result;
         }
         catch (Exception ex)
         {
             promise.SetException(ex);
-            throw;
         }
         finally
         {

--- a/Bodu.Financial/test/Financial/SingleFlightCoordinatorTests.cs
+++ b/Bodu.Financial/test/Financial/SingleFlightCoordinatorTests.cs
@@ -201,4 +201,206 @@ public sealed class SingleFlightCoordinatorTests
             () => { _ = coordinator.RunAsync("key", (Func<Task<int>>)null!); },
             "operation");
     }
+
+    /// <summary>
+    /// Verifies that the cancellation-aware void overload rejects a <see langword="null" /> operation.
+    /// </summary>
+    [TestMethod]
+    public void RunAsync_WhenCancellableOperationIsNull_ShouldThrowArgumentNullException()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () => { _ = coordinator.RunAsync("key", (Func<CancellationToken, Task>)null!, CancellationToken.None); },
+            "operation");
+    }
+
+    /// <summary>
+    /// Verifies that the cancellation-aware result-producing overload rejects a <see langword="null" /> operation.
+    /// </summary>
+    [TestMethod]
+    public void RunAsync_OfTResult_WhenCancellableOperationIsNull_ShouldThrowArgumentNullException()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () => { _ = coordinator.RunAsync("key", (Func<CancellationToken, Task<int>>)null!, CancellationToken.None); },
+            "operation");
+    }
+
+    /// <summary>
+    /// Verifies that when a joiner cancels its token only that joiner observes a
+    /// <see cref="TaskCanceledException" />, while the shared operation still completes and the winner still receives its
+    /// result.
+    /// </summary>
+    [TestMethod]
+    public async Task RunAsync_WhenJoinerCancels_ShouldCancelOnlyJoinerAndStillCompleteSharedOperation()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runCount = 0;
+
+        async Task<int> Operation(CancellationToken _)
+        {
+            Interlocked.Increment(ref runCount);
+            await gate.Task;
+            return 42;
+        }
+
+        using CancellationTokenSource joinerCts = new();
+
+        // The winner registers first and runs the operation; the joiner coalesces onto the same shared task.
+        Task<int> winner = coordinator.RunAsync("key", Operation, CancellationToken.None);
+        Task<int> joiner = coordinator.RunAsync("key", Operation, joinerCts.Token);
+
+        joinerCts.Cancel();
+
+        TaskCanceledException ex = await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await joiner);
+        Assert.AreEqual(joinerCts.Token, ex.CancellationToken);
+
+        // The winner's wait is unaffected: releasing the gate lets the shared operation finish and yield its result.
+        gate.SetResult();
+        var result = await winner;
+
+        Assert.AreEqual(42, result);
+        Assert.AreEqual(1, runCount);
+    }
+
+    /// <summary>
+    /// Verifies that when the winner abandons its wait by cancelling, the shared operation still runs to completion and
+    /// a joiner receives the shared result.
+    /// </summary>
+    [TestMethod]
+    public async Task RunAsync_WhenWinnerCancelsWait_ShouldStillFulfillJoiner()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runCount = 0;
+
+        async Task<int> Operation(CancellationToken _)
+        {
+            Interlocked.Increment(ref runCount);
+            await gate.Task;
+            return 7;
+        }
+
+        using CancellationTokenSource winnerCts = new();
+
+        Task<int> winner = coordinator.RunAsync("key", Operation, winnerCts.Token);
+        Task<int> joiner = coordinator.RunAsync("key", Operation, CancellationToken.None);
+
+        // The winner abandons its wait; the detached fulfillment task must still drive the operation to completion.
+        winnerCts.Cancel();
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await winner);
+
+        gate.SetResult();
+        var result = await joiner;
+
+        Assert.AreEqual(7, result);
+        Assert.AreEqual(1, runCount);
+    }
+
+    /// <summary>
+    /// Verifies that a caller cancelling its wait does not signal the token handed to the operation, proving the shared
+    /// work is decoupled from any single caller's cancellation.
+    /// </summary>
+    [TestMethod]
+    public async Task RunAsync_WhenCallerCancels_ShouldNotSignalOperationToken()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken observedToken = default;
+
+        async Task Operation(CancellationToken operationToken)
+        {
+            observedToken = operationToken;
+            entered.TrySetResult();
+            await gate.Task;
+        }
+
+        using CancellationTokenSource winnerCts = new();
+
+        Task winner = coordinator.RunAsync("key", Operation, winnerCts.Token);
+
+        // Wait until the operation is running so the token it captured is observable, then cancel the winner's wait.
+        await entered.Task;
+        winnerCts.Cancel();
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await winner);
+
+        // The token handed to the operation is decoupled from the caller, so the caller's cancellation never reaches it.
+        Assert.IsFalse(observedToken.IsCancellationRequested);
+        Assert.AreEqual(CancellationToken.None, observedToken);
+
+        // Let the still-running shared operation finish cleanly.
+        gate.SetResult();
+    }
+
+    /// <summary>
+    /// Verifies that the cancellation-aware void overload coalesces concurrent same-key callers into a single run and
+    /// that a caller's already-cancelled token abandons only that caller's wait.
+    /// </summary>
+    [TestMethod]
+    public async Task RunAsync_WhenCancellableVoidOverloadJoinerCancels_ShouldCancelOnlyJoinerAndRunOnce()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runCount = 0;
+
+        async Task Operation(CancellationToken _)
+        {
+            Interlocked.Increment(ref runCount);
+            await gate.Task;
+        }
+
+        using CancellationTokenSource joinerCts = new();
+
+        Task winner = coordinator.RunAsync("key", Operation, CancellationToken.None);
+        Task joiner = coordinator.RunAsync("key", Operation, joinerCts.Token);
+
+        joinerCts.Cancel();
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () => await joiner);
+
+        gate.SetResult();
+        await winner;
+
+        Assert.AreEqual(1, runCount);
+    }
+
+    /// <summary>
+    /// Verifies that a faulting cancellation-aware operation propagates the same exception to every current awaiter and
+    /// releases the key so a later call runs a fresh attempt.
+    /// </summary>
+    [TestMethod]
+    public async Task RunAsync_WhenCancellableOperationFaults_ShouldPropagateToAllAndReleaseKey()
+    {
+        SingleFlightCoordinator<string> coordinator = new();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var runCount = 0;
+
+        async Task Operation(CancellationToken _)
+        {
+            Interlocked.Increment(ref runCount);
+            await gate.Task;
+            throw new InvalidOperationException("boom");
+        }
+
+        Task winner = coordinator.RunAsync("key", Operation, CancellationToken.None);
+        Task joiner = coordinator.RunAsync("key", Operation, CancellationToken.None);
+
+        gate.SetResult();
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await winner);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await joiner);
+        Assert.AreEqual(1, runCount);
+
+        var reran = false;
+        await coordinator.RunAsync("key", _ =>
+        {
+            reran = true;
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+
+        Assert.IsTrue(reran);
+    }
 }


### PR DESCRIPTION
## Summary

Extends `SingleFlightCoordinator<TKey>` with cancellation-aware overloads that decouple the shared operation's lifetime from any single caller's cancellation token. Once started, the operation runs to completion and fulfills the shared promise even if every caller abandons its wait; each caller's token governs only that caller's wait, not the shared operation itself.

## Key Changes

- **New `RunAsync` overloads**: Added four cancellation-aware methods:
  - `RunAsync(TKey, Func<CancellationToken, Task>, CancellationToken)` — void operation variant
  - `RunAsync<TResult>(TKey, Func<CancellationToken, Task<TResult>>, CancellationToken)` — result-producing variant
  - Corresponding internal `RunCoreAsync` implementations that handle both void and generic result cases

- **Decoupled operation execution**: The winner starts a detached fulfillment task that runs the operation with `CancellationToken.None`, ensuring the shared work completes regardless of caller abandonment. Every caller awaits the shared promise through `Task.WaitAsync(cancellationToken)`, so cancellation is observed per-caller and never propagates to the operation.

- **Refactored existing overloads**: The token-less `RunAsync` methods now delegate to the cancellation-aware core with `CancellationToken.None`, eliminating code duplication.

- **Comprehensive test coverage**: Added 6 new test methods validating:
  - Null-operation rejection for both cancellation-aware overloads
  - Joiner cancellation isolation (only the joiner observes `TaskCanceledException`)
  - Winner cancellation resilience (joiner still receives the shared result)
  - Operation token decoupling (caller's cancellation never signals the operation's token)
  - Void overload coalescing with selective cancellation
  - Fault propagation and key release after operation failure

- **Updated documentation**: Enhanced XML docs and class-level remarks to explain the cancellation semantics: the operation is invoked with a decoupled token, caller tokens govern only that caller's wait, and the shared work is safe for idempotent cache-warming fetches where one caller's cancellation must never fault other joiners.

- **Provider integration**: Updated `BoeExchangeRateProvider`, `YahooExchangeRateProvider`, `EcbExchangeRateProvider`, and `RbaExchangeRateProvider` to use the new cancellation-aware overloads, with corresponding regression tests verifying that one concurrent caller's cancellation does not prevent others from completing.

## Implementation Details

The core insight is that the winner detaches the fulfillment task from its own wait: the operation runs independently, completes the shared promise, and removes the in-flight entry, so joiners always receive the result even if the winner abandons its wait. This makes the pattern safe for shared cache-warming work where individual caller timeouts or cancellations must never poison the shared fetch for other participants.

https://claude.ai/code/session_01SpzaEaEnaStauXeTFv2Kxu