### PR TITLE
Mirror the cooperative write-state depth guard to the Bencode serializer

### DIFF
--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization.Converters/CollectionConverter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization.Converters/CollectionConverter.cs
@@ -81,6 +81,16 @@ internal sealed class CollectionConverter<TCollection, TElement>
     {
         ThrowHelper.ThrowIfNull(value);
 
+        BencodeWriteStack? state = writer.WriteStack;
+        if (state is { HasFailure: true })
+            return;
+
+        if (state is not null && writer.CurrentDepth >= writer.EffectiveMaxDepth)
+        {
+            state.SetFailure(string.Format(CultureInfo.CurrentCulture, BencodeResourceStrings.Op_Invalid_WriterMaxDepthExceeded, writer.EffectiveMaxDepth));
+            return;
+        }
+
         writer.WriteStartList();
         foreach (TElement element in (IEnumerable<TElement>)value)
         {
@@ -88,6 +98,8 @@ internal sealed class CollectionConverter<TCollection, TElement>
                 throw new BencodeSerializationException(BencodeResourceStrings.Op_NotSupported_NullCollectionElement);
 
             _elementConverter.WriteAsObject(writer, element, options);
+            if (state is { HasFailure: true })
+                return;
         }
 
         writer.WriteEndList();

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization.Converters/DictionaryConverter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization.Converters/DictionaryConverter.cs
@@ -100,6 +100,16 @@ internal sealed class DictionaryConverter<TDictionary, TKey, TValue>
     {
         ThrowHelper.ThrowIfNull(value);
 
+        BencodeWriteStack? state = writer.WriteStack;
+        if (state is { HasFailure: true })
+            return;
+
+        if (state is not null && writer.CurrentDepth >= writer.EffectiveMaxDepth)
+        {
+            state.SetFailure(string.Format(CultureInfo.CurrentCulture, BencodeResourceStrings.Op_Invalid_WriterMaxDepthExceeded, writer.EffectiveMaxDepth));
+            return;
+        }
+
         writer.WriteStartDictionary();
         foreach (KeyValuePair<TKey, TValue> entry in (IEnumerable<KeyValuePair<TKey, TValue>>)value)
         {
@@ -108,6 +118,8 @@ internal sealed class DictionaryConverter<TDictionary, TKey, TValue>
 
             writer.WritePropertyName(FormatKey(entry.Key));
             _valueConverter.WriteAsObject(writer, entry.Value, options);
+            if (state is { HasFailure: true })
+                return;
         }
 
         writer.WriteEndDictionary();

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization.Converters/ObjectConverter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization.Converters/ObjectConverter.cs
@@ -109,9 +109,22 @@ internal sealed class ObjectConverter<T>
         if (value is null)
             return;
 
+        BencodeWriteStack? state = writer.WriteStack;
+        if (state is { HasFailure: true })
+            return;
+
         (value as IBencodeOnSerializing)?.OnSerializing();
 
         TypeMetadata metadata = options.GetTypeMetadata(typeof(T));
+
+        // Refuse to descend past the ceiling before opening the dictionary, so the failure is recorded cooperatively
+        // and the recursion unwinds through returns rather than throwing from the deepest writer frame.
+        if (state is not null && writer.CurrentDepth >= writer.EffectiveMaxDepth)
+        {
+            state.SetFailure(string.Format(CultureInfo.CurrentCulture, BencodeResourceStrings.Op_Invalid_WriterMaxDepthExceeded, writer.EffectiveMaxDepth));
+            return;
+        }
+
         writer.WriteStartDictionary();
         foreach (PropertyMetadata property in metadata.Properties)
         {
@@ -121,6 +134,8 @@ internal sealed class ObjectConverter<T>
 
             writer.WritePropertyName(property.WireName);
             property.Converter.WriteAsObject(writer, memberValue, options);
+            if (state is { HasFailure: true })
+                return;
         }
 
         WriteExtensionData(writer, metadata, value);

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterOfT.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterOfT.cs
@@ -68,6 +68,13 @@ public abstract class BencodeConverter<T>
         Read(ref reader, typeToConvert, options);
 
     /// <inheritdoc />
-    internal sealed override void WriteAsObject(Utf8BencodeWriter writer, object? value, BencodeSerializerOptions options) =>
+    internal sealed override void WriteAsObject(Utf8BencodeWriter writer, object? value, BencodeSerializerOptions options)
+    {
+        // Once a failure has been recorded, stop dispatching so the recursion unwinds through normal returns rather
+        // than entering another converter on an exhausted stack.
+        if (writer.WriteStack is { HasFailure: true })
+            return;
+
         Write(writer, (T)value!, options);
+    }
 }

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeSerializerEngine.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeSerializerEngine.cs
@@ -35,8 +35,17 @@ internal static class BencodeSerializerEngine
         ThrowHelper.ThrowIfNull(options);
 
         options.MakeReadOnly();
+
+        // Attach the serializer write state so the converters record an over-deep graph cooperatively and unwind
+        // through returns; the single recorded failure is thrown once here, at the shallow root boundary, rather than
+        // from the deepest recursive frame.
+        var state = new BencodeWriteStack();
+        writer.AttachWriteStack(state);
+
         BencodeConverter converter = options.GetConverter(typeof(T));
         converter.WriteAsObject(writer, value, options);
+
+        state.ThrowIfFailed();
     }
 
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeWriteStack.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeWriteStack.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BencodeWriteStack.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Bencode.Serialization;
+
+/// <summary>
+/// Carries the serializer's failure state across the recursive converter calls of a single write, so an over-deep graph
+/// is reported cooperatively rather than by throwing from deep in the recursion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A container converter records an over-deep graph here and returns, instead of throwing from the deepest writer
+/// frame. The single recorded failure is thrown once by <see cref="BencodeSerializerEngine.Serialize{T}" /> after
+/// control has returned to the root, so the call stack unwinds through normal returns and cannot exhaust a constrained
+/// stack while dispatching the exception.
+/// </para>
+/// <para>
+/// Depth is intentionally <em>not</em> tracked here. The writer is the single owner of container depth (
+/// <c>Utf8BencodeWriter.CurrentDepth</c>); a converter consults it directly before opening a container, mirroring how
+/// <c>System.Text.Json</c>'s serializer reads <c>Utf8JsonWriter.CurrentDepth</c>. Unlike the TOML twin this carries no
+/// path or reference state: <see cref="BencodeSerializationException" /> has no member path, and Bencode performs no
+/// object-cycle detection.
+/// </para>
+/// </remarks>
+internal sealed class BencodeWriteStack
+{
+    /// <summary>
+    /// The first failure recorded during the write, or <see langword="null" /> while none has occurred.
+    /// </summary>
+    private BencodeSerializationException? _failure;
+
+    /// <summary>
+    /// Gets a value indicating whether a failure has been recorded, after which converters cooperatively stop work and
+    /// unwind.
+    /// </summary>
+    /// <returns><see langword="true" /> when a failure has been recorded; otherwise <see langword="false" />.</returns>
+    internal bool HasFailure => _failure is not null;
+
+    /// <summary>
+    /// Records a failure. Only the first failure is retained.
+    /// </summary>
+    /// <param name="message">The fully formatted, culture-aware failure message.</param>
+    internal void SetFailure(string message) =>
+        _failure ??= new BencodeSerializationException(message);
+
+    /// <summary>
+    /// Throws the recorded failure, if any. Called once at the root of the write after control has safely returned.
+    /// </summary>
+    /// <exception cref="BencodeSerializationException">Thrown when a failure was recorded during the write.</exception>
+    internal void ThrowIfFailed()
+    {
+        if (_failure is { } failure)
+            throw failure;
+    }
+}

--- a/Bodu.Text.Bencode/src/Text.Bencode.Writer/Utf8BencodeWriter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Writer/Utf8BencodeWriter.cs
@@ -8,6 +8,7 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Globalization;
 using System.Text;
+using Bodu.Text.Bencode.Serialization;
 
 namespace Bodu.Text.Bencode.Writer;
 
@@ -140,6 +141,30 @@ public ref struct Utf8BencodeWriter
             MaxDepth = _maxDepth,
             AllowMultipleRootValues = _allowMultipleRootValues,
         };
+
+    /// <summary>
+    /// Gets the effective maximum container nesting depth this writer enforces, after clamping to
+    /// <see cref="BencodeLimits.AbsoluteMaxDepth" />.
+    /// </summary>
+    /// <returns>The effective maximum depth.</returns>
+    internal readonly int EffectiveMaxDepth =>
+        _maxDepth;
+
+    /// <summary>
+    /// Gets the serializer write state attached to this writer, or <see langword="null" /> when the writer is used
+    /// directly rather than by the serializer.
+    /// </summary>
+    /// <returns>The attached <see cref="BencodeWriteStack" />, or <see langword="null" />.</returns>
+    internal readonly BencodeWriteStack? WriteStack =>
+        _root.WriteStack;
+
+    /// <summary>
+    /// Attaches the serializer write state to this writer so the converters can record an over-deep graph cooperatively
+    /// instead of throwing from deep in the recursion.
+    /// </summary>
+    /// <param name="state">The write state to attach.</param>
+    internal readonly void AttachWriteStack(BencodeWriteStack state) =>
+        _root.WriteStack = state;
 
     /// <summary>
     /// Writes the start of a list.
@@ -749,6 +774,13 @@ public ref struct Utf8BencodeWriter
         /// </summary>
         /// <returns><see langword="true" /> once the document's root value has begun.</returns>
         internal bool HasRootValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the serializer write state, when the writer is driven by the serializer; otherwise
+        /// <see langword="null" />.
+        /// </summary>
+        /// <returns>The attached write state, or <see langword="null" />.</returns>
+        internal BencodeWriteStack? WriteStack { get; set; }
     }
 
     /// <summary>

--- a/Bodu.Text.Bencode/test/Text.Bencode/BencodeSerializerTests.MaxDepth.cs
+++ b/Bodu.Text.Bencode/test/Text.Bencode/BencodeSerializerTests.MaxDepth.cs
@@ -91,6 +91,62 @@ public partial class BencodeSerializerTests
     }
 
     /// <summary>
+    /// Verifies that serializing lists nested far beyond the ceiling on a constrained stack throws a catchable
+    /// <see cref="BencodeSerializationException" /> rather than overflowing, confirming the collection converter detects
+    /// the ceiling cooperatively and unwinds through returns before the deep frames are entered.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenNestedListsFarExceedCapOnConstrainedStack_ShouldThrowBencodeSerializationExceptionNotOverflow()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+
+        var inner = new List<object>();
+        var current = inner;
+        for (var i = 0; i < (BencodeLimits.AbsoluteMaxDepth * 32) + 1; i++)
+        {
+            var next = new List<object>();
+            current.Add(next);
+            current = next;
+        }
+
+        var captured = RunOnConstrainedStack(() =>
+        {
+            _ = BencodeSerializer.Serialize(inner, options);
+        });
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(BencodeSerializationException), captured.GetType());
+    }
+
+    /// <summary>
+    /// Verifies that serializing dictionaries nested far beyond the ceiling on a constrained stack throws a catchable
+    /// <see cref="BencodeSerializationException" /> rather than overflowing, confirming the dictionary converter detects
+    /// the ceiling cooperatively and unwinds through returns before the deep frames are entered.
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WhenNestedDictionariesFarExceedCapOnConstrainedStack_ShouldThrowBencodeSerializationExceptionNotOverflow()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+
+        var root = new Dictionary<string, object>();
+        var current = root;
+        for (var i = 0; i < (BencodeLimits.AbsoluteMaxDepth * 32) + 1; i++)
+        {
+            var next = new Dictionary<string, object>();
+            current["child"] = next;
+            current = next;
+        }
+
+        var captured = RunOnConstrainedStack(() =>
+        {
+            _ = BencodeSerializer.Serialize(root, options);
+        });
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(BencodeSerializationException), captured.GetType());
+    }
+
+    /// <summary>
     /// Verifies that serializing a POCO graph nested no deeper than <see cref="BencodeSerializerOptions.MaxDepth" />
     /// succeeds and emits canonical bytes.
     /// </summary>
@@ -178,6 +234,104 @@ public partial class BencodeSerializerTests
         {
             options.MaxDepth = 8;
         });
+    }
+
+    /// <summary>
+    /// Verifies that deserializing a document nested beyond the absolute ceiling throws
+    /// <see cref="BencodeFormatException" /> even when the configured maximum depth is far larger, confirming the reader
+    /// clamps the caller-supplied <see cref="BencodeSerializerOptions.MaxDepth" /> to the hard ceiling.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WhenDocumentExceedsAbsoluteCapDespiteLargeMaxDepth_ShouldThrowBencodeFormatException()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+        var bytes = BuildNestedDictionaryDocument(BencodeLimits.AbsoluteMaxDepth + 1);
+
+        Assert.ThrowsExactly<BencodeFormatException>(() =>
+        {
+            _ = BencodeSerializer.Deserialize<RecursiveModel>(bytes, options);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="BencodeSerializerOptions.MaxDepth" /> larger than the absolute ceiling is still
+    /// accepted by the property, confirming the ceiling is enforced while writing or reading rather than at
+    /// configuration time.
+    /// </summary>
+    [TestMethod]
+    public void MaxDepth_WhenSetAboveAbsoluteCap_ShouldBeAccepted()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+
+        Assert.AreEqual(int.MaxValue, options.MaxDepth);
+    }
+
+    /// <summary>
+    /// Verifies that deserializing a document nested far beyond the ceiling on a constrained stack throws a catchable
+    /// <see cref="BencodeFormatException" /> rather than overflowing the call stack, confirming the reader's iterative
+    /// depth cap stops the binding recursion before the physical stack is exhausted on a modest stack budget.
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WhenDocumentFarExceedsCapOnConstrainedStack_ShouldThrowBencodeFormatExceptionNotOverflow()
+    {
+        var options = new BencodeSerializerOptions { MaxDepth = int.MaxValue };
+        var bytes = BuildNestedDictionaryDocument((BencodeLimits.AbsoluteMaxDepth * 32) + 1);
+
+        var captured = RunOnConstrainedStack(() =>
+        {
+            _ = BencodeSerializer.Deserialize<RecursiveModel>(bytes, options);
+        });
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(typeof(BencodeFormatException), captured.GetType());
+    }
+
+    /// <summary>
+    /// Runs <paramref name="work" /> on a deliberately constrained 256 KB thread stack, returning the exception it threw
+    /// or <see langword="null" /> when it completed. A process-terminating <see cref="StackOverflowException" /> cannot
+    /// be captured, so a non-null catchable result confirms the operation stayed within the stack budget.
+    /// </summary>
+    /// <param name="work">The operation to run.</param>
+    /// <returns>The captured exception, or <see langword="null" /> when the operation completed.</returns>
+    private static Exception? RunOnConstrainedStack(Action work)
+    {
+        Exception? captured = null;
+        var worker = new Thread(
+            () =>
+            {
+                try
+                {
+                    work();
+                }
+                catch (Exception ex)
+                {
+                    captured = ex;
+                }
+            },
+            maxStackSize: 256 << 10);
+
+        worker.Start();
+        worker.Join();
+
+        return captured;
+    }
+
+    /// <summary>
+    /// Builds a Bencode document of <paramref name="depth" /> nested dictionaries under a single recurring <c>Child</c>
+    /// key, used to drive the reader and binder to a controlled nesting depth.
+    /// </summary>
+    /// <param name="depth">The number of nested dictionaries to emit.</param>
+    /// <returns>The Bencode source bytes.</returns>
+    private static byte[] BuildNestedDictionaryDocument(int depth)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < depth - 1; i++)
+            builder.Append("d5:Child");
+        builder.Append("de");
+        for (var i = 0; i < depth - 1; i++)
+            builder.Append('e');
+
+        return Encoding.Latin1.GetBytes(builder.ToString());
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Mirrors the merged TOML cooperative write-state redesign (#484) to the Bencode serializer, so an over-deep object graph is reported **cooperatively** rather than by throwing from the deepest writer frame — which, on a constrained stack, can overflow while *dispatching* the exception.

This is the **depth-only subset** of the TOML change. Bencode is simpler: `BencodeSerializationException` has no member `Path`, Bencode does no object-cycle detection (per the agreed scope), and there's no per-frame catch/rethrow — so there's no path or reference state to carry.

## What changed

- **New internal `BencodeWriteStack`** — holds a single pending failure (`HasFailure`, `SetFailure`, `ThrowIfFailed`). It tracks **no depth**: converters read the writer's `CurrentDepth` directly, as `System.Text.Json` reads `Utf8JsonWriter.CurrentDepth`.
- **`Utf8BencodeWriter`** gains an internal write-state slot on `RootState` (`AttachWriteStack` / `WriteStack`) plus `EffectiveMaxDepth` (`CurrentDepth` already existed). Its `WriteStartList`/`WriteStartDictionary` depth throws remain as the backstop for direct/imperative use.
- **`ObjectConverter` / `CollectionConverter` / `DictionaryConverter`** check the ceiling **before** opening their container and record the failure into the state instead of throwing; they short-circuit on `HasFailure` after each child and unwind through returns. `BencodeConverter<T>.WriteAsObject` short-circuits once a failure is recorded.
- **`BencodeSerializerEngine.Serialize`** attaches the state and throws `ThrowIfFailed()` at the shallow root boundary.

No public API changes; same exception type and message.

## Read path

No change needed. Bencode's reader is an **iterative pull-reader** whose depth cap throws `BencodeFormatException` before the binding recursion exhausts the stack — confirmed by a constrained 256 KB-stack deserialize test (it throws cleanly, no overflow).

## Tests (recursive serialization **and** deserialization)

- Constrained-stack **serialize** tests for the **object, list, and dictionary** converter paths — all throw `BencodeSerializationException`, no overflow.
- A **deserialize clamp** test (`MaxDepth = int.MaxValue`, over-deep document → `BencodeFormatException`) and a constrained-stack **deep-deserialize** test proving the read path stays within the stack budget.
- A `MaxDepth`-accepts-large-value test.
- **925 Bencode tests pass** (full regression); full solution builds clean.

https://claude.ai/code/session_013cV8PGGMx6Q9cQx5CNXteK

---
_Generated by [Claude Code](https://claude.ai/code/session_013cV8PGGMx6Q9cQx5CNXteK)_