### PR TITLE
Fix Yahoo provider 429 by sending User-Agent on every chart request

### DIFF
--- a/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/DatedExchangeRateProviderRegistrationTests.cs
+++ b/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/DatedExchangeRateProviderRegistrationTests.cs
@@ -35,7 +35,7 @@ public sealed class DatedExchangeRateProviderRegistrationTests
             throw new NotSupportedException();
 
         /// <inheritdoc />
-        public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate) =>
+        public ExchangeRateRangeResult GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate) =>
             throw new NotSupportedException();
 
         /// <inheritdoc />
@@ -47,7 +47,7 @@ public sealed class DatedExchangeRateProviderRegistrationTests
             throw new NotSupportedException();
 
         /// <inheritdoc />
-        public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
+        public ValueTask<ExchangeRateRangeResult> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
     }
 

--- a/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/DatedExchangeRateProviderRegistrationTests.cs
+++ b/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/DatedExchangeRateProviderRegistrationTests.cs
@@ -23,6 +23,10 @@ public sealed class DatedExchangeRateProviderRegistrationTests
         : IDatedExchangeRateProvider
     {
         /// <inheritdoc />
+        public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc />
         public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
             throw new NotSupportedException();
 
@@ -31,7 +35,19 @@ public sealed class DatedExchangeRateProviderRegistrationTests
             throw new NotSupportedException();
 
         /// <inheritdoc />
-        public ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
+        public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public ValueTask<ExchangeRateLookupResult> GetRateAsync(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public ValueTask<ExchangeRateLookupResult> GetRateAsync(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
     }
 

--- a/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Financial.ExchangeRates.Boe/BoeExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="BoeExchangeRateProvider.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -16,18 +16,18 @@ namespace Bodu.Financial.ExchangeRates.Boe;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The provider implements the dated <see cref="IDatedExchangeRateProvider" /> contract (the natural fit for historical
-/// data) and the simple <see cref="IExchangeRateProvider" /> contract (returning the most recent available rate). It
-/// also exposes the asynchronous <see cref="LoadRangeAsync" /> method to warm its in-memory store, and
-/// <see cref="GetRatesAsync" /> to read a whole date range at once.
+/// The provider derives from <see cref="WebExchangeRateProvider" />, which supplies the in-memory accumulator, the
+/// immutable snapshot, the full synchronous and asynchronous lookup matrix, and ownership of the
+/// <see cref="HttpClient" /> when this provider creates one. The IADB is queried by date range, so loading is
+/// range-based: each load fetches the requested inclusive range and accumulates it. Use <see cref="LoadRangeAsync" /> to
+/// warm a range.
 /// </para>
 /// <para>
-/// Unlike a file-partitioned source, the IADB is queried by date range, so loading is range-based: each load fetches
-/// the requested inclusive range and accumulates it into an immutable <see cref="ExchangeRateBook" /> snapshot that
-/// backs the synchronous lookups. A synchronous lookup that misses an unloaded date will, when
-/// <see cref="BoeExchangeRateOptions.AllowSynchronousNetworkAccess" /> is enabled, block to download a bounded window
-/// around that date and retry. Inverse pairs, same-currency identity, and date-resolution policies are inherited from
-/// <see cref="FixedDatedExchangeRateProvider" />.
+/// <strong>HttpClient ownership.</strong> The constructor that takes only options builds and owns an
+/// <see cref="HttpClient" /> configured from <see cref="BoeEndpointOptions.UserAgent" /> and
+/// <see cref="BoeEndpointOptions.HttpTimeout" />, disposing it with the provider. The constructor that takes an
+/// <see cref="HttpClient" /> uses the caller-supplied client as-is; this is the path the dependency-injection package
+/// uses.
 /// </para>
 /// <para>
 /// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
@@ -39,7 +39,7 @@ namespace Bodu.Financial.ExchangeRates.Boe;
 /// </para>
 /// </remarks>
 public sealed class BoeExchangeRateProvider
-    : IDatedExchangeRateProvider, IExchangeRateProvider
+    : WebExchangeRateProvider
 {
     /// <summary>
     /// The provider identifier stamped on every rate this provider produces.
@@ -52,13 +52,6 @@ public sealed class BoeExchangeRateProvider
     public const string BaseCurrencyIsoCode = "GBP";
 
     /// <summary>
-    /// The tolerance, in days, used to resolve the most recent rate for the undated
-    /// <see cref="IExchangeRateProvider" /> surface; large enough to reach the start of the loaded history from the
-    /// current date.
-    /// </summary>
-    private const int LatestRateToleranceDays = 100_000;
-
-    /// <summary>
     /// The source that downloads and parses range responses.
     /// </summary>
     private readonly IBoeExchangeRateTableSource _source;
@@ -69,14 +62,9 @@ public sealed class BoeExchangeRateProvider
     private readonly BoeExchangeRateOptions _options;
 
     /// <summary>
-    /// Guards mutation of the accumulator, loaded-range list, series index, and snapshot fields.
+    /// The logger that records range downloads and on-demand network fetches.
     /// </summary>
-    private readonly object _gate = new();
-
-    /// <summary>
-    /// The accumulator into which each loaded range's observations are upserted.
-    /// </summary>
-    private readonly ExchangeRateTableBuilder _builder = new();
+    private readonly ILogger _logger;
 
     /// <summary>
     /// The inclusive ranges whose data has been loaded.
@@ -89,51 +77,39 @@ public sealed class BoeExchangeRateProvider
     private readonly Dictionary<ExchangeRatePair, BoeSeriesInfo> _series = new();
 
     /// <summary>
-    /// The current immutable book backing range queries; replaced under <see cref="_gate" /> after each load.
-    /// </summary>
-    private volatile ExchangeRateBook _book;
-
-    /// <summary>
-    /// The current immutable lookup provider; replaced under <see cref="_gate" /> after each load.
-    /// </summary>
-    private volatile FixedDatedExchangeRateProvider _snapshot;
-
-    /// <summary>
-    /// The logger that records range downloads and on-demand network fetches.
-    /// </summary>
-    private readonly ILogger _logger;
-
-    /// <summary>
-    /// The time source used to resolve the current instant for on-demand windowing and the undated lookup surface.
-    /// </summary>
-    private readonly TimeProvider _timeProvider;
-
-    /// <summary>
     /// Coalesces concurrent downloads of the same series window so a cache miss triggers at most one in-flight fetch
     /// per requested range.
     /// </summary>
     private readonly SingleFlightCoordinator<(DateOnly From, DateOnly To)> _loadCoordinator = new();
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="BoeExchangeRateProvider" /> class backed by an
+    /// <see cref="HttpClient" /> the provider creates and owns, configured from the supplied options.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
+    public BoeExchangeRateProvider(BoeExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(options, CreateOwnedClient(options), logger, timeProvider)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="BoeExchangeRateProvider" /> class backed by the IADB CSV endpoint,
-    /// queried with the supplied HTTP client.
+    /// queried with the caller-supplied HTTP client. The caller owns the client's configuration and lifetime.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to download range responses.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records range downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for on-demand windowing and the undated lookup surface.
-    /// <see langword="null" /> selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     public BoeExchangeRateProvider(HttpClient httpClient, BoeExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
-        : this(CreateSource(httpClient, options), options, logger, timeProvider)
+        : this(CreateSource(httpClient, options), options, ownedHttpClient: null, logger, timeProvider)
     {
     }
 
@@ -143,19 +119,46 @@ public sealed class BoeExchangeRateProvider
     /// </summary>
     /// <param name="source">The table source.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records range downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for on-demand windowing and the undated lookup surface.
-    /// <see langword="null" /> selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     internal BoeExchangeRateProvider(IBoeExchangeRateTableSource source, BoeExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(source, options, ownedHttpClient: null, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoeExchangeRateProvider" /> class from an owned client, building the
+    /// table source over it before forwarding to the core constructor.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The HTTP client this provider creates and owns.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private BoeExchangeRateProvider(BoeExchangeRateOptions options, HttpClient ownedHttpClient, ILogger? logger, TimeProvider? timeProvider)
+        : this(CreateSource(ownedHttpClient, options), options, ownedHttpClient, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoeExchangeRateProvider" /> class, the shared core all public and
+    /// internal constructors funnel through.
+    /// </summary>
+    /// <param name="source">The table source.</param>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The owned client to dispose with the provider, or <see langword="null" />.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private BoeExchangeRateProvider(
+        IBoeExchangeRateTableSource source,
+        BoeExchangeRateOptions options,
+        HttpClient? ownedHttpClient,
+        ILogger? logger,
+        TimeProvider? timeProvider)
+        : base(ownedHttpClient, timeProvider)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -164,73 +167,16 @@ public sealed class BoeExchangeRateProvider
         _source = source;
         _options = options;
         _logger = logger ?? NullLogger.Instance;
-        _timeProvider = timeProvider ?? TimeProvider.System;
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
 
-    /// <summary>
-    /// Resolves the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, throwing when none is available.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <returns>The resolved <see cref="ExchangeRateLookupResult" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the request.</exception>
-    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
-        TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
-            ? result
-            : throw new KeyNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, BoeResourceStrings.IO_KeyNotFound_BoeRate, fromIsoCode, toIsoCode, date));
+    /// <inheritdoc />
+    protected override string ProviderId => ProviderName;
 
-    /// <summary>
-    /// Attempts to resolve the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, loading a bounded window around the date on demand when permitted.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <param name="result">
-    /// When this method returns <see langword="true" />, the resolved result; otherwise <see langword="default" />.
-    /// </param>
-    /// <returns><see langword="true" /> when a rate was resolved; otherwise <see langword="false" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    public bool TryGetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, out ExchangeRateLookupResult result)
-    {
-        if (_snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
-            return true;
+    /// <inheritdoc />
+    protected override bool AllowSynchronousNetworkAccess => _options.AllowSynchronousNetworkAccess;
 
-        if (_options.AllowSynchronousNetworkAccess && TryLoadWindowForDate(date))
-            return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
-
-        result = default;
-        return false;
-    }
-
-    /// <summary>
-    /// Gets the most recent available rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" />.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <returns>The multiplier converting one unit of the source currency to the destination currency.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the pair.</exception>
-    public decimal GetRate(string fromIsoCode, string toIsoCode)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        return GetRate(fromIsoCode, toIsoCode, today, ExchangeRateLookupOptions.PreviousWithin(LatestRateToleranceDays)).Rate.Rate;
-    }
+    /// <inheritdoc />
+    protected override TimeSpan DefaultLookback => TimeSpan.FromDays(_options.OnDemandWindowDays);
 
     /// <summary>
     /// Downloads and loads the inclusive date range, unless it is already covered by a previous load.
@@ -244,95 +190,10 @@ public sealed class BoeExchangeRateProvider
     /// </exception>
     public Task LoadRangeAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
     {
-        ThrowIfRangeInverted(startDate, endDate);
+        if (endDate < startDate)
+            throw CreateRangeInvertedException(startDate, endDate);
 
-        lock (_gate)
-        {
-            if (IsRangeCovered(startDate, endDate))
-                return Task.CompletedTask;
-        }
-
-        // Coalesce concurrent loads of the same window so only one download is in flight; joiners await that task.
-        return _loadCoordinator.RunAsync((startDate, endDate), () => LoadRangeCoreAsync(startDate, endDate, cancellationToken));
-    }
-
-    /// <summary>
-    /// Downloads and stores a single range, re-checking coverage inside the single-flight section so a joiner that
-    /// arrives after a prior load completes does no redundant work.
-    /// </summary>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
-    /// <returns>A task that completes when the range has been loaded.</returns>
-    private async Task LoadRangeCoreAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
-    {
-        lock (_gate)
-        {
-            if (IsRangeCovered(startDate, endDate))
-                return;
-        }
-
-        Log.FeedLoadStarting(_logger, _options.DownloadStartingLogLevel, startDate, endDate);
-
-        BoeExchangeRateTable table;
-        try
-        {
-            table = await _source.GetTableAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Log.FeedLoadFailed(_logger, _options.DownloadFailedLogLevel, startDate, endDate, ex);
-            throw;
-        }
-
-        lock (_gate)
-        {
-            var count = Accumulate(table);
-            _loadedRanges.Add((startDate, endDate));
-            RebuildSnapshot();
-            Log.FeedLoaded(_logger, _options.DownloadCompletedLogLevel, startDate, endDate, count);
-        }
-    }
-
-    /// <summary>
-    /// Reads every available rate for a pair within the inclusive date range, loading the range first.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code; one side of the pair must be <c>GBP</c>.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code; one side of the pair must be <c>GBP</c>.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
-    /// <returns>A task that yields the rates in the range, ordered by date.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="BoeExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    /// <exception cref="BoeExchangeRateSeriesNotFoundException">
-    /// Thrown when neither side of the pair is <c>GBP</c>.
-    /// </exception>
-    public async ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
-        string fromIsoCode,
-        string toIsoCode,
-        DateOnly startDate,
-        DateOnly endDate,
-        CancellationToken cancellationToken = default)
-    {
-        ThrowHelper.ThrowIfNull(fromIsoCode);
-        ThrowHelper.ThrowIfNull(toIsoCode);
-        ThrowIfRangeInverted(startDate, endDate);
-
-        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-        if (!string.Equals(fromIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal) &&
-            !string.Equals(toIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal))
-        {
-            throw new BoeExchangeRateSeriesNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, BoeResourceStrings.IO_KeyNotFound_BoeSeries, fromIsoCode, toIsoCode));
-        }
-
-        await LoadRangeAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
-
-        return CollectRates(pair, startDate, endDate);
+        return LoadRangeInternalAsync(startDate, endDate, cancellationToken);
     }
 
     /// <summary>
@@ -341,11 +202,48 @@ public sealed class BoeExchangeRateProvider
     /// <returns>A snapshot of the discovered series, one per currency pair.</returns>
     public IReadOnlyCollection<BoeSeriesInfo> GetAvailablePairs()
     {
-        lock (_gate)
+        lock (SyncRoot)
         {
             return _series.Values.ToArray();
         }
     }
+
+    /// <inheritdoc />
+    protected override ValueTask EnsureLoadedAsync(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken) =>
+        new(LoadRangeInternalAsync(startDate, endDate, cancellationToken));
+
+    /// <inheritdoc />
+    protected override bool IsLoaded(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
+    {
+        lock (SyncRoot)
+        {
+            return IsRangeCovered(startDate, endDate);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateRangeRequest(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+        if (!string.Equals(fromIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal) &&
+            !string.Equals(toIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal))
+        {
+            throw new BoeExchangeRateSeriesNotFoundException(
+                string.Format(CultureInfo.CurrentCulture, BoeResourceStrings.IO_KeyNotFound_BoeSeries, fromIsoCode, toIsoCode));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnObservationIngested(ExchangeRate rate) =>
+        Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+
+    /// <inheritdoc />
+    protected override Exception CreateRangeInvertedException(DateOnly startDate, DateOnly endDate) =>
+        new BoeExchangeRateDateRangeException(
+            string.Format(CultureInfo.CurrentCulture, BoeResourceStrings.Arg_OutOfRange_BoeDateRange, startDate, endDate));
+
+    /// <inheritdoc />
+    protected override string FormatRateNotFound(string fromIsoCode, string toIsoCode, DateOnly date) =>
+        string.Format(CultureInfo.CurrentCulture, BoeResourceStrings.IO_KeyNotFound_BoeRate, fromIsoCode, toIsoCode, date);
 
     /// <summary>
     /// Builds the default IADB CSV table source from the supplied client and options.
@@ -367,24 +265,82 @@ public sealed class BoeExchangeRateProvider
     }
 
     /// <summary>
-    /// Throws when an inclusive date range is inverted.
+    /// Builds the <see cref="HttpClient" /> this provider owns, configured with the endpoint's user agent and timeout.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <returns>A new, configured client owned by the provider.</returns>
+    private static HttpClient CreateOwnedClient(BoeExchangeRateOptions options)
+    {
+        ThrowHelper.ThrowIfNull(options);
+        options.Validate();
+
+        return ExchangeRateHttpClientFactory.Create(options.Endpoint.UserAgent, options.Endpoint.HttpTimeout);
+    }
+
+    /// <summary>
+    /// Loads the inclusive date range, coalescing concurrent loads of the same window and skipping a covered range.
     /// </summary>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
-    /// <exception cref="BoeExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    private static void ThrowIfRangeInverted(DateOnly startDate, DateOnly endDate)
+    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
+    /// <returns>A task that completes when the range has been loaded.</returns>
+    private Task LoadRangeInternalAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
     {
-        if (endDate < startDate)
+        lock (SyncRoot)
         {
-            throw new BoeExchangeRateDateRangeException(
-                string.Format(CultureInfo.CurrentCulture, BoeResourceStrings.Arg_OutOfRange_BoeDateRange, startDate, endDate));
+            if (IsRangeCovered(startDate, endDate))
+                return Task.CompletedTask;
+        }
+
+        // Coalesce concurrent loads of the same window so only one download is in flight; joiners await that task.
+        return _loadCoordinator.RunAsync((startDate, endDate), () => LoadRangeCoreAsync(startDate, endDate, cancellationToken));
+    }
+
+    /// <summary>
+    /// Downloads and stores a single range, re-checking coverage inside the single-flight section so a joiner that
+    /// arrives after a prior load completes does no redundant work.
+    /// </summary>
+    /// <param name="startDate">The inclusive start of the range.</param>
+    /// <param name="endDate">The inclusive end of the range.</param>
+    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
+    /// <returns>A task that completes when the range has been loaded.</returns>
+    private async Task LoadRangeCoreAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
+    {
+        lock (SyncRoot)
+        {
+            if (IsRangeCovered(startDate, endDate))
+                return;
+        }
+
+        Log.FeedLoadStarting(_logger, _options.DownloadStartingLogLevel, startDate, endDate);
+
+        BoeExchangeRateTable table;
+        try
+        {
+            table = await _source.GetTableAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.FeedLoadFailed(_logger, _options.DownloadFailedLogLevel, startDate, endDate, ex);
+            throw;
+        }
+
+        lock (SyncRoot)
+        {
+            foreach (BoeSeriesInfo info in table.GetSeriesInfo())
+                _series[info.Pair] = info;
+
+            var count = AddObservations(table.EnumerateRates());
+            _loadedRanges.Add((startDate, endDate));
+            RebuildSnapshot();
+
+            Log.FeedLoaded(_logger, _options.DownloadCompletedLogLevel, startDate, endDate, count);
         }
     }
 
     /// <summary>
-    /// Determines whether an inclusive range is already contained within a single previously loaded range.
+    /// Determines whether an inclusive range is already contained within a single previously loaded range. The caller
+    /// must hold <see cref="WebExchangeRateProvider.SyncRoot" />.
     /// </summary>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
@@ -401,104 +357,5 @@ public sealed class BoeExchangeRateProvider
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Upserts a parsed table's observations and series metadata into the accumulator.
-    /// </summary>
-    /// <param name="table">The parsed table.</param>
-    /// <returns>The number of rate observations upserted.</returns>
-    private int Accumulate(BoeExchangeRateTable table)
-    {
-        foreach (BoeSeriesInfo info in table.GetSeriesInfo())
-            _series[info.Pair] = info;
-
-        var count = 0;
-        foreach (ExchangeRate rate in table.EnumerateRates())
-        {
-            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
-            count++;
-        }
-
-        return count;
-    }
-
-    /// <summary>
-    /// Rebuilds the immutable book and lookup snapshot from the accumulator.
-    /// </summary>
-    private void RebuildSnapshot()
-    {
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
-    }
-
-    /// <summary>
-    /// Synchronously loads a bounded window around a date when it is not already covered, for the on-demand lookup
-    /// path.
-    /// </summary>
-    /// <param name="date">The date whose surrounding window should be loaded.</param>
-    /// <returns>
-    /// <see langword="true" /> when a load was attempted; <see langword="false" /> when the window is empty or already
-    /// covered.
-    /// </returns>
-    private bool TryLoadWindowForDate(DateOnly date)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        var window = _options.OnDemandWindowDays;
-
-        var from = date.AddDays(-window);
-        var to = date.AddDays(window);
-        if (to > today)
-            to = today;
-
-        if (to < from)
-            return false;
-
-        lock (_gate)
-        {
-            if (IsRangeCovered(from, to))
-                return false;
-        }
-
-        // Intentional opt-in synchronous fetch on the lookup path, gated by AllowSynchronousNetworkAccess.
-#pragma warning disable VSTHRD002
-        LoadRangeAsync(from, to).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
-        return true;
-    }
-
-    /// <summary>
-    /// Collects the rates for a pair within a date range from the current book, inverting the reverse series when only
-    /// it is available.
-    /// </summary>
-    /// <param name="pair">The requested pair.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <returns>The rates in the range, ordered by date.</returns>
-    private List<ExchangeRate> CollectRates(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
-    {
-        ExchangeRateBook book = _book;
-        List<ExchangeRate> result = new();
-
-        if (book.TryGetSeries(pair, ProviderName, out ExchangeRateSeries? series) && series is not null)
-        {
-            foreach (ExchangeRateObservation observation in series.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, observation.Rate, ProviderName));
-            }
-        }
-        else if (book.TryGetSeries(pair.Inverse(), ProviderName, out ExchangeRateSeries? inverse) && inverse is not null)
-        {
-            foreach (ExchangeRateObservation observation in inverse.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, 1m / observation.Rate, ProviderName, isInverted: true));
-            }
-        }
-
-        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
-        return result;
     }
 }

--- a/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.GetRatesAsync.cs
@@ -20,7 +20,7 @@ public partial class BoeExchangeRateProviderTests
         (BoeExchangeRateProvider provider, _) = Create(allowSync: false);
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("GBP", "JPY", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31));
+            [.. await provider.GetRatesAsync("GBP", "JPY", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.AreEqual(new DateOnly(2023, 1, 3), rates[0].Date);
@@ -38,7 +38,7 @@ public partial class BoeExchangeRateProviderTests
         (BoeExchangeRateProvider provider, _) = Create(allowSync: false);
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("JPY", "GBP", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31));
+            [.. await provider.GetRatesAsync("JPY", "GBP", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.IsTrue(rates[0].IsInverted);

--- a/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.TimeProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.TimeProvider.cs
@@ -21,7 +21,7 @@ public partial class BoeExchangeRateProviderTests
         BoeExchangeRateProvider provider = new(source, options, logger: null, timeProvider);
         await provider.LoadRangeAsync(new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31));
 
-        var rate = provider.GetRate("GBP", "USD");
+        var rate = provider.GetRate("GBP", "USD").Rate.Rate;
 
         Assert.AreEqual(1.2065m, rate);
     }

--- a/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.cs
+++ b/Bodu.Financial.ExchangeRates.Boe/test/Financial.ExchangeRates.Boe/BoeExchangeRateProviderTests.cs
@@ -118,7 +118,7 @@ public partial class BoeExchangeRateProviderTests
     {
         BoeExchangeRateProvider provider = await CreatePreloadedAsync();
 
-        var latest = provider.GetRate("GBP", "USD");
+        var latest = provider.GetRate("GBP", "USD").Rate.Rate;
 
         Assert.AreEqual(1.2050m, latest);
     }

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Financial.ExchangeRates.Caching.DependencyInjection/ExchangeRateCachingServiceBuilderExtensionsTests.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Financial.ExchangeRates.Caching.DependencyInjection/ExchangeRateCachingServiceBuilderExtensionsTests.cs
@@ -182,7 +182,7 @@ public sealed partial class ExchangeRateCachingServiceBuilderExtensionsTests
             Inner.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
 
         /// <inheritdoc />
-        public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate) =>
+        public ExchangeRateRangeResult GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate) =>
             Inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate);
 
         /// <inheritdoc />
@@ -194,7 +194,7 @@ public sealed partial class ExchangeRateCachingServiceBuilderExtensionsTests
             Inner.GetRateAsync(fromIsoCode, toIsoCode, date, options, cancellationToken);
 
         /// <inheritdoc />
-        public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
+        public ValueTask<ExchangeRateRangeResult> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
             Inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken);
     }
 }

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Financial.ExchangeRates.Caching.DependencyInjection/ExchangeRateCachingServiceBuilderExtensionsTests.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Financial.ExchangeRates.Caching.DependencyInjection/ExchangeRateCachingServiceBuilderExtensionsTests.cs
@@ -170,6 +170,10 @@ public sealed partial class ExchangeRateCachingServiceBuilderExtensionsTests
             new(new[] { new ExchangeRate("AUD", "USD", new DateOnly(2023, 1, 3), 0.5m, "RBA") });
 
         /// <inheritdoc />
+        public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null) =>
+            Inner.GetRate(fromIsoCode, toIsoCode, options);
+
+        /// <inheritdoc />
         public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
             Inner.GetRate(fromIsoCode, toIsoCode, date, options);
 
@@ -178,7 +182,19 @@ public sealed partial class ExchangeRateCachingServiceBuilderExtensionsTests
             Inner.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
 
         /// <inheritdoc />
-        public ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
+        public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate) =>
+            Inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate);
+
+        /// <inheritdoc />
+        public ValueTask<ExchangeRateLookupResult> GetRateAsync(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null, CancellationToken cancellationToken = default) =>
+            Inner.GetRateAsync(fromIsoCode, toIsoCode, options, cancellationToken);
+
+        /// <inheritdoc />
+        public ValueTask<ExchangeRateLookupResult> GetRateAsync(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null, CancellationToken cancellationToken = default) =>
+            Inner.GetRateAsync(fromIsoCode, toIsoCode, date, options, cancellationToken);
+
+        /// <inheritdoc />
+        public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
             Inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken);
     }
 }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AggregatingExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AggregatingExchangeRateProvider.cs
@@ -182,6 +182,13 @@ public sealed class AggregatingExchangeRateProvider
     }
 
     /// <inheritdoc />
+    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null)
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+        return GetRate(fromIsoCode, toIsoCode, today, options ?? _options.DefaultLookupOptions);
+    }
+
+    /// <inheritdoc />
     public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null)
     {
         return TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
@@ -189,6 +196,23 @@ public sealed class AggregatingExchangeRateProvider
             : throw new KeyNotFoundException(
                 string.Format(CultureInfo.CurrentCulture, CachingResourceStrings.IO_KeyNotFound_ExchangeRate, fromIsoCode, toIsoCode, date));
     }
+
+    /// <inheritdoc />
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        new(GetRate(fromIsoCode, toIsoCode, options));
+
+    /// <inheritdoc />
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly date,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        new(GetRate(fromIsoCode, toIsoCode, date, options));
 
     /// <inheritdoc />
     public bool TryGetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, out ExchangeRateLookupResult result)
@@ -227,7 +251,15 @@ public sealed class AggregatingExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
+    public IEnumerable<ExchangeRateLookupResult> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+#pragma warning disable VSTHRD002 // The aggregation strategy exposes range combination only asynchronously.
+        return GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -246,16 +278,12 @@ public sealed class AggregatingExchangeRateProvider
             Log.RouteSelected(_logger, _options.RouteSelectedLogLevel, fromIsoCode, toIsoCode, providerOrder);
         }
 
-        return strategy.AggregateRangeAsync(fromIsoCode, toIsoCode, startDate, endDate, candidates, cancellationToken);
+        return await strategy.AggregateRangeAsync(fromIsoCode, toIsoCode, startDate, endDate, candidates, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public decimal GetRate(string fromIsoCode, string toIsoCode)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-
-        return new DatedExchangeRateProviderAdapter(this, today, _options.DefaultLookupOptions).GetRate(fromIsoCode, toIsoCode);
-    }
+    decimal IExchangeRateProvider.GetRate(string fromIsoCode, string toIsoCode) =>
+        GetRate(fromIsoCode, toIsoCode).Rate.Rate;
 
     /// <summary>
     /// Resolves the candidate set and strategy for a pair, preferring a direct route, then an inverse route (when

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AggregatingExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AggregatingExchangeRateProvider.cs
@@ -251,7 +251,7 @@ public sealed class AggregatingExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRateLookupResult> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
 #pragma warning disable VSTHRD002 // The aggregation strategy exposes range combination only asynchronously.
         return GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, CancellationToken.None).AsTask().GetAwaiter().GetResult();
@@ -259,7 +259,7 @@ public sealed class AggregatingExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+    public async ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AggregatingExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AggregatingExchangeRateProvider.cs
@@ -251,7 +251,7 @@ public sealed class AggregatingExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public ExchangeRateRangeResult GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
 #pragma warning disable VSTHRD002 // The aggregation strategy exposes range combination only asynchronously.
         return GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, CancellationToken.None).AsTask().GetAwaiter().GetResult();
@@ -259,7 +259,7 @@ public sealed class AggregatingExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
+    public async ValueTask<ExchangeRateRangeResult> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -278,7 +278,9 @@ public sealed class AggregatingExchangeRateProvider
             Log.RouteSelected(_logger, _options.RouteSelectedLogLevel, fromIsoCode, toIsoCode, providerOrder);
         }
 
-        return await strategy.AggregateRangeAsync(fromIsoCode, toIsoCode, startDate, endDate, candidates, cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<ExchangeRate> rates =
+            await strategy.AggregateRangeAsync(fromIsoCode, toIsoCode, startDate, endDate, candidates, cancellationToken).ConfigureAwait(false);
+        return new ExchangeRateRangeResult(fromIsoCode, toIsoCode, startDate, endDate, rates);
     }
 
     /// <inheritdoc />

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AverageStrategy.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AverageStrategy.cs
@@ -99,7 +99,7 @@ public sealed class AverageStrategy
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(
+    public async ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -110,22 +110,22 @@ public sealed class AverageStrategy
         ThrowHelper.ThrowIfNull(candidates);
 
         if (candidates.Count == 0)
-            return Array.Empty<ExchangeRateLookupResult>();
+            return Array.Empty<ExchangeRate>();
 
         // Gather each candidate's observations keyed by date; the last observation wins for a duplicated date.
         List<Dictionary<DateOnly, decimal>> perCandidate = new(candidates.Count);
         foreach (NamedDatedExchangeRateProvider candidate in candidates)
         {
-            IEnumerable<ExchangeRateLookupResult> rates =
+            IEnumerable<ExchangeRate> rates =
                 await candidate.Provider.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false);
 
             Dictionary<DateOnly, decimal> byDate = new();
-            foreach (ExchangeRateLookupResult rate in rates)
-                byDate[rate.Rate.Date] = rate.Rate.Rate;
+            foreach (ExchangeRate rate in rates)
+                byDate[rate.Date] = rate.Rate;
 
             // A missing or empty candidate makes the inner join empty; return early.
             if (byDate.Count == 0)
-                return Array.Empty<ExchangeRateLookupResult>();
+                return Array.Empty<ExchangeRate>();
 
             perCandidate.Add(byDate);
         }
@@ -138,7 +138,7 @@ public sealed class AverageStrategy
                 smallest = perCandidate[i];
         }
 
-        List<ExchangeRateLookupResult> result = new(smallest.Count);
+        List<ExchangeRate> result = new(smallest.Count);
         foreach (DateOnly date in smallest.Keys)
         {
             var sum = 0m;
@@ -156,13 +156,10 @@ public sealed class AverageStrategy
             }
 
             if (present)
-            {
-                ExchangeRate averaged = new(fromIsoCode, toIsoCode, date, sum / perCandidate.Count, _providerLabel);
-                result.Add(new ExchangeRateLookupResult(averaged, date, ExchangeRateDateResolution.Exact, 0));
-            }
+                result.Add(new ExchangeRate(fromIsoCode, toIsoCode, date, sum / perCandidate.Count, _providerLabel));
         }
 
-        result.Sort(static (left, right) => left.Rate.Date.CompareTo(right.Rate.Date));
+        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
         return result;
     }
 }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AverageStrategy.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/AverageStrategy.cs
@@ -99,7 +99,7 @@ public sealed class AverageStrategy
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(
+    public async ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -110,22 +110,22 @@ public sealed class AverageStrategy
         ThrowHelper.ThrowIfNull(candidates);
 
         if (candidates.Count == 0)
-            return Array.Empty<ExchangeRate>();
+            return Array.Empty<ExchangeRateLookupResult>();
 
         // Gather each candidate's observations keyed by date; the last observation wins for a duplicated date.
         List<Dictionary<DateOnly, decimal>> perCandidate = new(candidates.Count);
         foreach (NamedDatedExchangeRateProvider candidate in candidates)
         {
-            IReadOnlyList<ExchangeRate> rates =
+            IEnumerable<ExchangeRateLookupResult> rates =
                 await candidate.Provider.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false);
 
-            Dictionary<DateOnly, decimal> byDate = new(rates.Count);
-            foreach (ExchangeRate rate in rates)
-                byDate[rate.Date] = rate.Rate;
+            Dictionary<DateOnly, decimal> byDate = new();
+            foreach (ExchangeRateLookupResult rate in rates)
+                byDate[rate.Rate.Date] = rate.Rate.Rate;
 
             // A missing or empty candidate makes the inner join empty; return early.
             if (byDate.Count == 0)
-                return Array.Empty<ExchangeRate>();
+                return Array.Empty<ExchangeRateLookupResult>();
 
             perCandidate.Add(byDate);
         }
@@ -138,7 +138,7 @@ public sealed class AverageStrategy
                 smallest = perCandidate[i];
         }
 
-        List<ExchangeRate> result = new(smallest.Count);
+        List<ExchangeRateLookupResult> result = new(smallest.Count);
         foreach (DateOnly date in smallest.Keys)
         {
             var sum = 0m;
@@ -156,10 +156,13 @@ public sealed class AverageStrategy
             }
 
             if (present)
-                result.Add(new ExchangeRate(fromIsoCode, toIsoCode, date, sum / perCandidate.Count, _providerLabel));
+            {
+                ExchangeRate averaged = new(fromIsoCode, toIsoCode, date, sum / perCandidate.Count, _providerLabel);
+                result.Add(new ExchangeRateLookupResult(averaged, date, ExchangeRateDateResolution.Exact, 0));
+            }
         }
 
-        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
+        result.Sort(static (left, right) => left.Rate.Date.CompareTo(right.Rate.Date));
         return result;
     }
 }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
@@ -166,7 +166,7 @@ public abstract class CachingExchangeRateProviderBase
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRateLookupResult> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
         if (endDate < startDate)
             throw new ArgumentException(CachingResourceStrings.Arg_Invalid_RangeInverted, nameof(endDate));
@@ -175,18 +175,18 @@ public abstract class CachingExchangeRateProviderBase
         var now = _timeProvider.GetUtcNow();
         var duration = _options.GetExpiry(_cache.Provider);
 
-        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRateLookupResult> cached))
+        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
         {
             Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
             return cached;
         }
 
-        IReadOnlyList<ExchangeRateLookupResult> fetched = [.. Inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate)];
+        IReadOnlyList<ExchangeRate> fetched = [.. Inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate)];
         return StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode);
     }
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+    public async ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -200,13 +200,13 @@ public abstract class CachingExchangeRateProviderBase
         var now = _timeProvider.GetUtcNow();
         var duration = _options.GetExpiry(_cache.Provider);
 
-        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRateLookupResult> cached))
+        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
         {
             Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
             return cached;
         }
 
-        IReadOnlyList<ExchangeRateLookupResult> fetched =
+        IReadOnlyList<ExchangeRate> fetched =
             [.. await Inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false)];
         return StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode);
     }
@@ -228,18 +228,18 @@ public abstract class CachingExchangeRateProviderBase
     /// <param name="fromIsoCode">The source-currency ISO code, for diagnostics.</param>
     /// <param name="toIsoCode">The destination-currency ISO code, for diagnostics.</param>
     /// <returns>The stored range, or an empty sequence when <paramref name="fetched" /> is empty.</returns>
-    private IReadOnlyList<ExchangeRateLookupResult> StoreFetchedRange(
+    private IReadOnlyList<ExchangeRate> StoreFetchedRange(
         TimeSpan duration,
         ExchangeRatePair pair,
         DateOnly startDate,
         DateOnly endDate,
-        IReadOnlyList<ExchangeRateLookupResult> fetched,
+        IReadOnlyList<ExchangeRate> fetched,
         DateTimeOffset now,
         string fromIsoCode,
         string toIsoCode)
     {
         if (fetched.Count == 0)
-            return Array.Empty<ExchangeRateLookupResult>();
+            return Array.Empty<ExchangeRate>();
 
         StoreRange(duration, pair, fetched, now);
 
@@ -307,25 +307,22 @@ public abstract class CachingExchangeRateProviderBase
     /// <returns>
     /// <see langword="true" /> when the range was satisfied from the cache; otherwise <see langword="false" />.
     /// </returns>
-    private bool TryServeRangeFromCache(TimeSpan duration, ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, DateTimeOffset now, out IReadOnlyList<ExchangeRateLookupResult> result)
+    private bool TryServeRangeFromCache(TimeSpan duration, ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, DateTimeOffset now, out IReadOnlyList<ExchangeRate> result)
     {
         // The fresh coverage, not the span of the rate rows, decides whether the whole window was actually fetched.
         if (!_cache.GetCoverage(pair, duration, now).Contains(startDate, endDate))
         {
-            result = Array.Empty<ExchangeRateLookupResult>();
+            result = Array.Empty<ExchangeRate>();
             return false;
         }
 
         var provider = _cache.Provider;
         IReadOnlyList<CachedExchangeRate> fresh = _cache.GetRates(pair, duration, now);
-        List<ExchangeRateLookupResult> rates = new();
+        List<ExchangeRate> rates = new();
         foreach (CachedExchangeRate rate in fresh)
         {
             if (rate.Date >= startDate && rate.Date <= endDate)
-            {
-                ExchangeRate observed = new(pair.FromIsoCode, pair.ToIsoCode, rate.Date, rate.Rate, provider);
-                rates.Add(new ExchangeRateLookupResult(observed, rate.Date, ExchangeRateDateResolution.Exact, 0));
-            }
+                rates.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, rate.Date, rate.Rate, provider));
         }
 
         result = rates;
@@ -354,11 +351,11 @@ public abstract class CachingExchangeRateProviderBase
     /// <param name="pair">The requested currency pair.</param>
     /// <param name="rates">The rates returned by the inner provider.</param>
     /// <param name="now">The instant to stamp the cached rows with.</param>
-    private void StoreRange(TimeSpan duration, ExchangeRatePair pair, IReadOnlyList<ExchangeRateLookupResult> rates, DateTimeOffset now)
+    private void StoreRange(TimeSpan duration, ExchangeRatePair pair, IReadOnlyList<ExchangeRate> rates, DateTimeOffset now)
     {
         var rows = new CachedExchangeRate[rates.Count];
         for (var i = 0; i < rates.Count; i++)
-            rows[i] = new CachedExchangeRate(rates[i].Rate.Date, rates[i].Rate.Rate, now);
+            rows[i] = new CachedExchangeRate(rates[i].Date, rates[i].Rate, now);
 
         _cache.Store(pair, rows, duration, now);
     }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
@@ -166,7 +166,7 @@ public abstract class CachingExchangeRateProviderBase
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public ExchangeRateRangeResult GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
         if (endDate < startDate)
             throw new ArgumentException(CachingResourceStrings.Arg_Invalid_RangeInverted, nameof(endDate));
@@ -178,15 +178,16 @@ public abstract class CachingExchangeRateProviderBase
         if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
         {
             Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
-            return cached;
+            return new ExchangeRateRangeResult(fromIsoCode, toIsoCode, startDate, endDate, cached);
         }
 
         IReadOnlyList<ExchangeRate> fetched = [.. Inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate)];
-        return StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode);
+        return new ExchangeRateRangeResult(
+            fromIsoCode, toIsoCode, startDate, endDate, StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode));
     }
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
+    public async ValueTask<ExchangeRateRangeResult> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -203,12 +204,13 @@ public abstract class CachingExchangeRateProviderBase
         if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
         {
             Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
-            return cached;
+            return new ExchangeRateRangeResult(fromIsoCode, toIsoCode, startDate, endDate, cached);
         }
 
         IReadOnlyList<ExchangeRate> fetched =
             [.. await Inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false)];
-        return StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode);
+        return new ExchangeRateRangeResult(
+            fromIsoCode, toIsoCode, startDate, endDate, StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode));
     }
 
     /// <inheritdoc />

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/CachingExchangeRateProviderBase.cs
@@ -93,6 +93,13 @@ public abstract class CachingExchangeRateProviderBase
     protected abstract IDatedExchangeRateProvider Inner { get; }
 
     /// <inheritdoc />
+    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null)
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+        return GetRate(fromIsoCode, toIsoCode, today, options ?? _options.DefaultLookupOptions);
+    }
+
+    /// <inheritdoc />
     public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null)
     {
         return TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
@@ -125,7 +132,61 @@ public abstract class CachingExchangeRateProviderBase
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+        return GetRateAsync(fromIsoCode, toIsoCode, today, options ?? _options.DefaultLookupOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly date,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var duration = _options.GetExpiry(_cache.Provider);
+
+        if (TryServeFromCache(duration, fromIsoCode, toIsoCode, date, options, now, out ExchangeRateLookupResult result))
+        {
+            Log.CacheHit(_logger, _options.CacheHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode, date);
+            return result;
+        }
+
+        result = await Inner.GetRateAsync(fromIsoCode, toIsoCode, date, options, cancellationToken).ConfigureAwait(false);
+        StoreResult(duration, fromIsoCode, toIsoCode, result, now);
+        Log.CacheMissStored(_logger, _options.CacheMissLogLevel, _cache.Provider, fromIsoCode, toIsoCode, date);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ExchangeRateLookupResult> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+        if (endDate < startDate)
+            throw new ArgumentException(CachingResourceStrings.Arg_Invalid_RangeInverted, nameof(endDate));
+
+        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
+        var now = _timeProvider.GetUtcNow();
+        var duration = _options.GetExpiry(_cache.Provider);
+
+        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRateLookupResult> cached))
+        {
+            Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
+            return cached;
+        }
+
+        IReadOnlyList<ExchangeRateLookupResult> fetched = [.. Inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate)];
+        return StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -139,36 +200,55 @@ public abstract class CachingExchangeRateProviderBase
         var now = _timeProvider.GetUtcNow();
         var duration = _options.GetExpiry(_cache.Provider);
 
-        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRate> cached))
+        if (TryServeRangeFromCache(duration, pair, startDate, endDate, now, out IReadOnlyList<ExchangeRateLookupResult> cached))
         {
             Log.RangeCacheHit(_logger, _options.CacheRangeHitLogLevel, _cache.Provider, fromIsoCode, toIsoCode);
             return cached;
         }
 
-        IReadOnlyList<ExchangeRate> fetched =
-            await Inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false);
-
-        if (fetched.Count > 0)
-        {
-            StoreRange(duration, pair, fetched, now);
-
-            // Record the whole requested window as covered, not merely the dates that returned a row: the request asked
-            // for every interior day, so a later lookup of the same window can be served without refetching gaps.
-            _cache.RecordCoverage(pair, startDate, endDate, duration, now);
-
-            Log.RangeRefetched(_logger, _options.CacheRangeRefetchLogLevel, _cache.Provider, fromIsoCode, toIsoCode, fetched.Count);
-            return fetched;
-        }
-
-        return Array.Empty<ExchangeRate>();
+        IReadOnlyList<ExchangeRateLookupResult> fetched =
+            [.. await Inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false)];
+        return StoreFetchedRange(duration, pair, startDate, endDate, fetched, now, fromIsoCode, toIsoCode);
     }
 
     /// <inheritdoc />
-    public decimal GetRate(string fromIsoCode, string toIsoCode)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+    decimal IExchangeRateProvider.GetRate(string fromIsoCode, string toIsoCode) =>
+        GetRate(fromIsoCode, toIsoCode).Rate.Rate;
 
-        return new DatedExchangeRateProviderAdapter(this, today, _options.DefaultLookupOptions).GetRate(fromIsoCode, toIsoCode);
+    /// <summary>
+    /// Stores a freshly fetched range, records the requested window as covered, logs the refetch, and returns the range;
+    /// returns an empty sequence when the fetch yielded nothing.
+    /// </summary>
+    /// <param name="duration">The duration cached rows and coverage windows stay fresh.</param>
+    /// <param name="pair">The requested currency pair.</param>
+    /// <param name="startDate">The inclusive start of the range.</param>
+    /// <param name="endDate">The inclusive end of the range.</param>
+    /// <param name="fetched">The rates returned by the inner provider.</param>
+    /// <param name="now">The instant to stamp the cached rows and coverage with.</param>
+    /// <param name="fromIsoCode">The source-currency ISO code, for diagnostics.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code, for diagnostics.</param>
+    /// <returns>The stored range, or an empty sequence when <paramref name="fetched" /> is empty.</returns>
+    private IReadOnlyList<ExchangeRateLookupResult> StoreFetchedRange(
+        TimeSpan duration,
+        ExchangeRatePair pair,
+        DateOnly startDate,
+        DateOnly endDate,
+        IReadOnlyList<ExchangeRateLookupResult> fetched,
+        DateTimeOffset now,
+        string fromIsoCode,
+        string toIsoCode)
+    {
+        if (fetched.Count == 0)
+            return Array.Empty<ExchangeRateLookupResult>();
+
+        StoreRange(duration, pair, fetched, now);
+
+        // Record the whole requested window as covered, not merely the dates that returned a row: the request asked for
+        // every interior day, so a later lookup of the same window can be served without refetching gaps.
+        _cache.RecordCoverage(pair, startDate, endDate, duration, now);
+
+        Log.RangeRefetched(_logger, _options.CacheRangeRefetchLogLevel, _cache.Provider, fromIsoCode, toIsoCode, fetched.Count);
+        return fetched;
     }
 
     /// <summary>
@@ -227,22 +307,25 @@ public abstract class CachingExchangeRateProviderBase
     /// <returns>
     /// <see langword="true" /> when the range was satisfied from the cache; otherwise <see langword="false" />.
     /// </returns>
-    private bool TryServeRangeFromCache(TimeSpan duration, ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, DateTimeOffset now, out IReadOnlyList<ExchangeRate> result)
+    private bool TryServeRangeFromCache(TimeSpan duration, ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, DateTimeOffset now, out IReadOnlyList<ExchangeRateLookupResult> result)
     {
         // The fresh coverage, not the span of the rate rows, decides whether the whole window was actually fetched.
         if (!_cache.GetCoverage(pair, duration, now).Contains(startDate, endDate))
         {
-            result = Array.Empty<ExchangeRate>();
+            result = Array.Empty<ExchangeRateLookupResult>();
             return false;
         }
 
         var provider = _cache.Provider;
         IReadOnlyList<CachedExchangeRate> fresh = _cache.GetRates(pair, duration, now);
-        List<ExchangeRate> rates = new();
+        List<ExchangeRateLookupResult> rates = new();
         foreach (CachedExchangeRate rate in fresh)
         {
             if (rate.Date >= startDate && rate.Date <= endDate)
-                rates.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, rate.Date, rate.Rate, provider));
+            {
+                ExchangeRate observed = new(pair.FromIsoCode, pair.ToIsoCode, rate.Date, rate.Rate, provider);
+                rates.Add(new ExchangeRateLookupResult(observed, rate.Date, ExchangeRateDateResolution.Exact, 0));
+            }
         }
 
         result = rates;
@@ -271,11 +354,11 @@ public abstract class CachingExchangeRateProviderBase
     /// <param name="pair">The requested currency pair.</param>
     /// <param name="rates">The rates returned by the inner provider.</param>
     /// <param name="now">The instant to stamp the cached rows with.</param>
-    private void StoreRange(TimeSpan duration, ExchangeRatePair pair, IReadOnlyList<ExchangeRate> rates, DateTimeOffset now)
+    private void StoreRange(TimeSpan duration, ExchangeRatePair pair, IReadOnlyList<ExchangeRateLookupResult> rates, DateTimeOffset now)
     {
         var rows = new CachedExchangeRate[rates.Count];
         for (var i = 0; i < rates.Count; i++)
-            rows[i] = new CachedExchangeRate(rates[i].Date, rates[i].Rate, now);
+            rows[i] = new CachedExchangeRate(rates[i].Rate.Date, rates[i].Rate.Rate, now);
 
         _cache.Store(pair, rows, duration, now);
     }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/IExchangeRateAggregationStrategy.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/IExchangeRateAggregationStrategy.cs
@@ -37,19 +37,19 @@ namespace Bodu.Financial.ExchangeRates.Caching;
 ///         return false;
 ///     }
 ///
-///     public async ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(string fromIsoCode, string toIsoCode,
+///     public async ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(string fromIsoCode, string toIsoCode,
 ///         DateOnly startDate, DateOnly endDate, IReadOnlyList<NamedDatedExchangeRateProvider> candidates,
 ///         CancellationToken cancellationToken)
 ///     {
 ///         for (int i = candidates.Count - 1; i >= 0; i--)
 ///         {
-///             IReadOnlyList<ExchangeRate> rates = await candidates[i].Provider
-///                 .GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken);
+///             IReadOnlyList<ExchangeRateLookupResult> rates = [.. await candidates[i].Provider
+///                 .GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken)];
 ///             if (rates.Count > 0)
 ///                 return rates;
 ///         }
 ///
-///         return Array.Empty<ExchangeRate>();
+///         return Array.Empty<ExchangeRateLookupResult>();
 ///     }
 /// }
 ///]]>
@@ -88,7 +88,7 @@ public interface IExchangeRateAggregationStrategy
     /// <param name="candidates">The ordered candidate providers to combine.</param>
     /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
     /// <returns>The combined rates ordered by date, or an empty list when none are available.</returns>
-    ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(
+    ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/IExchangeRateAggregationStrategy.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/IExchangeRateAggregationStrategy.cs
@@ -37,19 +37,19 @@ namespace Bodu.Financial.ExchangeRates.Caching;
 ///         return false;
 ///     }
 ///
-///     public async ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(string fromIsoCode, string toIsoCode,
+///     public async ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(string fromIsoCode, string toIsoCode,
 ///         DateOnly startDate, DateOnly endDate, IReadOnlyList<NamedDatedExchangeRateProvider> candidates,
 ///         CancellationToken cancellationToken)
 ///     {
 ///         for (int i = candidates.Count - 1; i >= 0; i--)
 ///         {
-///             IReadOnlyList<ExchangeRateLookupResult> rates = [.. await candidates[i].Provider
+///             IReadOnlyList<ExchangeRate> rates = [.. await candidates[i].Provider
 ///                 .GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken)];
 ///             if (rates.Count > 0)
 ///                 return rates;
 ///         }
 ///
-///         return Array.Empty<ExchangeRateLookupResult>();
+///         return Array.Empty<ExchangeRate>();
 ///     }
 /// }
 ///]]>
@@ -88,7 +88,7 @@ public interface IExchangeRateAggregationStrategy
     /// <param name="candidates">The ordered candidate providers to combine.</param>
     /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
     /// <returns>The combined rates ordered by date, or an empty list when none are available.</returns>
-    ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(
+    ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/PriorityFallbackStrategy.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/PriorityFallbackStrategy.cs
@@ -53,7 +53,7 @@ public sealed class PriorityFallbackStrategy
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(
+    public async ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -65,13 +65,13 @@ public sealed class PriorityFallbackStrategy
 
         for (var i = 0; i < candidates.Count; i++)
         {
-            IReadOnlyList<ExchangeRateLookupResult> rates =
+            IReadOnlyList<ExchangeRate> rates =
                 [.. await candidates[i].Provider.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false)];
 
             if (rates.Count > 0)
                 return rates;
         }
 
-        return Array.Empty<ExchangeRateLookupResult>();
+        return Array.Empty<ExchangeRate>();
     }
 }

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/PriorityFallbackStrategy.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/PriorityFallbackStrategy.cs
@@ -53,7 +53,7 @@ public sealed class PriorityFallbackStrategy
     }
 
     /// <inheritdoc />
-    public async ValueTask<IReadOnlyList<ExchangeRate>> AggregateRangeAsync(
+    public async ValueTask<IReadOnlyList<ExchangeRateLookupResult>> AggregateRangeAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -65,13 +65,13 @@ public sealed class PriorityFallbackStrategy
 
         for (var i = 0; i < candidates.Count; i++)
         {
-            IReadOnlyList<ExchangeRate> rates =
-                await candidates[i].Provider.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false);
+            IReadOnlyList<ExchangeRateLookupResult> rates =
+                [.. await candidates[i].Provider.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false)];
 
             if (rates.Count > 0)
                 return rates;
         }
 
-        return Array.Empty<ExchangeRate>();
+        return Array.Empty<ExchangeRateLookupResult>();
     }
 }

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/AggregatingExchangeRateProviderTests.PriorityFallback.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/AggregatingExchangeRateProviderTests.PriorityFallback.cs
@@ -69,7 +69,7 @@ public sealed partial class AggregatingExchangeRateProviderTests
             Named("Second", ("USD", "AUD", D1, 1.60m)),
         });
 
-        IReadOnlyList<ExchangeRate> rates = await agg.GetRatesAsync("USD", "AUD", D1, D1);
+        IReadOnlyList<ExchangeRate> rates = [.. await agg.GetRatesAsync("USD", "AUD", D1, D1)];
 
         Assert.AreEqual(1, rates.Count);
         Assert.AreEqual("Second", rates[0].Provider);
@@ -83,7 +83,7 @@ public sealed partial class AggregatingExchangeRateProviderTests
     {
         AggregatingExchangeRateProvider agg = new(new[] { Named("First") });
 
-        IReadOnlyList<ExchangeRate> rates = await agg.GetRatesAsync("USD", "AUD", D1, D1);
+        IReadOnlyList<ExchangeRate> rates = [.. await agg.GetRatesAsync("USD", "AUD", D1, D1)];
 
         Assert.AreEqual(0, rates.Count);
     }

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingExchangeRateProviderTests.GetRatesAsync.cs
@@ -21,7 +21,7 @@ public sealed partial class CachingExchangeRateProviderTests
         SeedCoverage(pair, new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
         CachingExchangeRateProvider sut = CreateDecorator(inner);
 
-        IReadOnlyList<ExchangeRate> rates = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+        IReadOnlyList<ExchangeRate> rates = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.AreEqual(0.5m, rates[0].Rate);
@@ -40,8 +40,8 @@ public sealed partial class CachingExchangeRateProviderTests
             ("AUD", "USD", new DateOnly(2023, 1, 6), 0.51m));
         CachingExchangeRateProvider sut = CreateDecorator(inner);
 
-        IReadOnlyList<ExchangeRate> first = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
-        IReadOnlyList<ExchangeRate> second = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+        IReadOnlyList<ExchangeRate> first = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6))];
+        IReadOnlyList<ExchangeRate> second = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6))];
 
         Assert.AreEqual(2, first.Count);
         Assert.AreEqual(2, second.Count);
@@ -60,7 +60,7 @@ public sealed partial class CachingExchangeRateProviderTests
         SeedCache(new ExchangeRatePair("AUD", "USD"), (new DateOnly(2023, 1, 3), 0.5m));
         CachingExchangeRateProvider sut = CreateDecorator(inner);
 
-        IReadOnlyList<ExchangeRate> rates = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 10));
+        IReadOnlyList<ExchangeRate> rates = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 10))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.AreEqual(1, inner.GetRatesAsyncCallCount);
@@ -79,7 +79,7 @@ public sealed partial class CachingExchangeRateProviderTests
         CachingExchangeRateProvider sut = CreateDecorator(inner);
 
         _clock.Advance(Duration + TimeSpan.FromHours(1));
-        IReadOnlyList<ExchangeRate> rates = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+        IReadOnlyList<ExchangeRate> rates = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.AreEqual(1, inner.GetRatesAsyncCallCount);

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingExchangeRateProviderTests.RangeCoverage.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CachingExchangeRateProviderTests.RangeCoverage.cs
@@ -28,7 +28,7 @@ public sealed partial class CachingExchangeRateProviderTests
         SeedCoverage(pair, new DateOnly(2023, 1, 6), new DateOnly(2023, 1, 6));
         CachingExchangeRateProvider sut = CreateDecorator(inner);
 
-        IReadOnlyList<ExchangeRate> rates = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
+        IReadOnlyList<ExchangeRate> rates = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6))];
 
         Assert.AreEqual(1, inner.GetRatesAsyncCallCount);
         Assert.AreEqual(3, rates.Count);
@@ -49,7 +49,7 @@ public sealed partial class CachingExchangeRateProviderTests
         CachingExchangeRateProvider sut = CreateDecorator(inner);
 
         _ = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 6));
-        IReadOnlyList<ExchangeRate> sub = await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 4), new DateOnly(2023, 1, 5));
+        IReadOnlyList<ExchangeRate> sub = [.. await sut.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 4), new DateOnly(2023, 1, 5))];
 
         Assert.AreEqual(1, inner.GetRatesAsyncCallCount);
         Assert.AreEqual(2, sub.Count);

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CountingDatedExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CountingDatedExchangeRateProvider.cs
@@ -71,7 +71,7 @@ internal sealed class CountingDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public ExchangeRateRangeResult GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
         GetRatesAsyncCallCount++;
         return _inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate);
@@ -92,7 +92,7 @@ internal sealed class CountingDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
+    public ValueTask<ExchangeRateRangeResult> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
     {
         GetRatesAsyncCallCount++;
         return _inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken);

--- a/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CountingDatedExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Financial.ExchangeRates.Caching/CountingDatedExchangeRateProvider.cs
@@ -50,6 +50,13 @@ internal sealed class CountingDatedExchangeRateProvider
     public int TotalCallCount => GetRateCallCount + TryGetRateCallCount;
 
     /// <inheritdoc />
+    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null)
+    {
+        GetRateCallCount++;
+        return _inner.GetRate(fromIsoCode, toIsoCode, options);
+    }
+
+    /// <inheritdoc />
     public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null)
     {
         GetRateCallCount++;
@@ -64,7 +71,28 @@ internal sealed class CountingDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
+    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+        GetRatesAsyncCallCount++;
+        return _inner.GetRates(fromIsoCode, toIsoCode, startDate, endDate);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        GetRateCallCount++;
+        return _inner.GetRateAsync(fromIsoCode, toIsoCode, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        GetRateCallCount++;
+        return _inner.GetRateAsync(fromIsoCode, toIsoCode, date, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
     {
         GetRatesAsyncCallCount++;
         return _inner.GetRatesAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken);

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Financial.ExchangeRates.Ecb/EcbExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="EcbExchangeRateProvider.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -16,19 +16,18 @@ namespace Bodu.Financial.ExchangeRates.Ecb;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The provider implements the dated <see cref="IDatedExchangeRateProvider" /> contract (the natural fit for historical
-/// data) and the simple <see cref="IExchangeRateProvider" /> contract (returning the most recent available rate). It
-/// also exposes asynchronous <see cref="PreloadAsync" />, <see cref="LoadFeedAsync" />, and
-/// <see cref="LoadRangeAsync" /> methods to warm its in-memory store, and <see cref="GetRatesAsync" /> to read a whole
-/// date range at once.
+/// The provider derives from <see cref="WebExchangeRateProvider" />, which supplies the in-memory accumulator, the
+/// immutable snapshot, the full synchronous and asynchronous lookup matrix, and ownership of the
+/// <see cref="HttpClient" /> when this provider creates one. Loading is feed-based: each ECB feed runs from its earliest
+/// date to the most recent business day, so the feed covering a requested date also covers the remainder of the range.
+/// Use <see cref="PreloadAsync" />, <see cref="LoadFeedAsync" />, or <see cref="LoadRangeAsync" /> to warm the store.
 /// </para>
 /// <para>
-/// Because downloads are asynchronous while the lookup contracts are synchronous, a synchronous lookup that misses a
-/// date whose covering feed has not yet been loaded will, when
-/// <see cref="EcbExchangeRateOptions.AllowSynchronousNetworkAccess" /> is enabled, block to download the narrowest feed
-/// that covers that date and retry. Loaded feeds are accumulated into an immutable <see cref="ExchangeRateBook" />
-/// snapshot that backs the synchronous lookups, so inverse pairs, same-currency identity, and date-resolution policies
-/// are inherited from <see cref="FixedDatedExchangeRateProvider" />.
+/// <strong>HttpClient ownership.</strong> The constructor that takes only options builds and owns an
+/// <see cref="HttpClient" /> configured from <see cref="EcbEndpointOptions.UserAgent" /> and
+/// <see cref="EcbEndpointOptions.HttpTimeout" />, disposing it with the provider. The constructor that takes an
+/// <see cref="HttpClient" /> uses the caller-supplied client as-is; this is the path the dependency-injection package
+/// uses.
 /// </para>
 /// <para>
 /// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
@@ -41,7 +40,7 @@ namespace Bodu.Financial.ExchangeRates.Ecb;
 /// </para>
 /// </remarks>
 public sealed class EcbExchangeRateProvider
-    : IDatedExchangeRateProvider, IExchangeRateProvider
+    : WebExchangeRateProvider
 {
     /// <summary>
     /// The provider identifier stamped on every rate this provider produces.
@@ -54,13 +53,6 @@ public sealed class EcbExchangeRateProvider
     public const string BaseCurrencyIsoCode = "EUR";
 
     /// <summary>
-    /// The tolerance, in days, used to resolve the most recent rate for the undated
-    /// <see cref="IExchangeRateProvider" /> surface; large enough to reach the start of the ECB history from the
-    /// current date.
-    /// </summary>
-    private const int LatestRateToleranceDays = 100_000;
-
-    /// <summary>
     /// The source that downloads and parses feed files.
     /// </summary>
     private readonly IEcbExchangeRateTableSource _source;
@@ -71,14 +63,9 @@ public sealed class EcbExchangeRateProvider
     private readonly EcbExchangeRateOptions _options;
 
     /// <summary>
-    /// Guards mutation of the accumulator, loaded-feed set, series index, and snapshot fields.
+    /// The logger that records feed downloads and on-demand network fetches.
     /// </summary>
-    private readonly object _gate = new();
-
-    /// <summary>
-    /// The accumulator into which each loaded feed's observations are upserted.
-    /// </summary>
-    private readonly ExchangeRateTableBuilder _builder = new();
+    private readonly ILogger _logger;
 
     /// <summary>
     /// The names of feeds whose data has been loaded.
@@ -91,50 +78,39 @@ public sealed class EcbExchangeRateProvider
     private readonly Dictionary<ExchangeRatePair, EcbSeriesInfo> _series = new();
 
     /// <summary>
-    /// The current immutable book backing range queries; replaced under <see cref="_gate" /> after each load.
-    /// </summary>
-    private volatile ExchangeRateBook _book;
-
-    /// <summary>
-    /// The current immutable lookup provider; replaced under <see cref="_gate" /> after each load.
-    /// </summary>
-    private volatile FixedDatedExchangeRateProvider _snapshot;
-
-    /// <summary>
-    /// The logger that records feed downloads and on-demand network fetches.
-    /// </summary>
-    private readonly ILogger _logger;
-
-    /// <summary>
-    /// The time source used to resolve the current instant for feed selection and the undated lookup surface.
-    /// </summary>
-    private readonly TimeProvider _timeProvider;
-
-    /// <summary>
     /// Coalesces concurrent downloads of the same feed so a cache miss triggers at most one in-flight fetch per feed.
     /// </summary>
     private readonly SingleFlightCoordinator<string> _loadCoordinator = new();
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="EcbExchangeRateProvider" /> class backed by an
+    /// <see cref="HttpClient" /> the provider creates and owns, configured from the supplied options.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
+    public EcbExchangeRateProvider(EcbExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(options, CreateOwnedClient(options), logger, timeProvider)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="EcbExchangeRateProvider" /> class backed by the ECB
-    /// <c>eurofxref</c> feeds, downloaded with the supplied HTTP client.
+    /// <c>eurofxref</c> feeds, downloaded with the caller-supplied HTTP client. The caller owns the client's
+    /// configuration and lifetime.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to download feed files.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records feed downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for feed selection and the undated lookup surface.
-    /// <see langword="null" /> selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     public EcbExchangeRateProvider(HttpClient httpClient, EcbExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
-        : this(CreateSource(httpClient, options), options, logger, timeProvider)
+        : this(CreateSource(httpClient, options), options, ownedHttpClient: null, logger, timeProvider)
     {
     }
 
@@ -144,19 +120,46 @@ public sealed class EcbExchangeRateProvider
     /// </summary>
     /// <param name="source">The table source.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records feed downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for feed selection and the undated lookup surface.
-    /// <see langword="null" /> selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     internal EcbExchangeRateProvider(IEcbExchangeRateTableSource source, EcbExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(source, options, ownedHttpClient: null, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcbExchangeRateProvider" /> class from an owned client, building the
+    /// table source over it before forwarding to the core constructor.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The HTTP client this provider creates and owns.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private EcbExchangeRateProvider(EcbExchangeRateOptions options, HttpClient ownedHttpClient, ILogger? logger, TimeProvider? timeProvider)
+        : this(CreateSource(ownedHttpClient, options), options, ownedHttpClient, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcbExchangeRateProvider" /> class, the shared core all public and
+    /// internal constructors funnel through.
+    /// </summary>
+    /// <param name="source">The table source.</param>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The owned client to dispose with the provider, or <see langword="null" />.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private EcbExchangeRateProvider(
+        IEcbExchangeRateTableSource source,
+        EcbExchangeRateOptions options,
+        HttpClient? ownedHttpClient,
+        ILogger? logger,
+        TimeProvider? timeProvider)
+        : base(ownedHttpClient, timeProvider)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -165,76 +168,16 @@ public sealed class EcbExchangeRateProvider
         _source = source;
         _options = options;
         _logger = logger ?? NullLogger.Instance;
-        _timeProvider = timeProvider ?? TimeProvider.System;
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
 
-    /// <summary>
-    /// Resolves the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, throwing when none is available.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <returns>The resolved <see cref="ExchangeRateLookupResult" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the request.</exception>
-    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
-        TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
-            ? result
-            : throw new KeyNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, EcbResourceStrings.IO_KeyNotFound_EcbRate, fromIsoCode, toIsoCode, date));
+    /// <inheritdoc />
+    protected override string ProviderId => ProviderName;
 
-    /// <summary>
-    /// Attempts to resolve the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, loading the covering feed on demand when permitted.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <param name="result">
-    /// When this method returns <see langword="true" />, the resolved result; otherwise <see langword="default" />.
-    /// </param>
-    /// <returns><see langword="true" /> when a rate was resolved; otherwise <see langword="false" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    public bool TryGetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, out ExchangeRateLookupResult result)
-    {
-        if (_snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
-            return true;
+    /// <inheritdoc />
+    protected override bool AllowSynchronousNetworkAccess => _options.AllowSynchronousNetworkAccess;
 
-        if (_options.AllowSynchronousNetworkAccess && TryLoadFeedForDate(date))
-        {
-            Log.SynchronousNetworkFetch(_logger, _options.SynchronousNetworkFetchLogLevel, date);
-            return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
-        }
-
-        result = default;
-        return false;
-    }
-
-    /// <summary>
-    /// Gets the most recent available rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" />.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <returns>The multiplier converting one unit of the source currency to the destination currency.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the pair.</exception>
-    public decimal GetRate(string fromIsoCode, string toIsoCode)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        return GetRate(fromIsoCode, toIsoCode, today, ExchangeRateLookupOptions.PreviousWithin(LatestRateToleranceDays)).Rate.Rate;
-    }
+    /// <inheritdoc />
+    protected override TimeSpan DefaultLookback => TimeSpan.Zero;
 
     /// <summary>
     /// Downloads and loads the full-history feed, warming the store with every published day.
@@ -255,14 +198,12 @@ public sealed class EcbExchangeRateProvider
     /// <param name="feed">The feed to load.</param>
     /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
     /// <returns>A task that completes when the feed has been loaded.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="feed" /> is <see langword="null" />.
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="feed" /> is <see langword="null" />.</exception>
     public Task LoadFeedAsync(EcbExchangeRateFeed feed, CancellationToken cancellationToken = default)
     {
         ThrowHelper.ThrowIfNull(feed);
 
-        lock (_gate)
+        lock (SyncRoot)
         {
             if (_loadedFeeds.Contains(feed.Name))
                 return Task.CompletedTask;
@@ -270,45 +211,6 @@ public sealed class EcbExchangeRateProvider
 
         // Coalesce concurrent loads of the same feed so only one download is in flight; joiners await that shared task.
         return _loadCoordinator.RunAsync(feed.Name, () => LoadFeedCoreAsync(feed, cancellationToken));
-    }
-
-    /// <summary>
-    /// Downloads and stores a single feed, re-checking the loaded set inside the single-flight section so a joiner that
-    /// arrives after a prior load completes does no redundant work.
-    /// </summary>
-    /// <param name="feed">The feed to load.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
-    /// <returns>A task that completes when the feed has been loaded.</returns>
-    private async Task LoadFeedCoreAsync(EcbExchangeRateFeed feed, CancellationToken cancellationToken)
-    {
-        lock (_gate)
-        {
-            if (_loadedFeeds.Contains(feed.Name))
-                return;
-        }
-
-        Log.FeedLoadStarting(_logger, _options.DownloadStartingLogLevel, feed.Name);
-
-        EcbExchangeRateTable table;
-        try
-        {
-            table = await _source.GetTableAsync(feed, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Log.FeedLoadFailed(_logger, _options.DownloadFailedLogLevel, feed.Name, ex);
-            throw;
-        }
-
-        lock (_gate)
-        {
-            if (!_loadedFeeds.Add(feed.Name))
-                return;
-
-            var count = Accumulate(table);
-            RebuildSnapshot();
-            Log.FeedLoaded(_logger, _options.DownloadCompletedLogLevel, feed.Name, count);
-        }
     }
 
     /// <summary>
@@ -321,60 +223,12 @@ public sealed class EcbExchangeRateProvider
     /// <exception cref="EcbExchangeRateDateRangeException">
     /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
     /// </exception>
-    /// <remarks>
-    /// A single ECB feed runs from its earliest date to the most recent business day, so the feed that covers
-    /// <paramref name="startDate" /> also covers the remainder of the range; when no feed reaches that far back, the
-    /// widest feed is loaded.
-    /// </remarks>
     public Task LoadRangeAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
     {
-        ThrowIfRangeInverted(startDate, endDate);
+        if (endDate < startDate)
+            throw CreateRangeInvertedException(startDate, endDate);
 
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        EcbExchangeRateFeed feed = EcbExchangeRateFeed.ForDate(startDate, _options.Feeds, today) ?? SelectWidestFeed();
-
-        return LoadFeedAsync(feed, cancellationToken);
-    }
-
-    /// <summary>
-    /// Reads every available rate for a pair within the inclusive date range, loading any covering feed first.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code; one side of the pair must be <c>EUR</c>.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code; one side of the pair must be <c>EUR</c>.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
-    /// <returns>A task that yields the rates in the range, ordered by date.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="EcbExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    /// <exception cref="EcbExchangeRateSeriesNotFoundException">
-    /// Thrown when neither side of the pair is <c>EUR</c>.
-    /// </exception>
-    public async ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
-        string fromIsoCode,
-        string toIsoCode,
-        DateOnly startDate,
-        DateOnly endDate,
-        CancellationToken cancellationToken = default)
-    {
-        ThrowHelper.ThrowIfNull(fromIsoCode);
-        ThrowHelper.ThrowIfNull(toIsoCode);
-        ThrowIfRangeInverted(startDate, endDate);
-
-        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-        if (!string.Equals(fromIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal) &&
-            !string.Equals(toIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal))
-        {
-            throw new EcbExchangeRateSeriesNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, EcbResourceStrings.IO_KeyNotFound_EcbSeries, fromIsoCode, toIsoCode));
-        }
-
-        await LoadRangeAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
-
-        return CollectRates(pair, startDate, endDate);
+        return LoadFeedAsync(SelectFeedForRange(startDate), cancellationToken);
     }
 
     /// <summary>
@@ -383,11 +237,54 @@ public sealed class EcbExchangeRateProvider
     /// <returns>A snapshot of the discovered series, one per currency pair.</returns>
     public IReadOnlyCollection<EcbSeriesInfo> GetAvailablePairs()
     {
-        lock (_gate)
+        lock (SyncRoot)
         {
             return _series.Values.ToArray();
         }
     }
+
+    /// <inheritdoc />
+    protected override ValueTask EnsureLoadedAsync(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken) =>
+        new(LoadFeedAsync(SelectFeedForRange(startDate), cancellationToken));
+
+    /// <inheritdoc />
+    protected override bool IsLoaded(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
+    {
+        EcbExchangeRateFeed feed = SelectFeedForRange(startDate);
+
+        lock (SyncRoot)
+        {
+            return _loadedFeeds.Contains(feed.Name);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateRangeRequest(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+        if (!string.Equals(fromIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal) &&
+            !string.Equals(toIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal))
+        {
+            throw new EcbExchangeRateSeriesNotFoundException(
+                string.Format(CultureInfo.CurrentCulture, EcbResourceStrings.IO_KeyNotFound_EcbSeries, fromIsoCode, toIsoCode));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnObservationIngested(ExchangeRate rate) =>
+        Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+
+    /// <inheritdoc />
+    protected override void OnSynchronousNetworkFetch(DateOnly date) =>
+        Log.SynchronousNetworkFetch(_logger, _options.SynchronousNetworkFetchLogLevel, date);
+
+    /// <inheritdoc />
+    protected override Exception CreateRangeInvertedException(DateOnly startDate, DateOnly endDate) =>
+        new EcbExchangeRateDateRangeException(
+            string.Format(CultureInfo.CurrentCulture, EcbResourceStrings.Arg_OutOfRange_EcbDateRange, startDate, endDate));
+
+    /// <inheritdoc />
+    protected override string FormatRateNotFound(string fromIsoCode, string toIsoCode, DateOnly date) =>
+        string.Format(CultureInfo.CurrentCulture, EcbResourceStrings.IO_KeyNotFound_EcbRate, fromIsoCode, toIsoCode, date);
 
     /// <summary>
     /// Builds the default <c>eurofxref</c> table source from the supplied client and options.
@@ -409,20 +306,71 @@ public sealed class EcbExchangeRateProvider
     }
 
     /// <summary>
-    /// Throws when an inclusive date range is inverted.
+    /// Builds the <see cref="HttpClient" /> this provider owns, configured with the endpoint's user agent and timeout.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <returns>A new, configured client owned by the provider.</returns>
+    private static HttpClient CreateOwnedClient(EcbExchangeRateOptions options)
+    {
+        ThrowHelper.ThrowIfNull(options);
+        options.Validate();
+
+        return ExchangeRateHttpClientFactory.Create(options.Endpoint.UserAgent, options.Endpoint.HttpTimeout);
+    }
+
+    /// <summary>
+    /// Downloads and stores a single feed, re-checking the loaded set inside the single-flight section so a joiner that
+    /// arrives after a prior load completes does no redundant work.
+    /// </summary>
+    /// <param name="feed">The feed to load.</param>
+    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
+    /// <returns>A task that completes when the feed has been loaded.</returns>
+    private async Task LoadFeedCoreAsync(EcbExchangeRateFeed feed, CancellationToken cancellationToken)
+    {
+        lock (SyncRoot)
+        {
+            if (_loadedFeeds.Contains(feed.Name))
+                return;
+        }
+
+        Log.FeedLoadStarting(_logger, _options.DownloadStartingLogLevel, feed.Name);
+
+        EcbExchangeRateTable table;
+        try
+        {
+            table = await _source.GetTableAsync(feed, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.FeedLoadFailed(_logger, _options.DownloadFailedLogLevel, feed.Name, ex);
+            throw;
+        }
+
+        lock (SyncRoot)
+        {
+            if (!_loadedFeeds.Add(feed.Name))
+                return;
+
+            foreach (EcbSeriesInfo info in table.GetSeriesInfo())
+                _series[info.Pair] = info;
+
+            var count = AddObservations(table.EnumerateRates());
+            RebuildSnapshot();
+
+            Log.FeedLoaded(_logger, _options.DownloadCompletedLogLevel, feed.Name, count);
+        }
+    }
+
+    /// <summary>
+    /// Selects the feed that covers the start of a requested range, falling back to the widest feed when none reaches
+    /// that far back.
     /// </summary>
     /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <exception cref="EcbExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    private static void ThrowIfRangeInverted(DateOnly startDate, DateOnly endDate)
+    /// <returns>The covering feed.</returns>
+    private EcbExchangeRateFeed SelectFeedForRange(DateOnly startDate)
     {
-        if (endDate < startDate)
-        {
-            throw new EcbExchangeRateDateRangeException(
-                string.Format(CultureInfo.CurrentCulture, EcbResourceStrings.Arg_OutOfRange_EcbDateRange, startDate, endDate));
-        }
+        var today = DateOnly.FromDateTime(TimeProvider.GetUtcNow().UtcDateTime);
+        return EcbExchangeRateFeed.ForDate(startDate, _options.Feeds, today) ?? SelectWidestFeed();
     }
 
     /// <summary>
@@ -440,97 +388,5 @@ public sealed class EcbExchangeRateProvider
         }
 
         return feeds[^1];
-    }
-
-    /// <summary>
-    /// Upserts a parsed table's observations and series metadata into the accumulator.
-    /// </summary>
-    /// <param name="table">The parsed table.</param>
-    /// <returns>The number of rate observations upserted.</returns>
-    private int Accumulate(EcbExchangeRateTable table)
-    {
-        foreach (EcbSeriesInfo info in table.GetSeriesInfo())
-            _series[info.Pair] = info;
-
-        var count = 0;
-        foreach (ExchangeRate rate in table.EnumerateRates())
-        {
-            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
-            count++;
-        }
-
-        return count;
-    }
-
-    /// <summary>
-    /// Rebuilds the immutable book and lookup snapshot from the accumulator.
-    /// </summary>
-    private void RebuildSnapshot()
-    {
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
-    }
-
-    /// <summary>
-    /// Synchronously loads the feed covering a date when it has not been loaded, for the on-demand lookup path.
-    /// </summary>
-    /// <param name="date">The date whose covering feed should be loaded.</param>
-    /// <returns>
-    /// <see langword="true" /> when a load was attempted; <see langword="false" /> when no feed covers the date or it
-    /// was already loaded.
-    /// </returns>
-    private bool TryLoadFeedForDate(DateOnly date)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        EcbExchangeRateFeed? feed = EcbExchangeRateFeed.ForDate(date, _options.Feeds, today);
-        if (feed is null)
-            return false;
-
-        lock (_gate)
-        {
-            if (_loadedFeeds.Contains(feed.Name))
-                return false;
-        }
-
-        // Intentional opt-in synchronous fetch on the lookup path, gated by AllowSynchronousNetworkAccess.
-#pragma warning disable VSTHRD002
-        LoadFeedAsync(feed).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
-        return true;
-    }
-
-    /// <summary>
-    /// Collects the rates for a pair within a date range from the current book, inverting the reverse series when only
-    /// it is available.
-    /// </summary>
-    /// <param name="pair">The requested pair.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <returns>The rates in the range, ordered by date.</returns>
-    private List<ExchangeRate> CollectRates(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
-    {
-        ExchangeRateBook book = _book;
-        List<ExchangeRate> result = new();
-
-        if (book.TryGetSeries(pair, ProviderName, out ExchangeRateSeries? series) && series is not null)
-        {
-            foreach (ExchangeRateObservation observation in series.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, observation.Rate, ProviderName));
-            }
-        }
-        else if (book.TryGetSeries(pair.Inverse(), ProviderName, out ExchangeRateSeries? inverse) && inverse is not null)
-        {
-            foreach (ExchangeRateObservation observation in inverse.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, 1m / observation.Rate, ProviderName, isInverted: true));
-            }
-        }
-
-        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
-        return result;
     }
 }

--- a/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.GetRatesAsync.cs
@@ -20,7 +20,7 @@ public partial class EcbExchangeRateProviderTests
         (EcbExchangeRateProvider provider, _) = Create(allowSync: false);
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("EUR", "JPY", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31));
+            [.. await provider.GetRatesAsync("EUR", "JPY", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.AreEqual(new DateOnly(2023, 1, 3), rates[0].Date);
@@ -38,7 +38,7 @@ public partial class EcbExchangeRateProviderTests
         (EcbExchangeRateProvider provider, _) = Create(allowSync: false);
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("JPY", "EUR", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31));
+            [.. await provider.GetRatesAsync("JPY", "EUR", new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.IsTrue(rates[0].IsInverted);

--- a/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.TimeProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.TimeProvider.cs
@@ -21,7 +21,7 @@ public partial class EcbExchangeRateProviderTests
         EcbExchangeRateProvider provider = new(source, options, logger: null, timeProvider);
         await provider.LoadRangeAsync(new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31));
 
-        var rate = provider.GetRate("EUR", "USD");
+        var rate = provider.GetRate("EUR", "USD").Rate.Rate;
 
         Assert.AreEqual(1.0545m, rate);
     }

--- a/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.cs
+++ b/Bodu.Financial.ExchangeRates.Ecb/test/Financial.ExchangeRates.Ecb/EcbExchangeRateProviderTests.cs
@@ -118,7 +118,7 @@ public partial class EcbExchangeRateProviderTests
     {
         EcbExchangeRateProvider provider = await CreatePreloadedAsync();
 
-        var latest = provider.GetRate("EUR", "USD");
+        var latest = provider.GetRate("EUR", "USD").Rate.Rate;
 
         Assert.AreEqual(1.0600m, latest);
     }

--- a/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Financial.ExchangeRates.Rba/RbaExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="RbaExchangeRateProvider.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -16,18 +16,18 @@ namespace Bodu.Financial.ExchangeRates.Rba;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The provider implements the dated <see cref="IDatedExchangeRateProvider" /> contract (the natural fit for historical
-/// data) and the simple <see cref="IExchangeRateProvider" /> contract (returning the most recent available rate). It
-/// also exposes asynchronous <see cref="PreloadAsync" />, <see cref="LoadEraAsync" />, and
-/// <see cref="LoadRangeAsync" /> methods to warm its in-memory store, and <see cref="GetRatesAsync" /> to read a whole
-/// date range at once.
+/// The provider derives from <see cref="WebExchangeRateProvider" />, which supplies the in-memory accumulator, the
+/// immutable snapshot, the full synchronous and asynchronous lookup matrix, and ownership of the
+/// <see cref="HttpClient" /> when this provider creates one. Loading is era-based: each era is a published <c>.xls</c>
+/// file covering a span of dates, and a range load fetches every era overlapping the requested window. Use
+/// <see cref="PreloadAsync" />, <see cref="LoadEraAsync" />, or <see cref="LoadRangeAsync" /> to warm the store.
 /// </para>
 /// <para>
-/// Because downloads are asynchronous while the lookup contracts are synchronous, a synchronous lookup that misses an
-/// era which has not yet been loaded will, when <see cref="RbaExchangeRateOptions.AllowSynchronousNetworkAccess" /> is
-/// enabled, block to download that era and retry. Loaded eras are accumulated into an immutable
-/// <see cref="ExchangeRateBook" /> snapshot that backs the synchronous lookups, so inverse pairs, same-currency
-/// identity, and date-resolution policies are inherited from <see cref="FixedDatedExchangeRateProvider" />.
+/// <strong>HttpClient ownership.</strong> The constructor that takes only options builds and owns an
+/// <see cref="HttpClient" /> configured from <see cref="RbaExchangeRateOptions.UserAgent" /> and
+/// <see cref="RbaExchangeRateOptions.HttpTimeout" />, disposing it with the provider. The constructor that takes an
+/// <see cref="HttpClient" /> uses the caller-supplied client as-is; this is the path the dependency-injection package
+/// uses.
 /// </para>
 /// <para>
 /// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
@@ -39,7 +39,7 @@ namespace Bodu.Financial.ExchangeRates.Rba;
 /// </para>
 /// </remarks>
 public sealed class RbaExchangeRateProvider
-    : IDatedExchangeRateProvider, IExchangeRateProvider
+    : WebExchangeRateProvider
 {
     /// <summary>
     /// The provider identifier stamped on every rate this provider produces.
@@ -52,13 +52,6 @@ public sealed class RbaExchangeRateProvider
     public const string BaseCurrencyIsoCode = "AUD";
 
     /// <summary>
-    /// The tolerance, in days, used to resolve the most recent rate for the undated
-    /// <see cref="IExchangeRateProvider" /> surface; large enough to reach the start of the RBA history from the
-    /// current date.
-    /// </summary>
-    private const int LatestRateToleranceDays = 100_000;
-
-    /// <summary>
     /// The source that downloads and parses era files.
     /// </summary>
     private readonly IRbaExchangeRateTableSource _source;
@@ -69,14 +62,9 @@ public sealed class RbaExchangeRateProvider
     private readonly RbaExchangeRateOptions _options;
 
     /// <summary>
-    /// Guards mutation of the accumulator, loaded-era set, series index, and snapshot fields.
+    /// The logger that records era downloads and on-demand network fetches.
     /// </summary>
-    private readonly object _gate = new();
-
-    /// <summary>
-    /// The accumulator into which each loaded era's observations are upserted.
-    /// </summary>
-    private readonly ExchangeRateTableBuilder _builder = new();
+    private readonly ILogger _logger;
 
     /// <summary>
     /// The labels of eras whose data has been loaded.
@@ -89,50 +77,38 @@ public sealed class RbaExchangeRateProvider
     private readonly Dictionary<ExchangeRatePair, RbaSeriesInfo> _series = new();
 
     /// <summary>
-    /// The current immutable book backing range queries; replaced under <see cref="_gate" /> after each load.
-    /// </summary>
-    private volatile ExchangeRateBook _book;
-
-    /// <summary>
-    /// The current immutable lookup provider; replaced under <see cref="_gate" /> after each load.
-    /// </summary>
-    private volatile FixedDatedExchangeRateProvider _snapshot;
-
-    /// <summary>
-    /// The logger that records era downloads and on-demand network fetches.
-    /// </summary>
-    private readonly ILogger _logger;
-
-    /// <summary>
-    /// The time source used to resolve the current instant for the undated lookup surface.
-    /// </summary>
-    private readonly TimeProvider _timeProvider;
-
-    /// <summary>
     /// Coalesces concurrent downloads of the same era so a cache miss triggers at most one in-flight fetch per era.
     /// </summary>
     private readonly SingleFlightCoordinator<string> _loadCoordinator = new();
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="RbaExchangeRateProvider" /> class backed by an
+    /// <see cref="HttpClient" /> the provider creates and owns, configured from the supplied options.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
+    public RbaExchangeRateProvider(RbaExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(options, CreateOwnedClient(options), logger, timeProvider)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="RbaExchangeRateProvider" /> class backed by the RBA <c>.xls</c>
-    /// files, downloaded with the supplied HTTP client.
+    /// files, downloaded with the caller-supplied HTTP client. The caller owns the client's configuration and lifetime.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to download era files.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records era downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for the undated lookup surface. <see langword="null" />
-    /// selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpClient" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     public RbaExchangeRateProvider(HttpClient httpClient, RbaExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
-        : this(CreateSource(httpClient, options), options, logger, timeProvider)
+        : this(CreateSource(httpClient, options), options, ownedHttpClient: null, logger, timeProvider)
     {
     }
 
@@ -142,19 +118,46 @@ public sealed class RbaExchangeRateProvider
     /// </summary>
     /// <param name="source">The table source.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records era downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for the undated lookup surface. <see langword="null" />
-    /// selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     internal RbaExchangeRateProvider(IRbaExchangeRateTableSource source, RbaExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(source, options, ownedHttpClient: null, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RbaExchangeRateProvider" /> class from an owned client, building the
+    /// table source over it before forwarding to the core constructor.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The HTTP client this provider creates and owns.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private RbaExchangeRateProvider(RbaExchangeRateOptions options, HttpClient ownedHttpClient, ILogger? logger, TimeProvider? timeProvider)
+        : this(CreateSource(ownedHttpClient, options), options, ownedHttpClient, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RbaExchangeRateProvider" /> class, the shared core all public and
+    /// internal constructors funnel through.
+    /// </summary>
+    /// <param name="source">The table source.</param>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The owned client to dispose with the provider, or <see langword="null" />.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private RbaExchangeRateProvider(
+        IRbaExchangeRateTableSource source,
+        RbaExchangeRateOptions options,
+        HttpClient? ownedHttpClient,
+        ILogger? logger,
+        TimeProvider? timeProvider)
+        : base(ownedHttpClient, timeProvider)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -163,73 +166,16 @@ public sealed class RbaExchangeRateProvider
         _source = source;
         _options = options;
         _logger = logger ?? NullLogger.Instance;
-        _timeProvider = timeProvider ?? TimeProvider.System;
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
 
-    /// <summary>
-    /// Resolves the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, throwing when none is available.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <returns>The resolved <see cref="ExchangeRateLookupResult" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the request.</exception>
-    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
-        TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
-            ? result
-            : throw new KeyNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, RbaResourceStrings.IO_KeyNotFound_RbaRate, fromIsoCode, toIsoCode, date));
+    /// <inheritdoc />
+    protected override string ProviderId => ProviderName;
 
-    /// <summary>
-    /// Attempts to resolve the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, loading the covering era on demand when permitted.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <param name="result">
-    /// When this method returns <see langword="true" />, the resolved result; otherwise <see langword="default" />.
-    /// </param>
-    /// <returns><see langword="true" /> when a rate was resolved; otherwise <see langword="false" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    public bool TryGetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, out ExchangeRateLookupResult result)
-    {
-        if (_snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
-            return true;
+    /// <inheritdoc />
+    protected override bool AllowSynchronousNetworkAccess => _options.AllowSynchronousNetworkAccess;
 
-        if (_options.AllowSynchronousNetworkAccess && TryLoadEraForDate(date))
-            return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
-
-        result = default;
-        return false;
-    }
-
-    /// <summary>
-    /// Gets the most recent available rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" />.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <returns>The multiplier converting one unit of the source currency to the destination currency.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the pair.</exception>
-    public decimal GetRate(string fromIsoCode, string toIsoCode)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        return GetRate(fromIsoCode, toIsoCode, today, ExchangeRateLookupOptions.PreviousWithin(LatestRateToleranceDays)).Rate.Rate;
-    }
+    /// <inheritdoc />
+    protected override TimeSpan DefaultLookback => TimeSpan.Zero;
 
     /// <summary>
     /// Downloads and loads every era in the configured catalogue.
@@ -248,14 +194,12 @@ public sealed class RbaExchangeRateProvider
     /// <param name="era">The era to load.</param>
     /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
     /// <returns>A task that completes when the era has been loaded.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="era" /> is <see langword="null" />.
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="era" /> is <see langword="null" />.</exception>
     public Task LoadEraAsync(RbaEra era, CancellationToken cancellationToken = default)
     {
         ThrowHelper.ThrowIfNull(era);
 
-        lock (_gate)
+        lock (SyncRoot)
         {
             if (_loadedEras.Contains(era.Label))
                 return Task.CompletedTask;
@@ -263,45 +207,6 @@ public sealed class RbaExchangeRateProvider
 
         // Coalesce concurrent loads of the same era so only one download is in flight; joiners await that shared task.
         return _loadCoordinator.RunAsync(era.Label, () => LoadEraCoreAsync(era, cancellationToken));
-    }
-
-    /// <summary>
-    /// Downloads and stores a single era, re-checking the loaded set inside the single-flight section so a joiner that
-    /// arrives after a prior load completes does no redundant work.
-    /// </summary>
-    /// <param name="era">The era to load.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
-    /// <returns>A task that completes when the era has been loaded.</returns>
-    private async Task LoadEraCoreAsync(RbaEra era, CancellationToken cancellationToken)
-    {
-        lock (_gate)
-        {
-            if (_loadedEras.Contains(era.Label))
-                return;
-        }
-
-        Log.EraLoadStarting(_logger, _options.DownloadStartingLogLevel, era.Label);
-
-        RbaExchangeRateTable table;
-        try
-        {
-            table = await _source.GetTableAsync(era, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Log.EraLoadFailed(_logger, _options.DownloadFailedLogLevel, era.Label, ex);
-            throw;
-        }
-
-        lock (_gate)
-        {
-            if (!_loadedEras.Add(era.Label))
-                return;
-
-            var count = Accumulate(table);
-            RebuildSnapshot();
-            Log.EraLoaded(_logger, _options.DownloadCompletedLogLevel, era.Label, count);
-        }
     }
 
     /// <summary>
@@ -314,56 +219,12 @@ public sealed class RbaExchangeRateProvider
     /// <exception cref="RbaExchangeRateDateRangeException">
     /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
     /// </exception>
-    public async Task LoadRangeAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
+    public Task LoadRangeAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default)
     {
-        ThrowIfRangeInverted(startDate, endDate);
+        if (endDate < startDate)
+            throw CreateRangeInvertedException(startDate, endDate);
 
-        foreach (RbaEra era in _options.Eras)
-        {
-            if (era.Start <= endDate && (era.End is null || era.End.Value >= startDate))
-                await LoadEraAsync(era, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
-    /// Reads every available rate for a pair within the inclusive date range, loading any covering eras first.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code; one side of the pair must be <c>AUD</c>.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code; one side of the pair must be <c>AUD</c>.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the loads.</param>
-    /// <returns>A task that yields the rates in the range, ordered by date.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="RbaExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    /// <exception cref="RbaExchangeRateSeriesNotFoundException">
-    /// Thrown when neither side of the pair is <c>AUD</c>.
-    /// </exception>
-    public async ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
-        string fromIsoCode,
-        string toIsoCode,
-        DateOnly startDate,
-        DateOnly endDate,
-        CancellationToken cancellationToken = default)
-    {
-        ThrowHelper.ThrowIfNull(fromIsoCode);
-        ThrowHelper.ThrowIfNull(toIsoCode);
-        ThrowIfRangeInverted(startDate, endDate);
-
-        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-        if (!string.Equals(fromIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal) &&
-            !string.Equals(toIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal))
-        {
-            throw new RbaExchangeRateSeriesNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, RbaResourceStrings.IO_KeyNotFound_RbaSeries, fromIsoCode, toIsoCode));
-        }
-
-        await LoadRangeAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
-
-        return CollectRates(pair, startDate, endDate);
+        return LoadRangeInternalAsync(startDate, endDate, cancellationToken);
     }
 
     /// <summary>
@@ -372,11 +233,54 @@ public sealed class RbaExchangeRateProvider
     /// <returns>A snapshot of the discovered series, one per currency pair.</returns>
     public IReadOnlyCollection<RbaSeriesInfo> GetAvailablePairs()
     {
-        lock (_gate)
+        lock (SyncRoot)
         {
             return _series.Values.ToArray();
         }
     }
+
+    /// <inheritdoc />
+    protected override ValueTask EnsureLoadedAsync(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken) =>
+        new(LoadRangeInternalAsync(startDate, endDate, cancellationToken));
+
+    /// <inheritdoc />
+    protected override bool IsLoaded(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
+    {
+        lock (SyncRoot)
+        {
+            foreach (RbaEra era in _options.Eras)
+            {
+                if (era.Start <= endDate && (era.End is null || era.End.Value >= startDate) && !_loadedEras.Contains(era.Label))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateRangeRequest(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+        if (!string.Equals(fromIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal) &&
+            !string.Equals(toIsoCode, BaseCurrencyIsoCode, StringComparison.Ordinal))
+        {
+            throw new RbaExchangeRateSeriesNotFoundException(
+                string.Format(CultureInfo.CurrentCulture, RbaResourceStrings.IO_KeyNotFound_RbaSeries, fromIsoCode, toIsoCode));
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnObservationIngested(ExchangeRate rate) =>
+        Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+
+    /// <inheritdoc />
+    protected override Exception CreateRangeInvertedException(DateOnly startDate, DateOnly endDate) =>
+        new RbaExchangeRateDateRangeException(
+            string.Format(CultureInfo.CurrentCulture, RbaResourceStrings.Arg_OutOfRange_RbaDateRange, startDate, endDate));
+
+    /// <inheritdoc />
+    protected override string FormatRateNotFound(string fromIsoCode, string toIsoCode, DateOnly date) =>
+        string.Format(CultureInfo.CurrentCulture, RbaResourceStrings.IO_KeyNotFound_RbaRate, fromIsoCode, toIsoCode, date);
 
     /// <summary>
     /// Builds the default <c>.xls</c> table source from the supplied client and options.
@@ -398,110 +302,74 @@ public sealed class RbaExchangeRateProvider
     }
 
     /// <summary>
-    /// Throws when an inclusive date range is inverted.
+    /// Builds the <see cref="HttpClient" /> this provider owns, configured with the options' user agent and timeout.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <returns>A new, configured client owned by the provider.</returns>
+    private static HttpClient CreateOwnedClient(RbaExchangeRateOptions options)
+    {
+        ThrowHelper.ThrowIfNull(options);
+        options.Validate();
+
+        return ExchangeRateHttpClientFactory.Create(options.UserAgent, options.HttpTimeout);
+    }
+
+    /// <summary>
+    /// Loads every era overlapping the inclusive date range, skipping eras already loaded.
     /// </summary>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
-    /// <exception cref="RbaExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    private static void ThrowIfRangeInverted(DateOnly startDate, DateOnly endDate)
+    /// <param name="cancellationToken">A token to observe while awaiting the loads.</param>
+    /// <returns>A task that completes when the overlapping eras have been loaded.</returns>
+    private async Task LoadRangeInternalAsync(DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
     {
-        if (endDate < startDate)
+        foreach (RbaEra era in _options.Eras)
         {
-            throw new RbaExchangeRateDateRangeException(
-                string.Format(CultureInfo.CurrentCulture, RbaResourceStrings.Arg_OutOfRange_RbaDateRange, startDate, endDate));
+            if (era.Start <= endDate && (era.End is null || era.End.Value >= startDate))
+                await LoadEraAsync(era, cancellationToken).ConfigureAwait(false);
         }
     }
 
     /// <summary>
-    /// Upserts a parsed table's observations and series metadata into the accumulator.
+    /// Downloads and stores a single era, re-checking the loaded set inside the single-flight section so a joiner that
+    /// arrives after a prior load completes does no redundant work.
     /// </summary>
-    /// <param name="table">The parsed table.</param>
-    /// <returns>The number of rate observations upserted.</returns>
-    private int Accumulate(RbaExchangeRateTable table)
+    /// <param name="era">The era to load.</param>
+    /// <param name="cancellationToken">A token to observe while awaiting the load.</param>
+    /// <returns>A task that completes when the era has been loaded.</returns>
+    private async Task LoadEraCoreAsync(RbaEra era, CancellationToken cancellationToken)
     {
-        foreach (RbaSeriesInfo info in table.GetSeriesInfo())
-            _series[info.Pair] = info;
-
-        var count = 0;
-        foreach (ExchangeRate rate in table.EnumerateRates())
-        {
-            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
-            count++;
-        }
-
-        return count;
-    }
-
-    /// <summary>
-    /// Rebuilds the immutable book and lookup snapshot from the accumulator.
-    /// </summary>
-    private void RebuildSnapshot()
-    {
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
-    }
-
-    /// <summary>
-    /// Synchronously loads the era covering a date when it has not been loaded, for the on-demand lookup path.
-    /// </summary>
-    /// <param name="date">The date whose covering era should be loaded.</param>
-    /// <returns>
-    /// <see langword="true" /> when a load was attempted; <see langword="false" /> when no era covers the date or it
-    /// was already loaded.
-    /// </returns>
-    private bool TryLoadEraForDate(DateOnly date)
-    {
-        var era = RbaEra.ForDate(date, _options.Eras);
-        if (era is null)
-            return false;
-
-        lock (_gate)
+        lock (SyncRoot)
         {
             if (_loadedEras.Contains(era.Label))
-                return false;
+                return;
         }
 
-        // Intentional opt-in synchronous fetch on the lookup path, gated by AllowSynchronousNetworkAccess.
-#pragma warning disable VSTHRD002
-        LoadEraAsync(era).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
-        return true;
-    }
+        Log.EraLoadStarting(_logger, _options.DownloadStartingLogLevel, era.Label);
 
-    /// <summary>
-    /// Collects the rates for a pair within a date range from the current book, inverting the reverse series when only
-    /// it is available.
-    /// </summary>
-    /// <param name="pair">The requested pair.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <returns>The rates in the range, ordered by date.</returns>
-    private List<ExchangeRate> CollectRates(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
-    {
-        ExchangeRateBook book = _book;
-        List<ExchangeRate> result = new();
-
-        if (book.TryGetSeries(pair, ProviderName, out ExchangeRateSeries? series) && series is not null)
+        RbaExchangeRateTable table;
+        try
         {
-            foreach (ExchangeRateObservation observation in series.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, observation.Rate, ProviderName));
-            }
+            table = await _source.GetTableAsync(era, cancellationToken).ConfigureAwait(false);
         }
-        else if (book.TryGetSeries(pair.Inverse(), ProviderName, out ExchangeRateSeries? inverse) && inverse is not null)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            foreach (ExchangeRateObservation observation in inverse.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, 1m / observation.Rate, ProviderName, isInverted: true));
-            }
+            Log.EraLoadFailed(_logger, _options.DownloadFailedLogLevel, era.Label, ex);
+            throw;
         }
 
-        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
-        return result;
+        lock (SyncRoot)
+        {
+            if (!_loadedEras.Add(era.Label))
+                return;
+
+            foreach (RbaSeriesInfo info in table.GetSeriesInfo())
+                _series[info.Pair] = info;
+
+            var count = AddObservations(table.EnumerateRates());
+            RebuildSnapshot();
+
+            Log.EraLoaded(_logger, _options.DownloadCompletedLogLevel, era.Label, count);
+        }
     }
 }

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.GetRatesAsync.cs
@@ -19,7 +19,7 @@ public partial class RbaExchangeRateProviderTests
         RbaExchangeRateProvider provider = await CreatePreloadedAsync();
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 31));
+            [.. await provider.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 31))];
 
         Assert.IsTrue(rates.Count > 0);
         Assert.IsTrue(rates.All(r => r.Date >= new DateOnly(2023, 1, 3) && r.Date <= new DateOnly(2023, 1, 31)));
@@ -37,7 +37,7 @@ public partial class RbaExchangeRateProviderTests
         RbaExchangeRateProvider provider = await CreatePreloadedAsync();
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("USD", "AUD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 3));
+            [.. await provider.GetRatesAsync("USD", "AUD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 3))];
 
         Assert.AreEqual(1, rates.Count);
         Assert.IsTrue(rates[0].IsInverted);

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.TimeProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.TimeProvider.cs
@@ -21,7 +21,7 @@ public partial class RbaExchangeRateProviderTests
         RbaExchangeRateProvider provider = new(source, options, logger: null, timeProvider);
         await provider.LoadRangeAsync(new DateOnly(2023, 1, 1), new DateOnly(2026, 12, 31));
 
-        var rate = provider.GetRate("AUD", "USD");
+        var rate = provider.GetRate("AUD", "USD").Rate.Rate;
 
         Assert.AreEqual(0.6828m, rate);
     }

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaExchangeRateProviderTests.cs
@@ -118,7 +118,7 @@ public partial class RbaExchangeRateProviderTests
     {
         RbaExchangeRateProvider provider = await CreatePreloadedAsync();
 
-        var latest = provider.GetRate("AUD", "USD");
+        var latest = provider.GetRate("AUD", "USD").Rate.Rate;
 
         Assert.AreEqual(0.7029m, latest);
     }

--- a/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaRateKnownAnswerTests.cs
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Financial.ExchangeRates.Rba/RbaRateKnownAnswerTests.cs
@@ -109,7 +109,7 @@ public class RbaRateKnownAnswerTests
         RbaEra era = RbaEra.Default.Single(e => string.Equals(e.FileName, sourceFileName, StringComparison.Ordinal));
         DateOnly end = era.End ?? new DateOnly(2100, 1, 1);
 
-        IReadOnlyList<ExchangeRate> series = await provider.GetRatesAsync("AUD", ResolveCurrency(currency), era.Start, end);
+        IReadOnlyList<ExchangeRate> series = [.. await provider.GetRatesAsync("AUD", ResolveCurrency(currency), era.Start, end)];
         Assert.IsNotEmpty(series);
 
         var byType = s_allRows

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSource.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSource.cs
@@ -13,11 +13,10 @@ namespace Bodu.Financial.ExchangeRates.Yahoo;
 /// </summary>
 /// <remarks>
 /// The bar interval is fixed at one day; the date range is taken from the request and expressed as the <c>period1</c>/
-/// <c>period2</c> Unix-second query parameters. Each request carries the configured
-/// <see cref="YahooExchangeRateOptions.UserAgent" />, set per request so the shared client's headers are not mutated;
-/// the Yahoo Finance endpoint answers requests that omit a recognizable user agent with <c>429 Too Many Requests</c>.
-/// Connection reuse is the responsibility of the supplied <see cref="HttpClient" /> (typically one created by
-/// <c>IHttpClientFactory</c>).
+/// <c>period2</c> Unix-second query parameters. The <c>User-Agent</c> the Yahoo Finance endpoint requires is configured
+/// on the <see cref="HttpClient" /> (by the provider when it owns the client, or by the caller when the client is
+/// supplied), not per request. Connection reuse is the responsibility of the supplied <see cref="HttpClient" />
+/// (typically one created by <c>IHttpClientFactory</c>).
 /// </remarks>
 internal sealed class YahooChartExchangeRateSource
     : IYahooExchangeRateChartSource
@@ -57,33 +56,9 @@ internal sealed class YahooChartExchangeRateSource
         ThrowHelper.ThrowIfNull(request);
 
         Uri url = BuildRequestUri(request);
-
-        using HttpRequestMessage message = new(HttpMethod.Get, url);
-        ApplyHeaders(message);
-
-        using HttpResponseMessage response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-
-        var json = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        var json = await _httpClient.GetByteArrayAsync(url, cancellationToken).ConfigureAwait(false);
 
         return YahooChartResponseParser.Parse(json, request, _options);
-    }
-
-    /// <summary>
-    /// Applies the configured request headers — notably the <c>User-Agent</c> the Yahoo Finance endpoint requires — to
-    /// an outgoing chart request.
-    /// </summary>
-    /// <param name="message">The request message to populate.</param>
-    /// <remarks>
-    /// The header is set per request rather than on the shared <see cref="HttpClient" />, so the provider presents a
-    /// recognizable user agent whether it is constructed directly or resolved from dependency injection, and the
-    /// shared client's headers are never mutated. Yahoo Finance answers requests that omit a recognizable user agent
-    /// with <c>429 Too Many Requests</c>.
-    /// </remarks>
-    private void ApplyHeaders(HttpRequestMessage message)
-    {
-        if (!string.IsNullOrWhiteSpace(_options.UserAgent))
-            message.Headers.TryAddWithoutValidation("User-Agent", _options.UserAgent);
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSource.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSource.cs
@@ -13,8 +13,11 @@ namespace Bodu.Financial.ExchangeRates.Yahoo;
 /// </summary>
 /// <remarks>
 /// The bar interval is fixed at one day; the date range is taken from the request and expressed as the <c>period1</c>/
-/// <c>period2</c> Unix-second query parameters. Connection reuse is the responsibility of the supplied
-/// <see cref="HttpClient" /> (typically one created by <c>IHttpClientFactory</c>).
+/// <c>period2</c> Unix-second query parameters. Each request carries the configured
+/// <see cref="YahooExchangeRateOptions.UserAgent" />, set per request so the shared client's headers are not mutated;
+/// the Yahoo Finance endpoint answers requests that omit a recognizable user agent with <c>429 Too Many Requests</c>.
+/// Connection reuse is the responsibility of the supplied <see cref="HttpClient" /> (typically one created by
+/// <c>IHttpClientFactory</c>).
 /// </remarks>
 internal sealed class YahooChartExchangeRateSource
     : IYahooExchangeRateChartSource
@@ -54,9 +57,33 @@ internal sealed class YahooChartExchangeRateSource
         ThrowHelper.ThrowIfNull(request);
 
         Uri url = BuildRequestUri(request);
-        var json = await _httpClient.GetByteArrayAsync(url, cancellationToken).ConfigureAwait(false);
+
+        using HttpRequestMessage message = new(HttpMethod.Get, url);
+        ApplyHeaders(message);
+
+        using HttpResponseMessage response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 
         return YahooChartResponseParser.Parse(json, request, _options);
+    }
+
+    /// <summary>
+    /// Applies the configured request headers — notably the <c>User-Agent</c> the Yahoo Finance endpoint requires — to
+    /// an outgoing chart request.
+    /// </summary>
+    /// <param name="message">The request message to populate.</param>
+    /// <remarks>
+    /// The header is set per request rather than on the shared <see cref="HttpClient" />, so the provider presents a
+    /// recognizable user agent whether it is constructed directly or resolved from dependency injection, and the
+    /// shared client's headers are never mutated. Yahoo Finance answers requests that omit a recognizable user agent
+    /// with <c>429 Too Many Requests</c>.
+    /// </remarks>
+    private void ApplyHeaders(HttpRequestMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.UserAgent))
+            message.Headers.TryAddWithoutValidation("User-Agent", _options.UserAgent);
     }
 
     /// <summary>

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
@@ -76,15 +76,17 @@ public sealed class YahooExchangeRateOptions
     public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Gets or sets the <c>User-Agent</c> header applied to every chart request the provider issues.
+    /// Gets or sets the <c>User-Agent</c> header applied to the HTTP client.
     /// </summary>
     /// <value>
     /// The user-agent string; defaults to a browser-like identifier, because the Yahoo Finance endpoint answers
     /// requests that do not present a recognizable user agent with <c>429 Too Many Requests</c>.
     /// </value>
     /// <remarks>
-    /// The provider applies this header per request, so it is honored whether the provider is constructed directly or
-    /// resolved from dependency injection. An empty or white-space value suppresses the header.
+    /// This value is applied when the provider creates and owns its own <see cref="HttpClient" /> (the constructor that
+    /// takes only options) and by the dependency-injection registration when it configures the named client. When an
+    /// <see cref="HttpClient" /> is supplied to the provider directly, configuring its headers is the caller's
+    /// responsibility and this value is not applied.
     /// </remarks>
     public string UserAgent { get; set; } =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateOptions.cs
@@ -76,12 +76,16 @@ public sealed class YahooExchangeRateOptions
     public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Gets or sets the <c>User-Agent</c> header applied to chart requests by the dependency-injection registration.
+    /// Gets or sets the <c>User-Agent</c> header applied to every chart request the provider issues.
     /// </summary>
     /// <value>
-    /// The user-agent string; defaults to a browser-like identifier, because the Yahoo Finance endpoint rejects
-    /// requests that do not present a recognizable user agent.
+    /// The user-agent string; defaults to a browser-like identifier, because the Yahoo Finance endpoint answers
+    /// requests that do not present a recognizable user agent with <c>429 Too Many Requests</c>.
     /// </value>
+    /// <remarks>
+    /// The provider applies this header per request, so it is honored whether the provider is constructed directly or
+    /// resolved from dependency injection. An empty or white-space value suppresses the header.
+    /// </remarks>
     public string UserAgent { get; set; } =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Financial.ExchangeRates.Yahoo/YahooExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="YahooExchangeRateProvider.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -16,18 +16,19 @@ namespace Bodu.Financial.ExchangeRates.Yahoo;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The provider implements the dated <see cref="IDatedExchangeRateProvider" /> contract and the simple
-/// <see cref="IExchangeRateProvider" /> contract (returning the most recent available rate). Unlike a single-issuer
-/// feed, Yahoo serves arbitrary pairs through the <c>{FROM}{TO}=X</c> ticker convention, so any pair of ISO codes can
-/// be requested directly. Use <see cref="LoadPairAsync" /> to warm a pair's in-memory store, or
-/// <see cref="GetRatesAsync" /> to read a whole date range at once.
+/// The provider derives from <see cref="WebExchangeRateProvider" />, which supplies the in-memory accumulator, the
+/// immutable snapshot, the full synchronous and asynchronous lookup matrix, and ownership of the
+/// <see cref="HttpClient" /> when this provider creates one. Yahoo serves arbitrary pairs through the
+/// <c>{FROM}{TO}=X</c> ticker convention, so any pair of ISO codes can be requested directly. Use
+/// <see cref="LoadPairAsync" /> to warm a pair's in-memory store.
 /// </para>
 /// <para>
-/// Because fetches are asynchronous while the lookup contracts are synchronous, a synchronous lookup that misses an
-/// un-fetched pair will, when <see cref="YahooExchangeRateOptions.AllowSynchronousNetworkAccess" /> is enabled, block
-/// to fetch a window around the requested date and retry. Fetched observations are accumulated into an immutable
-/// <see cref="ExchangeRateBook" /> snapshot that backs the synchronous lookups, so inverse pairs, same-currency
-/// identity, and date-resolution policies are inherited from <see cref="FixedDatedExchangeRateProvider" />.
+/// <strong>HttpClient ownership.</strong> The constructor that takes only options builds and owns an
+/// <see cref="HttpClient" /> configured with the options' <see cref="YahooExchangeRateOptions.UserAgent" /> and
+/// <see cref="YahooExchangeRateOptions.HttpTimeout" /> (the Yahoo endpoint answers requests without a recognizable user
+/// agent with <c>429 Too Many Requests</c>), disposing it with the provider. The constructor that takes an
+/// <see cref="HttpClient" /> uses the caller-supplied client as-is, leaving its configuration and lifetime to the
+/// caller; this is the path the dependency-injection package uses.
 /// </para>
 /// <para>
 /// <strong>Logging.</strong> When an <see cref="ILogger" /> is supplied (directly or through the dependency-injection
@@ -40,18 +41,12 @@ namespace Bodu.Financial.ExchangeRates.Yahoo;
 /// </para>
 /// </remarks>
 public sealed partial class YahooExchangeRateProvider
-    : IDatedExchangeRateProvider, IExchangeRateProvider
+    : WebExchangeRateProvider
 {
     /// <summary>
     /// The provider identifier stamped on every rate this provider produces.
     /// </summary>
     public const string ProviderName = "Yahoo";
-
-    /// <summary>
-    /// The tolerance, in days, used to resolve the most recent rate for the undated
-    /// <see cref="IExchangeRateProvider" /> surface; large enough to reach any rate fetched into the store.
-    /// </summary>
-    private const int LatestRateToleranceDays = 100_000;
 
     /// <summary>
     /// The source that fetches and parses charts.
@@ -64,14 +59,9 @@ public sealed partial class YahooExchangeRateProvider
     private readonly YahooExchangeRateOptions _options;
 
     /// <summary>
-    /// Guards mutation of the accumulator, loaded-range index, series index, and snapshot fields.
+    /// The logger that records chart downloads and on-demand network fetches.
     /// </summary>
-    private readonly object _gate = new();
-
-    /// <summary>
-    /// The accumulator into which each fetched chart's observations are upserted.
-    /// </summary>
-    private readonly ExchangeRateTableBuilder _builder = new();
+    private readonly ILogger _logger;
 
     /// <summary>
     /// The set of inclusive date ranges fetched so far for each pair. A gap-respecting coverage set is used rather than
@@ -86,34 +76,35 @@ public sealed partial class YahooExchangeRateProvider
     private readonly Dictionary<ExchangeRatePair, YahooSeriesInfo> _series = new();
 
     /// <summary>
-    /// The current immutable book backing range queries; replaced under <see cref="_gate" /> after each fetch.
-    /// </summary>
-    private volatile ExchangeRateBook _book;
-
-    /// <summary>
-    /// The current immutable lookup provider; replaced under <see cref="_gate" /> after each fetch.
-    /// </summary>
-    private volatile FixedDatedExchangeRateProvider _snapshot;
-
-    /// <summary>
-    /// The logger that records chart downloads and on-demand network fetches.
-    /// </summary>
-    private readonly ILogger _logger;
-
-    /// <summary>
-    /// The time source used to resolve the current instant for the undated lookup surface.
-    /// </summary>
-    private readonly TimeProvider _timeProvider;
-
-    /// <summary>
     /// Coalesces concurrent fetches of the same pair-and-window so a cache miss triggers at most one in-flight chart
     /// request, with other callers awaiting the shared fetch.
     /// </summary>
     private readonly SingleFlightCoordinator<PairWindow> _loadCoordinator = new();
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="YahooExchangeRateProvider" /> class backed by an
+    /// <see cref="HttpClient" /> the provider creates and owns, configured from the supplied options.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="logger">
+    /// The logger that records chart downloads and on-demand network fetches. <see langword="null" /> selects
+    /// <see cref="NullLogger.Instance" />.
+    /// </param>
+    /// <param name="timeProvider">
+    /// The time source used to resolve the current instant for the undated lookup surface. <see langword="null" />
+    /// selects <see cref="TimeProvider.System" />.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
+    public YahooExchangeRateProvider(YahooExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(options, CreateOwnedClient(options), logger, timeProvider)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="YahooExchangeRateProvider" /> class backed by the Yahoo Finance
-    /// chart endpoint, queried with the supplied HTTP client.
+    /// chart endpoint, queried with the caller-supplied HTTP client. The caller owns the client's configuration and
+    /// lifetime.
     /// </summary>
     /// <param name="httpClient">The HTTP client used to issue chart requests.</param>
     /// <param name="options">The provider options.</param>
@@ -130,7 +121,7 @@ public sealed partial class YahooExchangeRateProvider
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     public YahooExchangeRateProvider(HttpClient httpClient, YahooExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
-        : this(CreateSource(httpClient, options), options, logger, timeProvider)
+        : this(CreateSource(httpClient, options), options, ownedHttpClient: null, logger, timeProvider)
     {
     }
 
@@ -140,19 +131,46 @@ public sealed partial class YahooExchangeRateProvider
     /// </summary>
     /// <param name="source">The chart source.</param>
     /// <param name="options">The provider options.</param>
-    /// <param name="logger">
-    /// The logger that records chart downloads and on-demand network fetches. <see langword="null" /> selects
-    /// <see cref="NullLogger.Instance" />.
-    /// </param>
-    /// <param name="timeProvider">
-    /// The time source used to resolve the current instant for the undated lookup surface. <see langword="null" />
-    /// selects <see cref="TimeProvider.System" />.
-    /// </param>
+    /// <param name="logger">The logger. <see langword="null" /> selects <see cref="NullLogger.Instance" />.</param>
+    /// <param name="timeProvider">The time source. <see langword="null" /> selects <see cref="TimeProvider.System" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="source" /> or <paramref name="options" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="options" /> fails validation.</exception>
     internal YahooExchangeRateProvider(IYahooExchangeRateChartSource source, YahooExchangeRateOptions options, ILogger? logger = null, TimeProvider? timeProvider = null)
+        : this(source, options, ownedHttpClient: null, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YahooExchangeRateProvider" /> class from an owned client, building
+    /// the chart source over it before forwarding to the core constructor.
+    /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The HTTP client this provider creates and owns.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private YahooExchangeRateProvider(YahooExchangeRateOptions options, HttpClient ownedHttpClient, ILogger? logger, TimeProvider? timeProvider)
+        : this(new YahooChartExchangeRateSource(ownedHttpClient, options), options, ownedHttpClient, logger, timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YahooExchangeRateProvider" /> class, the shared core all public and
+    /// internal constructors funnel through.
+    /// </summary>
+    /// <param name="source">The chart source.</param>
+    /// <param name="options">The provider options.</param>
+    /// <param name="ownedHttpClient">The owned client to dispose with the provider, or <see langword="null" />.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time source.</param>
+    private YahooExchangeRateProvider(
+        IYahooExchangeRateChartSource source,
+        YahooExchangeRateOptions options,
+        HttpClient? ownedHttpClient,
+        ILogger? logger,
+        TimeProvider? timeProvider)
+        : base(ownedHttpClient, timeProvider)
     {
         ThrowHelper.ThrowIfNull(source);
         ThrowHelper.ThrowIfNull(options);
@@ -161,76 +179,16 @@ public sealed partial class YahooExchangeRateProvider
         _source = source;
         _options = options;
         _logger = logger ?? NullLogger.Instance;
-        _timeProvider = timeProvider ?? TimeProvider.System;
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
     }
 
-    /// <summary>
-    /// Resolves the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, throwing when none is available.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <returns>The resolved <see cref="ExchangeRateLookupResult" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the request.</exception>
-    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
-        TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
-            ? result
-            : throw new KeyNotFoundException(
-                string.Format(CultureInfo.CurrentCulture, YahooResourceStrings.IO_KeyNotFound_YahooRate, fromIsoCode, toIsoCode, date));
+    /// <inheritdoc />
+    protected override string ProviderId => ProviderName;
 
-    /// <summary>
-    /// Attempts to resolve the rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
-    /// <paramref name="date" />, fetching the pair on demand when permitted.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The calendar date for which a rate is required.</param>
-    /// <param name="options">
-    /// The lookup rules; <see langword="null" /> is treated as <see cref="ExchangeRateLookupOptions.Exact" />.
-    /// </param>
-    /// <param name="result">
-    /// When this method returns <see langword="true" />, the resolved result; otherwise <see langword="default" />.
-    /// </param>
-    /// <returns><see langword="true" /> when a rate was resolved; otherwise <see langword="false" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code or the options are invalid.</exception>
-    public bool TryGetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, out ExchangeRateLookupResult result)
-    {
-        if (_snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
-            return true;
+    /// <inheritdoc />
+    protected override bool AllowSynchronousNetworkAccess => _options.AllowSynchronousNetworkAccess;
 
-        if (_options.AllowSynchronousNetworkAccess && TryLoadPairForDate(fromIsoCode, toIsoCode, date))
-        {
-            Log.SynchronousNetworkFetch(_logger, _options.SynchronousNetworkFetchLogLevel, date);
-            return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
-        }
-
-        result = default;
-        return false;
-    }
-
-    /// <summary>
-    /// Gets the most recent available rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" />.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <returns>The multiplier converting one unit of the source currency to the destination currency.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="KeyNotFoundException">Thrown when no rate is available for the pair.</exception>
-    public decimal GetRate(string fromIsoCode, string toIsoCode)
-    {
-        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
-        return GetRate(fromIsoCode, toIsoCode, today, ExchangeRateLookupOptions.PreviousWithin(LatestRateToleranceDays)).Rate.Rate;
-    }
+    /// <inheritdoc />
+    protected override TimeSpan DefaultLookback => _options.DefaultLookback;
 
     /// <summary>
     /// Fetches and loads a pair's rates for the inclusive date range, unless that window is already covered.
@@ -250,102 +208,11 @@ public sealed partial class YahooExchangeRateProvider
     {
         ThrowHelper.ThrowIfNull(fromIsoCode);
         ThrowHelper.ThrowIfNull(toIsoCode);
-        ThrowIfRangeInverted(startDate, endDate);
+        if (endDate < startDate)
+            throw CreateRangeInvertedException(startDate, endDate);
 
         ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-
-        lock (_gate)
-        {
-            if (IsRangeCovered(pair, startDate, endDate))
-                return Task.CompletedTask;
-        }
-
-        // Coalesce concurrent fetches of the same pair-and-window so only one chart request is in flight.
-        return _loadCoordinator.RunAsync(
-            new PairWindow(pair, startDate, endDate),
-            () => LoadPairCoreAsync(pair, fromIsoCode, toIsoCode, startDate, endDate, cancellationToken));
-    }
-
-    /// <summary>
-    /// Fetches and stores a pair's chart for the inclusive window, re-checking coverage inside the single-flight
-    /// section so a joiner that arrives after a prior fetch completes does no redundant work.
-    /// </summary>
-    /// <param name="pair">The currency pair to fetch.</param>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the fetch.</param>
-    /// <returns>A task that completes when the pair's window has been loaded.</returns>
-    private async Task LoadPairCoreAsync(
-        ExchangeRatePair pair,
-        string fromIsoCode,
-        string toIsoCode,
-        DateOnly startDate,
-        DateOnly endDate,
-        CancellationToken cancellationToken)
-    {
-        lock (_gate)
-        {
-            if (IsRangeCovered(pair, startDate, endDate))
-                return;
-        }
-
-        var symbol = _options.BuildSymbol(fromIsoCode, toIsoCode);
-        YahooChartRequest request = new(pair, symbol, startDate, endDate);
-
-        Log.PairLoadStarting(_logger, _options.DownloadStartingLogLevel, symbol);
-
-        YahooExchangeRateChart chart;
-        try
-        {
-            chart = await _source.GetChartAsync(request, cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Log.PairLoadFailed(_logger, _options.DownloadFailedLogLevel, symbol, ex);
-            throw;
-        }
-
-        lock (_gate)
-        {
-            var count = Accumulate(chart);
-            ExtendCoveredRange(pair, startDate, endDate);
-            RebuildSnapshot();
-            Log.PairLoaded(_logger, _options.DownloadCompletedLogLevel, symbol, count);
-        }
-    }
-
-    /// <summary>
-    /// Reads every available rate for a pair within the inclusive date range, fetching it first.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <param name="cancellationToken">A token to observe while awaiting the fetch.</param>
-    /// <returns>A task that yields the rates in the range, ordered by date.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when an ISO code is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when an ISO code is invalid.</exception>
-    /// <exception cref="YahooExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    public async ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
-        string fromIsoCode,
-        string toIsoCode,
-        DateOnly startDate,
-        DateOnly endDate,
-        CancellationToken cancellationToken = default)
-    {
-        ThrowHelper.ThrowIfNull(fromIsoCode);
-        ThrowHelper.ThrowIfNull(toIsoCode);
-        ThrowIfRangeInverted(startDate, endDate);
-
-        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-
-        await LoadPairAsync(fromIsoCode, toIsoCode, startDate, endDate, cancellationToken).ConfigureAwait(false);
-
-        return CollectRates(pair, startDate, endDate);
+        return EnsureLoadedAsync(pair, startDate, endDate, cancellationToken).AsTask();
     }
 
     /// <summary>
@@ -354,11 +221,52 @@ public sealed partial class YahooExchangeRateProvider
     /// <returns>A snapshot of the discovered series, one per currency pair.</returns>
     public IReadOnlyCollection<YahooSeriesInfo> GetAvailablePairs()
     {
-        lock (_gate)
+        lock (SyncRoot)
         {
             return _series.Values.ToArray();
         }
     }
+
+    /// <inheritdoc />
+    protected override ValueTask EnsureLoadedAsync(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
+    {
+        lock (SyncRoot)
+        {
+            if (IsRangeCovered(pair, startDate, endDate))
+                return ValueTask.CompletedTask;
+        }
+
+        // Coalesce concurrent fetches of the same pair-and-window so only one chart request is in flight.
+        return new ValueTask(_loadCoordinator.RunAsync(
+            new PairWindow(pair, startDate, endDate),
+            () => LoadPairCoreAsync(pair, startDate, endDate, cancellationToken)));
+    }
+
+    /// <inheritdoc />
+    protected override bool IsLoaded(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
+    {
+        lock (SyncRoot)
+        {
+            return IsRangeCovered(pair, startDate, endDate);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnObservationIngested(ExchangeRate rate) =>
+        Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
+
+    /// <inheritdoc />
+    protected override void OnSynchronousNetworkFetch(DateOnly date) =>
+        Log.SynchronousNetworkFetch(_logger, _options.SynchronousNetworkFetchLogLevel, date);
+
+    /// <inheritdoc />
+    protected override Exception CreateRangeInvertedException(DateOnly startDate, DateOnly endDate) =>
+        new YahooExchangeRateDateRangeException(
+            string.Format(CultureInfo.CurrentCulture, YahooResourceStrings.Arg_OutOfRange_YahooDateRange, startDate, endDate));
+
+    /// <inheritdoc />
+    protected override string FormatRateNotFound(string fromIsoCode, string toIsoCode, DateOnly date) =>
+        string.Format(CultureInfo.CurrentCulture, YahooResourceStrings.IO_KeyNotFound_YahooRate, fromIsoCode, toIsoCode, date);
 
     /// <summary>
     /// Builds the default chart source from the supplied client and options.
@@ -376,68 +284,78 @@ public sealed partial class YahooExchangeRateProvider
     }
 
     /// <summary>
-    /// Throws when an inclusive date range is inverted.
+    /// Builds the <see cref="HttpClient" /> this provider owns, configured with the options' user agent and timeout.
     /// </summary>
+    /// <param name="options">The provider options.</param>
+    /// <returns>A new, configured client owned by the provider.</returns>
+    private static HttpClient CreateOwnedClient(YahooExchangeRateOptions options)
+    {
+        ThrowHelper.ThrowIfNull(options);
+        options.Validate();
+
+        return ExchangeRateHttpClientFactory.Create(options.UserAgent, options.HttpTimeout);
+    }
+
+    /// <summary>
+    /// Fetches and stores a pair's chart for the inclusive window, re-checking coverage inside the single-flight
+    /// section so a joiner that arrives after a prior fetch completes does no redundant work.
+    /// </summary>
+    /// <param name="pair">The currency pair to fetch.</param>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
-    /// <exception cref="YahooExchangeRateDateRangeException">
-    /// Thrown when <paramref name="endDate" /> precedes <paramref name="startDate" />.
-    /// </exception>
-    private static void ThrowIfRangeInverted(DateOnly startDate, DateOnly endDate)
+    /// <param name="cancellationToken">A token to observe while awaiting the fetch.</param>
+    /// <returns>A task that completes when the pair's window has been loaded.</returns>
+    private async Task LoadPairCoreAsync(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken)
     {
-        if (endDate < startDate)
+        lock (SyncRoot)
         {
-            throw new YahooExchangeRateDateRangeException(
-                string.Format(CultureInfo.CurrentCulture, YahooResourceStrings.Arg_OutOfRange_YahooDateRange, startDate, endDate));
+            if (IsRangeCovered(pair, startDate, endDate))
+                return;
+        }
+
+        var symbol = _options.BuildSymbol(pair.FromIsoCode, pair.ToIsoCode);
+        YahooChartRequest request = new(pair, symbol, startDate, endDate);
+
+        Log.PairLoadStarting(_logger, _options.DownloadStartingLogLevel, symbol);
+
+        YahooExchangeRateChart chart;
+        try
+        {
+            chart = await _source.GetChartAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.PairLoadFailed(_logger, _options.DownloadFailedLogLevel, symbol, ex);
+            throw;
+        }
+
+        lock (SyncRoot)
+        {
+            YahooSeriesInfo info = chart.GetSeriesInfo();
+            _series[info.Pair] = info;
+
+            var count = AddObservations(chart.EnumerateRates());
+            ExtendCoveredRange(pair, startDate, endDate);
+            RebuildSnapshot();
+
+            Log.PairLoaded(_logger, _options.DownloadCompletedLogLevel, symbol, count);
         }
     }
 
     /// <summary>
-    /// Upserts a fetched chart's observations and series metadata into the accumulator.
-    /// </summary>
-    /// <param name="chart">The parsed chart.</param>
-    /// <returns>The number of rate observations upserted.</returns>
-    private int Accumulate(YahooExchangeRateChart chart)
-    {
-        YahooSeriesInfo info = chart.GetSeriesInfo();
-        _series[info.Pair] = info;
-
-        var count = 0;
-        foreach (ExchangeRate rate in chart.EnumerateRates())
-        {
-            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
-            Log.ObservationIngested(_logger, _options.ObservationIngestedLogLevel, rate.FromIsoCode, rate.ToIsoCode, rate.Date, rate.Rate);
-            count++;
-        }
-
-        return count;
-    }
-
-    /// <summary>
-    /// Rebuilds the immutable book and lookup snapshot from the accumulator.
-    /// </summary>
-    private void RebuildSnapshot()
-    {
-        _book = _builder.ToBook();
-        _snapshot = new FixedDatedExchangeRateProvider(_book);
-    }
-
-    /// <summary>
-    /// Reports whether every day in the inclusive range has already been fetched for a pair.
+    /// Reports whether every day in the inclusive range has already been fetched for a pair. The caller must hold
+    /// <see cref="WebExchangeRateProvider.SyncRoot" />.
     /// </summary>
     /// <param name="pair">The pair to check.</param>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
     /// <returns><see langword="true" /> when the range is fully covered; otherwise <see langword="false" />.</returns>
-    /// <remarks>
-    /// Coverage is tracked as a gap-respecting set of intervals, so a window that straddles an unfetched interior gap
-    /// reports as not covered even when earlier and later sub-ranges have been fetched.
-    /// </remarks>
     private bool IsRangeCovered(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate) =>
         _coverage.TryGetValue(pair, out DateRangeCoverage? coverage) && coverage.Contains(startDate, endDate);
 
     /// <summary>
-    /// Records the inclusive range as fetched for a pair, merging it into the pair's coverage set.
+    /// Records the inclusive range as fetched for a pair, merging it into the pair's coverage set. The caller must hold
+    /// <see cref="WebExchangeRateProvider.SyncRoot" />.
     /// </summary>
     /// <param name="pair">The pair to extend.</param>
     /// <param name="startDate">The inclusive start of the range.</param>
@@ -451,68 +369,5 @@ public sealed partial class YahooExchangeRateProvider
         }
 
         coverage.Add(startDate, endDate);
-    }
-
-    /// <summary>
-    /// Synchronously fetches a window around a date for the on-demand lookup path, unless the pair is already covered
-    /// or is a same-currency request.
-    /// </summary>
-    /// <param name="fromIsoCode">The source-currency ISO code.</param>
-    /// <param name="toIsoCode">The destination-currency ISO code.</param>
-    /// <param name="date">The date around which to fetch.</param>
-    /// <returns><see langword="true" /> when a fetch was attempted; otherwise <see langword="false" />.</returns>
-    private bool TryLoadPairForDate(string fromIsoCode, string toIsoCode, DateOnly date)
-    {
-        if (string.Equals(fromIsoCode, toIsoCode, StringComparison.Ordinal))
-            return false;
-
-        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-        var startDate = date.AddDays(-(int)_options.DefaultLookback.TotalDays);
-
-        lock (_gate)
-        {
-            if (IsRangeCovered(pair, startDate, date))
-                return false;
-        }
-
-        // Intentional opt-in synchronous fetch on the lookup path, gated by AllowSynchronousNetworkAccess.
-#pragma warning disable VSTHRD002
-        LoadPairAsync(fromIsoCode, toIsoCode, startDate, date).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
-        return true;
-    }
-
-    /// <summary>
-    /// Collects the rates for a pair within a date range from the current book, inverting the reverse series when only
-    /// it is available.
-    /// </summary>
-    /// <param name="pair">The requested pair.</param>
-    /// <param name="startDate">The inclusive start of the range.</param>
-    /// <param name="endDate">The inclusive end of the range.</param>
-    /// <returns>The rates in the range, ordered by date.</returns>
-    private List<ExchangeRate> CollectRates(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
-    {
-        ExchangeRateBook book = _book;
-        List<ExchangeRate> result = new();
-
-        if (book.TryGetSeries(pair, ProviderName, out ExchangeRateSeries? series) && series is not null)
-        {
-            foreach (ExchangeRateObservation observation in series.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, observation.Rate, ProviderName));
-            }
-        }
-        else if (book.TryGetSeries(pair.Inverse(), ProviderName, out ExchangeRateSeries? inverse) && inverse is not null)
-        {
-            foreach (ExchangeRateObservation observation in inverse.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(pair.FromIsoCode, pair.ToIsoCode, observation.Date, 1m / observation.Rate, ProviderName, isInverted: true));
-            }
-        }
-
-        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
-        return result;
     }
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/StubHttpMessageHandler.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/StubHttpMessageHandler.cs
@@ -40,11 +40,21 @@ internal sealed class StubHttpMessageHandler
     /// <returns>The last request URI.</returns>
     public Uri? LastRequestUri { get; private set; }
 
+    /// <summary>
+    /// Gets the raw <c>User-Agent</c> header value on the most recent request, or <see langword="null" /> when none has
+    /// been received or the request carried no such header.
+    /// </summary>
+    /// <returns>The last request's user-agent header value.</returns>
+    public string? LastUserAgent { get; private set; }
+
     /// <inheritdoc />
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         RequestCount++;
         LastRequestUri = request.RequestUri;
+        LastUserAgent = request.Headers.TryGetValues("User-Agent", out IEnumerable<string>? values)
+            ? string.Join(" ", values)
+            : null;
         return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(_content) });
     }
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/StubHttpMessageHandler.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/StubHttpMessageHandler.cs
@@ -40,21 +40,11 @@ internal sealed class StubHttpMessageHandler
     /// <returns>The last request URI.</returns>
     public Uri? LastRequestUri { get; private set; }
 
-    /// <summary>
-    /// Gets the raw <c>User-Agent</c> header value on the most recent request, or <see langword="null" /> when none has
-    /// been received or the request carried no such header.
-    /// </summary>
-    /// <returns>The last request's user-agent header value.</returns>
-    public string? LastUserAgent { get; private set; }
-
     /// <inheritdoc />
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         RequestCount++;
         LastRequestUri = request.RequestUri;
-        LastUserAgent = request.Headers.TryGetValues("User-Agent", out IEnumerable<string>? values)
-            ? string.Join(" ", values)
-            : null;
         return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(_content) });
     }
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSourceTests.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSourceTests.cs
@@ -37,4 +37,37 @@ public class YahooChartExchangeRateSourceTests
         ExchangeRateLookupResult result = provider.GetRate("AUD", "USD", new DateOnly(2023, 1, 3));
         Assert.AreEqual(0.6828m, result.Rate.Rate);
     }
+
+    /// <summary>
+    /// Verifies that the source applies the configured <c>User-Agent</c> header to chart requests, so a directly
+    /// constructed provider presents a recognizable agent rather than being answered with <c>429 Too Many Requests</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task LoadPairAsync_WhenBackedByHttp_ShouldSendConfiguredUserAgentHeader()
+    {
+        StubHttpMessageHandler handler = new(YahooFixtures.ReadBytes(YahooFixtures.AudUsd));
+        using HttpClient client = new(handler);
+        YahooExchangeRateOptions options = new() { UserAgent = "test-agent/1.0" };
+        YahooExchangeRateProvider provider = new(client, options);
+
+        await provider.LoadPairAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31));
+
+        Assert.AreEqual("test-agent/1.0", handler.LastUserAgent);
+    }
+
+    /// <summary>
+    /// Verifies that the default options send a non-empty <c>User-Agent</c> header, the absence of which causes the
+    /// Yahoo Finance endpoint to reject requests with <c>429 Too Many Requests</c>.
+    /// </summary>
+    [TestMethod]
+    public async Task LoadPairAsync_WhenUsingDefaultOptions_ShouldSendNonEmptyUserAgentHeader()
+    {
+        StubHttpMessageHandler handler = new(YahooFixtures.ReadBytes(YahooFixtures.AudUsd));
+        using HttpClient client = new(handler);
+        YahooExchangeRateProvider provider = new(client, new YahooExchangeRateOptions());
+
+        await provider.LoadPairAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31));
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(handler.LastUserAgent));
+    }
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSourceTests.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooChartExchangeRateSourceTests.cs
@@ -37,37 +37,4 @@ public class YahooChartExchangeRateSourceTests
         ExchangeRateLookupResult result = provider.GetRate("AUD", "USD", new DateOnly(2023, 1, 3));
         Assert.AreEqual(0.6828m, result.Rate.Rate);
     }
-
-    /// <summary>
-    /// Verifies that the source applies the configured <c>User-Agent</c> header to chart requests, so a directly
-    /// constructed provider presents a recognizable agent rather than being answered with <c>429 Too Many Requests</c>.
-    /// </summary>
-    [TestMethod]
-    public async Task LoadPairAsync_WhenBackedByHttp_ShouldSendConfiguredUserAgentHeader()
-    {
-        StubHttpMessageHandler handler = new(YahooFixtures.ReadBytes(YahooFixtures.AudUsd));
-        using HttpClient client = new(handler);
-        YahooExchangeRateOptions options = new() { UserAgent = "test-agent/1.0" };
-        YahooExchangeRateProvider provider = new(client, options);
-
-        await provider.LoadPairAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31));
-
-        Assert.AreEqual("test-agent/1.0", handler.LastUserAgent);
-    }
-
-    /// <summary>
-    /// Verifies that the default options send a non-empty <c>User-Agent</c> header, the absence of which causes the
-    /// Yahoo Finance endpoint to reject requests with <c>429 Too Many Requests</c>.
-    /// </summary>
-    [TestMethod]
-    public async Task LoadPairAsync_WhenUsingDefaultOptions_ShouldSendNonEmptyUserAgentHeader()
-    {
-        StubHttpMessageHandler handler = new(YahooFixtures.ReadBytes(YahooFixtures.AudUsd));
-        using HttpClient client = new(handler);
-        YahooExchangeRateProvider provider = new(client, new YahooExchangeRateOptions());
-
-        await provider.LoadPairAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31));
-
-        Assert.IsFalse(string.IsNullOrWhiteSpace(handler.LastUserAgent));
-    }
 }

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.Disposal.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.Disposal.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="YahooExchangeRateProviderTests.Disposal.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial.ExchangeRates.Yahoo;
+
+/// <summary>
+/// Verifies the <see cref="HttpClient" /> ownership and disposal contract of <see cref="YahooExchangeRateProvider" />:
+/// the provider disposes only a client it created, never a caller-supplied one.
+/// </summary>
+public partial class YahooExchangeRateProviderTests
+{
+    /// <summary>
+    /// Verifies that disposing a provider built from a caller-supplied client does not dispose that client.
+    /// </summary>
+    [TestMethod]
+    public async Task Dispose_WhenClientSupplied_ShouldNotDisposeSuppliedClient()
+    {
+        StubHttpMessageHandler handler = new(YahooFixtures.ReadBytes(YahooFixtures.AudUsd));
+        using HttpClient client = new(handler);
+        YahooExchangeRateProvider provider = new(client, new YahooExchangeRateOptions());
+
+        provider.Dispose();
+
+        // The caller still owns the supplied client; disposing the provider must leave it usable.
+        var bytes = await client.GetByteArrayAsync(new Uri("https://query1.finance.yahoo.com/probe"));
+        Assert.IsTrue(bytes.Length > 0);
+    }
+
+    /// <summary>
+    /// Verifies that a provider that owns its client can be constructed and disposed, and that disposal is idempotent.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenClientOwned_ShouldBeIdempotent()
+    {
+        YahooExchangeRateProvider provider = new(new YahooExchangeRateOptions());
+
+        provider.Dispose();
+        provider.Dispose();
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.GetRatesAsync.cs
@@ -18,7 +18,7 @@ public partial class YahooExchangeRateProviderTests
         (YahooExchangeRateProvider provider, _) = Create(allowSync: false);
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31));
+            [.. await provider.GetRatesAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31))];
 
         Assert.AreEqual(3, rates.Count);
         Assert.IsTrue(rates.SequenceEqual(rates.OrderBy(r => r.Date)));
@@ -39,7 +39,7 @@ public partial class YahooExchangeRateProviderTests
         YahooExchangeRateProvider provider = await CreatePreloadedAsync();
 
         IReadOnlyList<ExchangeRate> rates =
-            await provider.GetRatesAsync("USD", "AUD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 3));
+            [.. await provider.GetRatesAsync("USD", "AUD", new DateOnly(2023, 1, 3), new DateOnly(2023, 1, 3))];
 
         Assert.AreEqual(1, rates.Count);
         Assert.IsTrue(rates[0].IsInverted);

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.Matrix.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.Matrix.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="YahooExchangeRateProviderTests.Matrix.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial.ExchangeRates.Yahoo;
+
+/// <summary>
+/// Verifies the symmetric synchronous and asynchronous lookup matrix exposed by
+/// <see cref="YahooExchangeRateProvider" /> through <see cref="WebExchangeRateProvider" />.
+/// </summary>
+public partial class YahooExchangeRateProviderTests
+{
+    /// <summary>
+    /// Verifies that the dated asynchronous lookup resolves the published rate for an exact date.
+    /// </summary>
+    [TestMethod]
+    public async Task GetRateAsync_WhenDated_ShouldReturnPublishedRate()
+    {
+        YahooExchangeRateProvider provider = await CreatePreloadedAsync();
+
+        ExchangeRateLookupResult result = await provider.GetRateAsync("AUD", "USD", new DateOnly(2023, 1, 3));
+
+        Assert.AreEqual(0.6828m, result.Rate.Rate);
+    }
+
+    /// <summary>
+    /// Verifies that the undated synchronous and asynchronous lookups agree and report the provider name.
+    /// </summary>
+    [TestMethod]
+    public async Task GetRate_WhenUndated_ShouldAgreeAcrossSyncAndAsync()
+    {
+        YahooExchangeRateProvider provider = await CreatePreloadedAsync();
+
+        ExchangeRateLookupResult sync = provider.GetRate("AUD", "USD");
+        ExchangeRateLookupResult async = await provider.GetRateAsync("AUD", "USD");
+
+        Assert.AreEqual(sync.Rate.Rate, async.Rate.Rate);
+        Assert.IsTrue(sync.Rate.Rate > 0m);
+        Assert.AreEqual(YahooExchangeRateProvider.ProviderName, sync.Rate.Provider);
+    }
+
+    /// <summary>
+    /// Verifies that the explicit timeless <see cref="IExchangeRateProvider" /> surface returns the same multiplier as
+    /// the rich undated lookup.
+    /// </summary>
+    [TestMethod]
+    public async Task GetRate_WhenAccessedThroughIExchangeRateProvider_ShouldMatchRichResult()
+    {
+        YahooExchangeRateProvider provider = await CreatePreloadedAsync();
+
+        ExchangeRateLookupResult rich = provider.GetRate("AUD", "USD");
+        decimal plain = ((IExchangeRateProvider)provider).GetRate("AUD", "USD");
+
+        Assert.AreEqual(rich.Rate.Rate, plain);
+    }
+
+    /// <summary>
+    /// Verifies that the synchronous range lookup returns the loaded window ordered by date.
+    /// </summary>
+    [TestMethod]
+    public async Task GetRates_WhenLoaded_ShouldReturnWindowOrderedByDate()
+    {
+        YahooExchangeRateProvider provider = await CreatePreloadedAsync();
+
+        List<ExchangeRate> rates = [.. provider.GetRates("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31))];
+
+        Assert.IsTrue(rates.Count > 0);
+        for (var i = 1; i < rates.Count; i++)
+            Assert.IsTrue(rates[i - 1].Date <= rates[i].Date);
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.TimeProvider.cs
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Financial.ExchangeRates.Yahoo/YahooExchangeRateProviderTests.TimeProvider.cs
@@ -21,7 +21,7 @@ public partial class YahooExchangeRateProviderTests
         YahooExchangeRateProvider provider = new(source, options, logger: null, timeProvider);
         await provider.LoadPairAsync("AUD", "USD", new DateOnly(2023, 1, 1), new DateOnly(2023, 1, 31));
 
-        var rate = provider.GetRate("AUD", "USD");
+        var rate = provider.GetRate("AUD", "USD").Rate.Rate;
 
         Assert.AreEqual(0.6855m, rate);
     }

--- a/Bodu.Financial/src/Financial/ExchangeRateHttpClientFactory.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateHttpClientFactory.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateHttpClientFactory.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Creates and configures the <see cref="HttpClient" /> a web-backed exchange-rate provider owns when the caller does
+/// not supply one, applying the HTTP contract (user agent and request timeout) the remote endpoint requires.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A provider that builds its own client owns the HTTP contract with the endpoint: it presents a recognizable
+/// <c>User-Agent</c> (several feeds — Yahoo Finance in particular — answer requests without one with
+/// <c>429 Too Many Requests</c>) and applies the configured request timeout. When the caller supplies a client instead,
+/// provisioning it correctly is the caller's responsibility, so this factory is not involved.
+/// </para>
+/// <para>
+/// The returned client is owned by the provider that requested it and is disposed when that provider is disposed.
+/// </para>
+/// </remarks>
+public static class ExchangeRateHttpClientFactory
+{
+    /// <summary>
+    /// Creates a new <see cref="HttpClient" /> configured with the supplied user agent and request timeout.
+    /// </summary>
+    /// <param name="userAgent">
+    /// The <c>User-Agent</c> header applied to every request. A <see langword="null" />, empty, or white-space value
+    /// suppresses the header.
+    /// </param>
+    /// <param name="httpTimeout">The request timeout applied to the client. Values not greater than zero are ignored.</param>
+    /// <returns>A new, configured <see cref="HttpClient" />.</returns>
+    /// <remarks>
+    /// The timeout is applied to <see cref="HttpClient.Timeout" /> directly because a provider-owned client has no
+    /// resilience handler enforcing a per-attempt timeout; a dependency-injection registration that adds its own
+    /// resilience pipeline supplies its client to the provider instead and does not use this factory.
+    /// </remarks>
+    public static HttpClient Create(string? userAgent, TimeSpan httpTimeout)
+    {
+        var client = new HttpClient();
+
+        if (!string.IsNullOrWhiteSpace(userAgent))
+            client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgent);
+
+        if (httpTimeout > TimeSpan.Zero)
+            client.Timeout = httpTimeout;
+
+        return client;
+    }
+}

--- a/Bodu.Financial/src/Financial/ExchangeRateRangeResult.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateRangeResult.cs
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateRangeResult.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Represents the outcome of a range exchange-rate lookup: the observations that fall within the requested window,
+/// ordered by date, together with the metadata that describes the request and the span actually covered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The type implements <see cref="IReadOnlyList{T}" /> over its <see cref="Rates" />, so it enumerates, indexes, and
+/// composes with LINQ exactly like a plain sequence (<c>foreach (var rate in result)</c>, <c>result[0]</c>,
+/// <c>result.Where(...)</c>) while still exposing the requested window through <see cref="RequestedStartDate" /> and
+/// <see cref="RequestedEndDate" />, and the observed span through <see cref="FirstObservedDate" /> and
+/// <see cref="LastObservedDate" />. Comparing the observed span to the requested window lets a caller see how much of
+/// the window carried data without re-deriving it from the elements.
+/// </para>
+/// <para>
+/// The range lookup does not apply a date-resolution policy and the per-observation provider and inversion flag are
+/// carried on each <see cref="ExchangeRate" />, so no per-row resolution metadata is repeated here.
+/// </para>
+/// </remarks>
+public sealed class ExchangeRateRangeResult
+    : IReadOnlyList<ExchangeRate>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateRangeResult" /> class.
+    /// </summary>
+    /// <param name="fromIsoCode">The requested source-currency ISO code.</param>
+    /// <param name="toIsoCode">The requested destination-currency ISO code.</param>
+    /// <param name="requestedStartDate">The inclusive start of the requested window.</param>
+    /// <param name="requestedEndDate">The inclusive end of the requested window.</param>
+    /// <param name="rates">The observations within the window, ordered by date.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="fromIsoCode" />, <paramref name="toIsoCode" />, or <paramref name="rates" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    public ExchangeRateRangeResult(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly requestedStartDate,
+        DateOnly requestedEndDate,
+        IReadOnlyList<ExchangeRate> rates)
+    {
+        ThrowHelper.ThrowIfNull(fromIsoCode);
+        ThrowHelper.ThrowIfNull(toIsoCode);
+        ThrowHelper.ThrowIfNull(rates);
+
+        FromIsoCode = fromIsoCode;
+        ToIsoCode = toIsoCode;
+        RequestedStartDate = requestedStartDate;
+        RequestedEndDate = requestedEndDate;
+        Rates = rates;
+    }
+
+    /// <summary>
+    /// Gets the requested source-currency ISO code.
+    /// </summary>
+    /// <returns>The source-currency ISO code.</returns>
+    public string FromIsoCode { get; }
+
+    /// <summary>
+    /// Gets the requested destination-currency ISO code.
+    /// </summary>
+    /// <returns>The destination-currency ISO code.</returns>
+    public string ToIsoCode { get; }
+
+    /// <summary>
+    /// Gets the inclusive start of the requested window.
+    /// </summary>
+    /// <returns>The requested start date.</returns>
+    public DateOnly RequestedStartDate { get; }
+
+    /// <summary>
+    /// Gets the inclusive end of the requested window.
+    /// </summary>
+    /// <returns>The requested end date.</returns>
+    public DateOnly RequestedEndDate { get; }
+
+    /// <summary>
+    /// Gets the observations within the window, ordered by date.
+    /// </summary>
+    /// <returns>The rates in the range.</returns>
+    public IReadOnlyList<ExchangeRate> Rates { get; }
+
+    /// <summary>
+    /// Gets the number of observations in the range.
+    /// </summary>
+    /// <returns>The observation count.</returns>
+    public int Count => Rates.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the range contains no observations.
+    /// </summary>
+    /// <returns><see langword="true" /> when no observations are present; otherwise <see langword="false" />.</returns>
+    public bool IsEmpty => Rates.Count == 0;
+
+    /// <summary>
+    /// Gets the earliest observation date present in the range, or <see langword="null" /> when the range is empty.
+    /// </summary>
+    /// <returns>The first observed date, or <see langword="null" />.</returns>
+    public DateOnly? FirstObservedDate => Rates.Count == 0 ? null : Rates[0].Date;
+
+    /// <summary>
+    /// Gets the latest observation date present in the range, or <see langword="null" /> when the range is empty.
+    /// </summary>
+    /// <returns>The last observed date, or <see langword="null" />.</returns>
+    public DateOnly? LastObservedDate => Rates.Count == 0 ? null : Rates[Rates.Count - 1].Date;
+
+    /// <summary>
+    /// Gets the observation at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index.</param>
+    /// <returns>The observation at <paramref name="index" />.</returns>
+    public ExchangeRate this[int index] => Rates[index];
+
+    /// <summary>
+    /// Returns an enumerator that iterates the observations in date order.
+    /// </summary>
+    /// <returns>An enumerator over the observations.</returns>
+    public IEnumerator<ExchangeRate> GetEnumerator() => Rates.GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/Bodu.Financial/src/Financial/FixedDatedExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/FixedDatedExchangeRateProvider.cs
@@ -235,7 +235,7 @@ public sealed class FixedDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRateLookupResult> GetRates(
+    public IEnumerable<ExchangeRate> GetRates(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -247,18 +247,18 @@ public sealed class FixedDatedExchangeRateProvider
             throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_ExchangeRateRangeInverted, nameof(endDate));
 
         ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-        List<ExchangeRateLookupResult> result = new();
+        List<ExchangeRate> result = new();
 
         // Prefer the directly quoted series; fall back to the reverse pair, reporting each observation inverted.
         if (!TryCollectRange(pair, startDate, endDate, isInverted: false, result))
             _ = TryCollectRange(pair.Inverse(), startDate, endDate, isInverted: true, result);
 
-        result.Sort(static (left, right) => left.Rate.Date.CompareTo(right.Rate.Date));
+        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
         return result;
     }
 
     /// <inheritdoc />
-    public ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+    public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -456,7 +456,7 @@ public sealed class FixedDatedExchangeRateProvider
         DateOnly startDate,
         DateOnly endDate,
         bool isInverted,
-        List<ExchangeRateLookupResult> result)
+        List<ExchangeRate> result)
     {
         var priority = _providerPriority;
         for (var i = 0; i < priority.Length; i++)
@@ -472,8 +472,7 @@ public sealed class FixedDatedExchangeRateProvider
                 if (observation.Date < startDate || observation.Date > endDate)
                     continue;
 
-                var rate = ExchangeRate.FromObservedRate(reportedFrom, reportedTo, observation.Date, observation.Rate, series.Provider, isInverted);
-                result.Add(new ExchangeRateLookupResult(rate, observation.Date, ExchangeRateDateResolution.Exact, 0));
+                result.Add(ExchangeRate.FromObservedRate(reportedFrom, reportedTo, observation.Date, observation.Rate, series.Provider, isInverted));
             }
 
             return true;

--- a/Bodu.Financial/src/Financial/FixedDatedExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/FixedDatedExchangeRateProvider.cs
@@ -235,7 +235,7 @@ public sealed class FixedDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRate> GetRates(
+    public ExchangeRateRangeResult GetRates(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -254,11 +254,11 @@ public sealed class FixedDatedExchangeRateProvider
             _ = TryCollectRange(pair.Inverse(), startDate, endDate, isInverted: true, result);
 
         result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
-        return result;
+        return new ExchangeRateRangeResult(fromIsoCode, toIsoCode, startDate, endDate, result);
     }
 
     /// <inheritdoc />
-    public ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
+    public ValueTask<ExchangeRateRangeResult> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial/src/Financial/FixedDatedExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/FixedDatedExchangeRateProvider.cs
@@ -143,6 +143,60 @@ public sealed class FixedDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
+    public ExchangeRateLookupResult GetRate(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null)
+    {
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
+        options ??= ExchangeRateLookupOptions.Exact;
+        options.Validate();
+
+        if (options.AllowSameCurrencyIdentityRate && string.Equals(fromIsoCode, toIsoCode, StringComparison.Ordinal))
+        {
+            var identityDate = LatestDateInBook();
+            ExchangeRate identity = new(fromIsoCode, toIsoCode, identityDate, 1m, IdentityProviderName);
+            return new ExchangeRateLookupResult(identity, identityDate, options.DateResolution, 0);
+        }
+
+        ExchangeRatePair directPair = new(fromIsoCode, toIsoCode);
+
+        if (TryGetLatestRate(directPair, options, isInverted: false, out ExchangeRateLookupResult result))
+            return result;
+
+        if (options.AllowInverse && TryGetLatestRate(directPair.Inverse(), options, isInverted: true, out result))
+            return result;
+
+        throw new KeyNotFoundException(
+            string.Format(
+                CultureInfo.CurrentCulture,
+                FinancialResourceStrings.IO_KeyNotFound_DatedExchangeRate,
+                fromIsoCode,
+                toIsoCode,
+                "(latest)",
+                options.DateResolution,
+                options.ToleranceDays));
+    }
+
+    /// <inheritdoc />
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        new(GetRate(fromIsoCode, toIsoCode, options));
+
+    /// <inheritdoc />
+    public ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly date,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        new(GetRate(fromIsoCode, toIsoCode, date, options));
+
+    /// <inheritdoc />
     public bool TryGetRate(
         string fromIsoCode,
         string toIsoCode,
@@ -181,12 +235,11 @@ public sealed class FixedDatedExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
+    public IEnumerable<ExchangeRateLookupResult> GetRates(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
-        DateOnly endDate,
-        CancellationToken cancellationToken = default)
+        DateOnly endDate)
     {
         FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
         FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
@@ -194,26 +247,24 @@ public sealed class FixedDatedExchangeRateProvider
             throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_ExchangeRateRangeInverted, nameof(endDate));
 
         ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
-        List<ExchangeRate> result = new();
+        List<ExchangeRateLookupResult> result = new();
 
-        var priority = _providerPriority;
-        for (var i = 0; i < priority.Length; i++)
-        {
-            if (!_book.TryGetSeries(pair, priority[i], out ExchangeRateSeries? series) || series is null)
-                continue;
+        // Prefer the directly quoted series; fall back to the reverse pair, reporting each observation inverted.
+        if (!TryCollectRange(pair, startDate, endDate, isInverted: false, result))
+            _ = TryCollectRange(pair.Inverse(), startDate, endDate, isInverted: true, result);
 
-            foreach (ExchangeRateObservation observation in series.GetObservations())
-            {
-                if (observation.Date >= startDate && observation.Date <= endDate)
-                    result.Add(new ExchangeRate(fromIsoCode, toIsoCode, observation.Date, observation.Rate, priority[i]));
-            }
-
-            break;
-        }
-
-        result.Sort(static (left, right) => left.Date.CompareTo(right.Date));
-        return new ValueTask<IReadOnlyList<ExchangeRate>>(result);
+        result.Sort(static (left, right) => left.Rate.Date.CompareTo(right.Rate.Date));
+        return result;
     }
+
+    /// <inheritdoc />
+    public ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly startDate,
+        DateOnly endDate,
+        CancellationToken cancellationToken = default) =>
+        new(GetRates(fromIsoCode, toIsoCode, startDate, endDate));
 
     /// <summary>
     /// Materialises the supplied observations into a multi-provider <see cref="ExchangeRateBook" />, validating that
@@ -343,5 +394,117 @@ public sealed class FixedDatedExchangeRateProvider
 
         result = default;
         return false;
+    }
+
+    /// <summary>
+    /// Attempts to resolve the most recent observation for the supplied <paramref name="pair" /> by walking the provider
+    /// priority and selecting the latest dated observation of the first matching series.
+    /// </summary>
+    /// <param name="pair">The pair to probe, possibly the inverse of the user's requested pair.</param>
+    /// <param name="options">The lookup options to apply.</param>
+    /// <param name="isInverted">
+    /// <see langword="true" /> if <paramref name="pair" /> is the inverse of the originally requested pair, in which
+    /// case the returned rate is inverted before being reported back to the caller.
+    /// </param>
+    /// <param name="result">When this method returns <see langword="true" />, the resolved lookup result.</param>
+    /// <returns><see langword="true" /> if a rate was resolved; otherwise <see langword="false" />.</returns>
+    private bool TryGetLatestRate(
+        ExchangeRatePair pair,
+        ExchangeRateLookupOptions options,
+        bool isInverted,
+        out ExchangeRateLookupResult result)
+    {
+        var priority = _providerPriority;
+        for (var i = 0; i < priority.Length; i++)
+        {
+            if (!_book.TryGetSeries(pair, priority[i], out ExchangeRateSeries? series) || series is null || series.Count == 0)
+                continue;
+
+            // Observations are stored in ascending date order, so the last is the most recent.
+            ExchangeRateObservation latest = series.GetObservations().Last();
+
+            var reportedFrom = isInverted ? pair.ToIsoCode : pair.FromIsoCode;
+            var reportedTo = isInverted ? pair.FromIsoCode : pair.ToIsoCode;
+            var rate = ExchangeRate.FromObservedRate(reportedFrom, reportedTo, latest.Date, latest.Rate, series.Provider, isInverted);
+
+            result = new ExchangeRateLookupResult(rate, latest.Date, options.DateResolution, 0);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Collects the in-window observations for the supplied <paramref name="pair" /> from the first series that matches
+    /// it under the provider priority, appending one <see cref="ExchangeRateLookupResult" /> per observation.
+    /// </summary>
+    /// <param name="pair">The pair to probe, possibly the inverse of the user's requested pair.</param>
+    /// <param name="startDate">The inclusive start of the range.</param>
+    /// <param name="endDate">The inclusive end of the range.</param>
+    /// <param name="isInverted">
+    /// <see langword="true" /> if <paramref name="pair" /> is the inverse of the requested pair, in which case each
+    /// observation is reported inverted.
+    /// </param>
+    /// <param name="result">The accumulator the matching observations are appended to.</param>
+    /// <returns>
+    /// <see langword="true" /> if a series matched the pair (even when no observation falls in the window); otherwise
+    /// <see langword="false" />.
+    /// </returns>
+    private bool TryCollectRange(
+        ExchangeRatePair pair,
+        DateOnly startDate,
+        DateOnly endDate,
+        bool isInverted,
+        List<ExchangeRateLookupResult> result)
+    {
+        var priority = _providerPriority;
+        for (var i = 0; i < priority.Length; i++)
+        {
+            if (!_book.TryGetSeries(pair, priority[i], out ExchangeRateSeries? series) || series is null)
+                continue;
+
+            var reportedFrom = isInverted ? pair.ToIsoCode : pair.FromIsoCode;
+            var reportedTo = isInverted ? pair.FromIsoCode : pair.ToIsoCode;
+
+            foreach (ExchangeRateObservation observation in series.GetObservations())
+            {
+                if (observation.Date < startDate || observation.Date > endDate)
+                    continue;
+
+                var rate = ExchangeRate.FromObservedRate(reportedFrom, reportedTo, observation.Date, observation.Rate, series.Provider, isInverted);
+                result.Add(new ExchangeRateLookupResult(rate, observation.Date, ExchangeRateDateResolution.Exact, 0));
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the latest observation date present across every series in the book, or <see cref="DateOnly.MinValue" />
+    /// when the book is empty. Used to stamp a same-currency identity result on the undated surface.
+    /// </summary>
+    /// <returns>The most recent observation date in the book, or <see cref="DateOnly.MinValue" /> when empty.</returns>
+    private DateOnly LatestDateInBook()
+    {
+        DateOnly max = DateOnly.MinValue;
+        var any = false;
+
+        foreach (ExchangeRateSeriesKey key in _book.Keys)
+        {
+            if (!_book.TryGetSeries(key.Pair, key.Provider, out ExchangeRateSeries? series) || series is null || series.Count == 0)
+                continue;
+
+            DateOnly last = series.GetObservations().Last().Date;
+            if (!any || last > max)
+            {
+                max = last;
+                any = true;
+            }
+        }
+
+        return max;
     }
 }

--- a/Bodu.Financial/src/Financial/IDatedExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/IDatedExchangeRateProvider.cs
@@ -130,7 +130,10 @@ public interface IDatedExchangeRateProvider
     /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
-    /// <returns>The rates in the range ordered by date, or an empty sequence when none are available.</returns>
+    /// <returns>
+    /// An <see cref="ExchangeRateRangeResult" /> carrying the rates in the range ordered by date, the requested window,
+    /// and the observed span; the result is empty when no rates are available.
+    /// </returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
     /// </exception>
@@ -143,7 +146,7 @@ public interface IDatedExchangeRateProvider
     /// within the window rather than resolving a single date. An implementation backed by a remote feed may block to
     /// fetch on demand, or serve only already-loaded data; use <see cref="GetRatesAsync" /> to fetch without blocking.
     /// </remarks>
-    IEnumerable<ExchangeRate> GetRates(
+    ExchangeRateRangeResult GetRates(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -218,7 +221,8 @@ public interface IDatedExchangeRateProvider
     /// <param name="endDate">The inclusive end of the range.</param>
     /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
     /// <returns>
-    /// A task that yields the rates in the range ordered by date, or an empty sequence when none are available.
+    /// A task that yields an <see cref="ExchangeRateRangeResult" /> carrying the rates in the range ordered by date,
+    /// the requested window, and the observed span; the result is empty when no rates are available.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
@@ -232,7 +236,7 @@ public interface IDatedExchangeRateProvider
     /// within the window rather than resolving a single date. Implementations backed by a remote feed may fetch on
     /// demand, which is why the method is asynchronous.
     /// </remarks>
-    ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
+    ValueTask<ExchangeRateRangeResult> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial/src/Financial/IDatedExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/IDatedExchangeRateProvider.cs
@@ -130,11 +130,7 @@ public interface IDatedExchangeRateProvider
     /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
-    /// <returns>
-    /// The rates in the range ordered by date, each wrapped in an <see cref="ExchangeRateLookupResult" /> reporting the
-    /// observation's own date with <see cref="ExchangeRateDateResolution.Exact" /> resolution and a zero offset; an
-    /// empty sequence when none are available.
-    /// </returns>
+    /// <returns>The rates in the range ordered by date, or an empty sequence when none are available.</returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
     /// </exception>
@@ -147,7 +143,7 @@ public interface IDatedExchangeRateProvider
     /// within the window rather than resolving a single date. An implementation backed by a remote feed may block to
     /// fetch on demand, or serve only already-loaded data; use <see cref="GetRatesAsync" /> to fetch without blocking.
     /// </remarks>
-    IEnumerable<ExchangeRateLookupResult> GetRates(
+    IEnumerable<ExchangeRate> GetRates(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -222,10 +218,7 @@ public interface IDatedExchangeRateProvider
     /// <param name="endDate">The inclusive end of the range.</param>
     /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
     /// <returns>
-    /// A task that yields the rates in the range ordered by date, each wrapped in an
-    /// <see cref="ExchangeRateLookupResult" /> reporting the observation's own date with
-    /// <see cref="ExchangeRateDateResolution.Exact" /> resolution and a zero offset; an empty sequence when none are
-    /// available.
+    /// A task that yields the rates in the range ordered by date, or an empty sequence when none are available.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
@@ -239,7 +232,7 @@ public interface IDatedExchangeRateProvider
     /// within the window rather than resolving a single date. Implementations backed by a remote feed may fetch on
     /// demand, which is why the method is asynchronous.
     /// </remarks>
-    ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+    ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial/src/Financial/IDatedExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/IDatedExchangeRateProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="IDatedExchangeRateProvider.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -7,8 +7,8 @@
 namespace Bodu.Financial;
 
 /// <summary>
-/// Defines the contract for an exchange-rate provider that resolves dated lookups and returns metadata describing how
-/// each rate was selected.
+/// Defines the contract for an exchange-rate provider that resolves dated and latest lookups and returns metadata
+/// describing how each rate was selected, over symmetric synchronous and asynchronous surfaces.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,12 +20,43 @@ namespace Bodu.Financial;
 /// <see cref="KeyNotFoundException" />, the latter returns <see langword="false" /> without allocating.
 /// </para>
 /// <para>
-/// Implementations must accept a <see langword="null" /> <paramref name="options" /> argument and substitute
-/// <see cref="ExchangeRateLookupOptions.Exact" /> so callers can opt into the documented safe default by omission.
+/// Implementations must accept a <see langword="null" /> <c>options</c> argument and substitute
+/// <see cref="ExchangeRateLookupOptions.Exact" /> (or, for the undated latest surface, an implementation-defined
+/// most-recent policy) so callers can opt into the documented safe default by omission.
+/// </para>
+/// <para>
+/// Every getter returns the same element type — a single <see cref="ExchangeRateLookupResult" /> for the point
+/// lookups, and an <see cref="IEnumerable{T}" /> of them for the range lookups. The synchronous getters and the
+/// asynchronous getters resolve identical results; the asynchronous surface exists because an implementation backed by a
+/// remote feed may fetch on demand, and the synchronous surface may block to do so (or serve only already-loaded data,
+/// at the implementation's discretion).
 /// </para>
 /// </remarks>
 public interface IDatedExchangeRateProvider
 {
+    /// <summary>
+    /// Resolves the most recent available exchange rate from <paramref name="fromIsoCode" /> to
+    /// <paramref name="toIsoCode" /> under <paramref name="options" />, throwing if no rate is available.
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO-style code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
+    /// <param name="options">
+    /// The lookup rules to apply. <see langword="null" /> selects the implementation's default most-recent policy.
+    /// </param>
+    /// <returns>The resolved <see cref="ExchangeRateLookupResult" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if either ISO code is not a three-character uppercase ASCII code, or if <paramref name="options" /> is
+    /// invalid.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">Thrown if no rate is available for the request.</exception>
+    ExchangeRateLookupResult GetRate(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null);
+
     /// <summary>
     /// Resolves the exchange rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" /> on
     /// <paramref name="date" /> under <paramref name="options" />, throwing if no rate is available.
@@ -99,8 +130,103 @@ public interface IDatedExchangeRateProvider
     /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
     /// <param name="startDate">The inclusive start of the range.</param>
     /// <param name="endDate">The inclusive end of the range.</param>
+    /// <returns>
+    /// The rates in the range ordered by date, each wrapped in an <see cref="ExchangeRateLookupResult" /> reporting the
+    /// observation's own date with <see cref="ExchangeRateDateResolution.Exact" /> resolution and a zero offset; an
+    /// empty sequence when none are available.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if either ISO code is not a three-character uppercase ASCII code, or if <paramref name="endDate" />
+    /// precedes <paramref name="startDate" />.
+    /// </exception>
+    /// <remarks>
+    /// The lookup is range-based and does not apply a date-resolution policy: it returns the observations that exist
+    /// within the window rather than resolving a single date. An implementation backed by a remote feed may block to
+    /// fetch on demand, or serve only already-loaded data; use <see cref="GetRatesAsync" /> to fetch without blocking.
+    /// </remarks>
+    IEnumerable<ExchangeRateLookupResult> GetRates(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly startDate,
+        DateOnly endDate);
+
+    /// <summary>
+    /// Asynchronously resolves the most recent available exchange rate from <paramref name="fromIsoCode" /> to
+    /// <paramref name="toIsoCode" /> under <paramref name="options" />, throwing if no rate is available.
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO-style code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
+    /// <param name="options">
+    /// The lookup rules to apply. <see langword="null" /> selects the implementation's default most-recent policy.
+    /// </param>
     /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
-    /// <returns>The rates in the range ordered by date, or an empty list when none are available.</returns>
+    /// <returns>A task that yields the resolved <see cref="ExchangeRateLookupResult" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if either ISO code is not a three-character uppercase ASCII code, or if <paramref name="options" /> is
+    /// invalid.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">Thrown if no rate is available for the request.</exception>
+    ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously resolves the exchange rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" />
+    /// on <paramref name="date" /> under <paramref name="options" />, throwing if no rate is available.
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO-style code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
+    /// <param name="date">The calendar date for which a rate is required.</param>
+    /// <param name="options">
+    /// The lookup rules to apply, including date-resolution policy and tolerance. <see langword="null" /> is treated as
+    /// <see cref="ExchangeRateLookupOptions.Exact" />.
+    /// </param>
+    /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
+    /// <returns>A task that yields the resolved <see cref="ExchangeRateLookupResult" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if either ISO code is not a three-character uppercase ASCII code, or if <paramref name="options" /> is
+    /// invalid.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="options" /> contains a negative tolerance or an undefined enum value.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown if no rate is available for the request under the supplied options.
+    /// </exception>
+    ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly date,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously returns every available rate from <paramref name="fromIsoCode" /> to <paramref name="toIsoCode" />
+    /// whose observation date falls within the inclusive range <paramref name="startDate" /> to
+    /// <paramref name="endDate" />.
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO-style code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO-style code.</param>
+    /// <param name="startDate">The inclusive start of the range.</param>
+    /// <param name="endDate">The inclusive end of the range.</param>
+    /// <param name="cancellationToken">A token to observe while awaiting the operation.</param>
+    /// <returns>
+    /// A task that yields the rates in the range ordered by date, each wrapped in an
+    /// <see cref="ExchangeRateLookupResult" /> reporting the observation's own date with
+    /// <see cref="ExchangeRateDateResolution.Exact" /> resolution and a zero offset; an empty sequence when none are
+    /// available.
+    /// </returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="fromIsoCode" /> or <paramref name="toIsoCode" /> is <see langword="null" />.
     /// </exception>
@@ -113,7 +239,7 @@ public interface IDatedExchangeRateProvider
     /// within the window rather than resolving a single date. Implementations backed by a remote feed may fetch on
     /// demand, which is why the method is asynchronous.
     /// </remarks>
-    ValueTask<IReadOnlyList<ExchangeRate>> GetRatesAsync(
+    ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial/src/Financial/WebExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/WebExchangeRateProvider.cs
@@ -103,7 +103,7 @@ public abstract class WebExchangeRateProvider
     /// Gets the provider identifier stamped on every rate this provider produces.
     /// </summary>
     /// <returns>The provider identifier.</returns>
-    protected abstract string ProviderName { get; }
+    protected abstract string ProviderId { get; }
 
     /// <summary>
     /// Gets a value indicating whether a synchronous lookup may block to fetch a missing window on demand.
@@ -163,12 +163,13 @@ public abstract class WebExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRateLookupResult> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
         FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
         FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
         if (endDate < startDate)
             throw CreateRangeInvertedException(startDate, endDate);
+        ValidateRangeRequest(fromIsoCode, toIsoCode, startDate, endDate);
 
         ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
 
@@ -218,7 +219,7 @@ public abstract class WebExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+    public async ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,
@@ -229,6 +230,7 @@ public abstract class WebExchangeRateProvider
         FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
         if (endDate < startDate)
             throw CreateRangeInvertedException(startDate, endDate);
+        ValidateRangeRequest(fromIsoCode, toIsoCode, startDate, endDate);
 
         ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
         await EnsureLoadedAsync(pair, startDate, endDate, cancellationToken).ConfigureAwait(false);
@@ -284,7 +286,7 @@ public abstract class WebExchangeRateProvider
         var count = 0;
         foreach (ExchangeRate rate in rates)
         {
-            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderId, rate.Date, rate.Rate);
             OnObservationIngested(rate);
             count++;
         }
@@ -316,6 +318,19 @@ public abstract class WebExchangeRateProvider
     /// </summary>
     /// <param name="date">The date around which the fetch was performed.</param>
     protected virtual void OnSynchronousNetworkFetch(DateOnly date)
+    {
+    }
+
+    /// <summary>
+    /// Validates a range request against feed-specific preconditions before any fetch is attempted. The default does
+    /// nothing; derived types may override to reject unsupported pairs (for example, a single-issuer feed that quotes
+    /// only against one base currency).
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="startDate">The inclusive start of the range.</param>
+    /// <param name="endDate">The inclusive end of the range.</param>
+    protected virtual void ValidateRangeRequest(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
     }
 

--- a/Bodu.Financial/src/Financial/WebExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/WebExchangeRateProvider.cs
@@ -1,0 +1,403 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WebExchangeRateProvider.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Provides the shared machinery for an exchange-rate provider that materializes a remote feed into an in-memory
+/// <see cref="ExchangeRateBook" /> snapshot: it owns the accumulator and the immutable snapshot, implements the full
+/// synchronous and asynchronous lookup matrix once, and optionally owns the <see cref="HttpClient" /> used to reach the
+/// feed. Derived types supply only the feed-specific fetch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>HttpClient ownership.</strong> A derived provider constructed without a caller-supplied client builds and
+/// owns its own (typically through <see cref="ExchangeRateHttpClientFactory.Create(string?, TimeSpan)" />), passing it
+/// to this base so it is disposed with the provider. A provider constructed with a caller-supplied client passes
+/// <see langword="null" /> as the owned client, leaving its lifetime — and its HTTP contract (user agent, timeout) — to
+/// the caller. This is the path a dependency-injection registration uses, supplying a client from
+/// <c>IHttpClientFactory</c>.
+/// </para>
+/// <para>
+/// <strong>Lookup matrix.</strong> All getters resolve against the current immutable snapshot. The synchronous point
+/// and range getters block to fetch on a miss only when <see cref="AllowSynchronousNetworkAccess" /> is enabled; the
+/// asynchronous getters always await a coverage-aware fetch. The undated getters resolve the most recent rate as of the
+/// current instant supplied by the time provider. Derived types implement the feed-specific
+/// <see cref="EnsureLoadedAsync(ExchangeRatePair, DateOnly, DateOnly, CancellationToken)" /> and
+/// <see cref="IsLoaded(ExchangeRatePair, DateOnly, DateOnly)" /> and accumulate fetched observations through
+/// <see cref="AddObservations(IEnumerable{ExchangeRate})" /> followed by <see cref="RebuildSnapshot" />, all under
+/// <see cref="SyncRoot" />.
+/// </para>
+/// </remarks>
+public abstract class WebExchangeRateProvider
+    : IDatedExchangeRateProvider, IExchangeRateProvider, IDisposable
+{
+    /// <summary>
+    /// The tolerance, in days, used to resolve the most recent rate for the undated surfaces; large enough to reach any
+    /// rate fetched into the store from the current date.
+    /// </summary>
+    private const int LatestRateToleranceDays = 100_000;
+
+    /// <summary>
+    /// Guards mutation of the accumulator and the snapshot fields, and is shared with derived types for their own
+    /// coverage and series indexes so a fetch publishes atomically.
+    /// </summary>
+    private readonly object _gate = new();
+
+    /// <summary>
+    /// The accumulator into which each fetched observation is upserted.
+    /// </summary>
+    private readonly ExchangeRateTableBuilder _builder = new();
+
+    /// <summary>
+    /// The time source used to resolve the current instant for the undated surfaces.
+    /// </summary>
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// The HTTP client owned by this provider, disposed with it; <see langword="null" /> when the client was supplied by
+    /// the caller and its lifetime is the caller's responsibility.
+    /// </summary>
+    private readonly HttpClient? _ownedHttpClient;
+
+    /// <summary>
+    /// The current immutable book backing range queries; replaced under <see cref="_gate" /> after each fetch.
+    /// </summary>
+    private volatile ExchangeRateBook _book;
+
+    /// <summary>
+    /// The current immutable lookup snapshot; replaced under <see cref="_gate" /> after each fetch.
+    /// </summary>
+    private volatile FixedDatedExchangeRateProvider _snapshot;
+
+    /// <summary>
+    /// Tracks whether this instance has been disposed so disposal is idempotent.
+    /// </summary>
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebExchangeRateProvider" /> class.
+    /// </summary>
+    /// <param name="ownedHttpClient">
+    /// The HTTP client this provider should own and dispose, or <see langword="null" /> when the client is
+    /// caller-supplied and its lifetime is the caller's responsibility.
+    /// </param>
+    /// <param name="timeProvider">
+    /// The time source used to resolve the current instant for the undated surfaces. <see langword="null" /> selects
+    /// <see cref="TimeProvider.System" />.
+    /// </param>
+    protected WebExchangeRateProvider(HttpClient? ownedHttpClient, TimeProvider? timeProvider)
+    {
+        _ownedHttpClient = ownedHttpClient;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _book = _builder.ToBook();
+        _snapshot = new FixedDatedExchangeRateProvider(_book);
+    }
+
+    /// <summary>
+    /// Gets the provider identifier stamped on every rate this provider produces.
+    /// </summary>
+    /// <returns>The provider identifier.</returns>
+    protected abstract string ProviderName { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a synchronous lookup may block to fetch a missing window on demand.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> when synchronous getters may block on the network; otherwise <see langword="false" />.
+    /// </returns>
+    protected abstract bool AllowSynchronousNetworkAccess { get; }
+
+    /// <summary>
+    /// Gets the look-back window used when a single-rate lookup must fetch on demand; the provider fetches the window
+    /// ending on the requested date and spanning this duration.
+    /// </summary>
+    /// <returns>The look-back window.</returns>
+    protected abstract TimeSpan DefaultLookback { get; }
+
+    /// <summary>
+    /// Gets the synchronization object guarding the accumulator and snapshot; derived types lock on it while checking
+    /// coverage and accumulating a fetch so the fetch publishes atomically.
+    /// </summary>
+    /// <returns>The synchronization object.</returns>
+    protected object SyncRoot => _gate;
+
+    /// <summary>
+    /// Gets the time source used to resolve the current instant.
+    /// </summary>
+    /// <returns>The time provider.</returns>
+    protected TimeProvider TimeProvider => _timeProvider;
+
+    /// <inheritdoc />
+    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, ExchangeRateLookupOptions? options = null)
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+        return GetRate(fromIsoCode, toIsoCode, today, options ?? ExchangeRateLookupOptions.PreviousWithin(LatestRateToleranceDays));
+    }
+
+    /// <inheritdoc />
+    public ExchangeRateLookupResult GetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options = null) =>
+        TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
+            ? result
+            : throw new KeyNotFoundException(FormatRateNotFound(fromIsoCode, toIsoCode, date));
+
+    /// <inheritdoc />
+    public bool TryGetRate(string fromIsoCode, string toIsoCode, DateOnly date, ExchangeRateLookupOptions? options, out ExchangeRateLookupResult result)
+    {
+        if (_snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result))
+            return true;
+
+        if (AllowSynchronousNetworkAccess && TryLoadForDate(fromIsoCode, toIsoCode, date))
+        {
+            OnSynchronousNetworkFetch(date);
+            return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out result);
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ExchangeRateLookupResult> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    {
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
+        if (endDate < startDate)
+            throw CreateRangeInvertedException(startDate, endDate);
+
+        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
+
+        if (AllowSynchronousNetworkAccess && !IsLoaded(pair, startDate, endDate))
+            BlockingLoad(pair, startDate, endDate);
+
+        return _snapshot.GetRates(fromIsoCode, toIsoCode, startDate, endDate);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var today = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+        return await GetRateAsync(
+            fromIsoCode,
+            toIsoCode,
+            today,
+            options ?? ExchangeRateLookupOptions.PreviousWithin(LatestRateToleranceDays),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ExchangeRateLookupResult> GetRateAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly date,
+        ExchangeRateLookupOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(fromIsoCode, toIsoCode, StringComparison.Ordinal))
+        {
+            FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
+            FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
+
+            ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
+            var startDate = date.AddDays(-(int)DefaultLookback.TotalDays);
+            await EnsureLoadedAsync(pair, startDate, date, cancellationToken).ConfigureAwait(false);
+        }
+
+        return _snapshot.TryGetRate(fromIsoCode, toIsoCode, date, options, out ExchangeRateLookupResult result)
+            ? result
+            : throw new KeyNotFoundException(FormatRateNotFound(fromIsoCode, toIsoCode, date));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<ExchangeRateLookupResult>> GetRatesAsync(
+        string fromIsoCode,
+        string toIsoCode,
+        DateOnly startDate,
+        DateOnly endDate,
+        CancellationToken cancellationToken = default)
+    {
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
+        if (endDate < startDate)
+            throw CreateRangeInvertedException(startDate, endDate);
+
+        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
+        await EnsureLoadedAsync(pair, startDate, endDate, cancellationToken).ConfigureAwait(false);
+
+        return _snapshot.GetRates(fromIsoCode, toIsoCode, startDate, endDate);
+    }
+
+    /// <inheritdoc />
+    decimal IExchangeRateProvider.GetRate(string fromIsoCode, string toIsoCode) =>
+        GetRate(fromIsoCode, toIsoCode).Rate.Rate;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Ensures the inclusive window for a pair has been fetched and accumulated, idempotently. Implementations perform
+    /// their own coverage check, request coalescing, fetch, and accumulation (via
+    /// <see cref="AddObservations(IEnumerable{ExchangeRate})" /> and <see cref="RebuildSnapshot" /> under
+    /// <see cref="SyncRoot" />).
+    /// </summary>
+    /// <param name="pair">The currency pair to ensure data for. Feeds that fetch by range, feed, or file may ignore it.</param>
+    /// <param name="startDate">The inclusive start of the window.</param>
+    /// <param name="endDate">The inclusive end of the window.</param>
+    /// <param name="cancellationToken">A token to observe while awaiting the fetch.</param>
+    /// <returns>A task that completes when the window has been loaded.</returns>
+    protected abstract ValueTask EnsureLoadedAsync(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reports whether the inclusive window for a pair has already been fetched, so the synchronous lookup path can skip
+    /// a redundant blocking fetch.
+    /// </summary>
+    /// <param name="pair">The currency pair to test.</param>
+    /// <param name="startDate">The inclusive start of the window.</param>
+    /// <param name="endDate">The inclusive end of the window.</param>
+    /// <returns><see langword="true" /> when the window is already covered; otherwise <see langword="false" />.</returns>
+    protected abstract bool IsLoaded(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate);
+
+    /// <summary>
+    /// Upserts a batch of fetched observations into the accumulator under the provider's identifier, invoking
+    /// <see cref="OnObservationIngested(ExchangeRate)" /> for each. The caller must hold <see cref="SyncRoot" /> and
+    /// follow the batch with <see cref="RebuildSnapshot" />.
+    /// </summary>
+    /// <param name="rates">The observations to upsert.</param>
+    /// <returns>The number of observations upserted.</returns>
+    protected int AddObservations(IEnumerable<ExchangeRate> rates)
+    {
+        ThrowHelper.ThrowIfNull(rates);
+
+        var count = 0;
+        foreach (ExchangeRate rate in rates)
+        {
+            _builder.Upsert(new ExchangeRatePair(rate.FromIsoCode, rate.ToIsoCode), ProviderName, rate.Date, rate.Rate);
+            OnObservationIngested(rate);
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Rebuilds the immutable book and lookup snapshot from the accumulator. The caller must hold
+    /// <see cref="SyncRoot" />.
+    /// </summary>
+    protected void RebuildSnapshot()
+    {
+        _book = _builder.ToBook();
+        _snapshot = new FixedDatedExchangeRateProvider(_book);
+    }
+
+    /// <summary>
+    /// Called once per observation as it is ingested, for derived-type diagnostics. The default does nothing.
+    /// </summary>
+    /// <param name="rate">The observation being ingested.</param>
+    protected virtual void OnObservationIngested(ExchangeRate rate)
+    {
+    }
+
+    /// <summary>
+    /// Called after a synchronous lookup blocks to fetch on demand, for derived-type diagnostics. The default does
+    /// nothing.
+    /// </summary>
+    /// <param name="date">The date around which the fetch was performed.</param>
+    protected virtual void OnSynchronousNetworkFetch(DateOnly date)
+    {
+    }
+
+    /// <summary>
+    /// Creates the exception thrown when an inclusive date range is inverted. Derived types may override to throw a
+    /// feed-specific exception type.
+    /// </summary>
+    /// <param name="startDate">The inclusive start of the range.</param>
+    /// <param name="endDate">The inclusive end of the range.</param>
+    /// <returns>The exception to throw.</returns>
+    protected virtual Exception CreateRangeInvertedException(DateOnly startDate, DateOnly endDate) =>
+        new ArgumentException(FinancialResourceStrings.Arg_Invalid_ExchangeRateRangeInverted, nameof(endDate));
+
+    /// <summary>
+    /// Formats the message for the <see cref="KeyNotFoundException" /> thrown when a single-rate lookup fails. Derived
+    /// types may override to use a feed-specific resource string.
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The requested date.</param>
+    /// <returns>The exception message.</returns>
+    protected virtual string FormatRateNotFound(string fromIsoCode, string toIsoCode, DateOnly date) =>
+        string.Format(
+            CultureInfo.CurrentCulture,
+            FinancialResourceStrings.IO_KeyNotFound_DatedExchangeRate,
+            fromIsoCode,
+            toIsoCode,
+            date,
+            ExchangeRateDateResolution.Exact,
+            0);
+
+    /// <summary>
+    /// Releases the resources used by this provider; disposes the owned <see cref="HttpClient" /> when one was created.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true" /> when called from <see cref="Dispose()" />; <see langword="false" /> when called from a
+    /// finalizer.
+    /// </param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (disposing)
+            _ownedHttpClient?.Dispose();
+
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Synchronously fetches a window around a date for the on-demand single-rate path, unless the pair is a
+    /// same-currency request or the window is already covered.
+    /// </summary>
+    /// <param name="fromIsoCode">The source-currency ISO code.</param>
+    /// <param name="toIsoCode">The destination-currency ISO code.</param>
+    /// <param name="date">The date around which to fetch.</param>
+    /// <returns><see langword="true" /> when a fetch was attempted; otherwise <see langword="false" />.</returns>
+    private bool TryLoadForDate(string fromIsoCode, string toIsoCode, DateOnly date)
+    {
+        if (string.Equals(fromIsoCode, toIsoCode, StringComparison.Ordinal))
+            return false;
+
+        ExchangeRatePair pair = new(fromIsoCode, toIsoCode);
+        var startDate = date.AddDays(-(int)DefaultLookback.TotalDays);
+
+        if (IsLoaded(pair, startDate, date))
+            return false;
+
+        BlockingLoad(pair, startDate, date);
+        return true;
+    }
+
+    /// <summary>
+    /// Blocks on the asynchronous load for the supplied window. Used only on the opt-in synchronous network path.
+    /// </summary>
+    /// <param name="pair">The currency pair to fetch.</param>
+    /// <param name="startDate">The inclusive start of the window.</param>
+    /// <param name="endDate">The inclusive end of the window.</param>
+    private void BlockingLoad(ExchangeRatePair pair, DateOnly startDate, DateOnly endDate)
+    {
+#pragma warning disable VSTHRD002 // Intentional opt-in synchronous fetch, gated by AllowSynchronousNetworkAccess.
+        EnsureLoadedAsync(pair, startDate, endDate, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+    }
+}

--- a/Bodu.Financial/src/Financial/WebExchangeRateProvider.cs
+++ b/Bodu.Financial/src/Financial/WebExchangeRateProvider.cs
@@ -163,7 +163,7 @@ public abstract class WebExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public IEnumerable<ExchangeRate> GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
+    public ExchangeRateRangeResult GetRates(string fromIsoCode, string toIsoCode, DateOnly startDate, DateOnly endDate)
     {
         FinancialThrowHelper.ThrowIfNotValidIsoCode(fromIsoCode);
         FinancialThrowHelper.ThrowIfNotValidIsoCode(toIsoCode);
@@ -219,7 +219,7 @@ public abstract class WebExchangeRateProvider
     }
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<ExchangeRate>> GetRatesAsync(
+    public async ValueTask<ExchangeRateRangeResult> GetRatesAsync(
         string fromIsoCode,
         string toIsoCode,
         DateOnly startDate,

--- a/Bodu.Financial/test/Financial/ExchangeRateHttpClientFactoryTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateHttpClientFactoryTests.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateHttpClientFactoryTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies that <see cref="ExchangeRateHttpClientFactory" /> applies the HTTP contract (user agent and timeout) used by
+/// a provider that owns its <see cref="HttpClient" />.
+/// </summary>
+[TestClass]
+public class ExchangeRateHttpClientFactoryTests
+{
+    /// <summary>
+    /// Verifies that a non-empty user agent is set on the created client's default request headers.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenUserAgentProvided_ShouldSetUserAgentHeader()
+    {
+        using HttpClient client = ExchangeRateHttpClientFactory.Create("test-agent/1.0", TimeSpan.FromSeconds(30));
+
+        Assert.IsTrue(client.DefaultRequestHeaders.TryGetValues("User-Agent", out IEnumerable<string>? values));
+        Assert.AreEqual("test-agent/1.0", string.Join(" ", values!));
+    }
+
+    /// <summary>
+    /// Verifies that a white-space user agent leaves the header unset.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenUserAgentWhiteSpace_ShouldNotSetUserAgentHeader()
+    {
+        using HttpClient client = ExchangeRateHttpClientFactory.Create("   ", TimeSpan.FromSeconds(30));
+
+        Assert.IsFalse(client.DefaultRequestHeaders.Contains("User-Agent"));
+    }
+
+    /// <summary>
+    /// Verifies that a positive timeout is applied to the created client.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenTimeoutPositive_ShouldApplyTimeout()
+    {
+        using HttpClient client = ExchangeRateHttpClientFactory.Create(null, TimeSpan.FromSeconds(42));
+
+        Assert.AreEqual(TimeSpan.FromSeconds(42), client.Timeout);
+    }
+}

--- a/Bodu.Financial/test/Financial/FixedDatedExchangeRateProviderTests.GetRate.cs
+++ b/Bodu.Financial/test/Financial/FixedDatedExchangeRateProviderTests.GetRate.cs
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FixedDatedExchangeRateProviderTests.GetRate.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class FixedDatedExchangeRateProviderTests
+{
+    /// <summary>
+    /// Verifies that the undated lookup resolves the most recent observation for the pair.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenUndated_ShouldReturnMostRecentObservation()
+    {
+        FixedDatedExchangeRateProvider table = new(
+        [
+            new ExchangeRate("AUD", "USD", new DateOnly(2024, 1, 3), 0.67m, "RBA"),
+            new ExchangeRate("AUD", "USD", new DateOnly(2024, 1, 10), 0.69m, "RBA"),
+            new ExchangeRate("AUD", "USD", new DateOnly(2024, 1, 6), 0.68m, "RBA"),
+        ]);
+
+        ExchangeRateLookupResult result = table.GetRate("AUD", "USD");
+
+        Assert.AreEqual(new DateOnly(2024, 1, 10), result.Rate.Date);
+        Assert.AreEqual(0.69m, result.Rate.Rate);
+        Assert.AreEqual(0, result.OffsetDays);
+    }
+
+    /// <summary>
+    /// Verifies that the undated lookup inverts the reverse pair when only it is available.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenUndatedAndOnlyInverseAvailable_ShouldReturnInvertedMostRecent()
+    {
+        FixedDatedExchangeRateProvider table = new(
+        [
+            new ExchangeRate("USD", "AUD", new DateOnly(2024, 1, 3), 1.50m, "RBA"),
+            new ExchangeRate("USD", "AUD", new DateOnly(2024, 1, 10), 1.25m, "RBA"),
+        ]);
+
+        ExchangeRateLookupResult result = table.GetRate("AUD", "USD");
+
+        Assert.AreEqual(new DateOnly(2024, 1, 10), result.Rate.Date);
+        Assert.IsTrue(result.Rate.IsInverted);
+        Assert.AreEqual(1m / 1.25m, result.Rate.Rate);
+    }
+
+    /// <summary>
+    /// Verifies that the undated lookup throws when no observation exists for the pair.
+    /// </summary>
+    [TestMethod]
+    public void GetRate_WhenUndatedAndPairAbsent_ShouldThrowKeyNotFoundException()
+    {
+        FixedDatedExchangeRateProvider table = new(
+        [
+            new ExchangeRate("AUD", "USD", new DateOnly(2024, 1, 3), 0.67m, "RBA"),
+        ]);
+
+        _ = Assert.ThrowsExactly<KeyNotFoundException>(() =>
+        {
+            _ = table.GetRate("EUR", "JPY");
+        });
+    }
+}

--- a/Bodu.Financial/test/Financial/FixedDatedExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial/test/Financial/FixedDatedExchangeRateProviderTests.GetRatesAsync.cs
@@ -58,4 +58,48 @@ public partial class FixedDatedExchangeRateProviderTests
 
         Assert.AreEqual("endDate", ex.ParamName);
     }
+
+    /// <summary>
+    /// Verifies that the range result reports the requested window and the observed span alongside the rates.
+    /// </summary>
+    [TestMethod]
+    public void GetRates_WhenObservationsInRange_ShouldReportRequestedWindowAndObservedSpan()
+    {
+        FixedDatedExchangeRateProvider table = new(
+        [
+            new ExchangeRate("USD", "AUD", new DateOnly(2024, 1, 6), 1.52m, "RBA"),
+            new ExchangeRate("USD", "AUD", new DateOnly(2024, 1, 3), 1.50m, "RBA"),
+            new ExchangeRate("USD", "AUD", new DateOnly(2024, 1, 10), 1.55m, "RBA"),
+        ]);
+
+        ExchangeRateRangeResult result = table.GetRates("USD", "AUD", new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 8));
+
+        Assert.AreEqual("USD", result.FromIsoCode);
+        Assert.AreEqual("AUD", result.ToIsoCode);
+        Assert.AreEqual(new DateOnly(2024, 1, 1), result.RequestedStartDate);
+        Assert.AreEqual(new DateOnly(2024, 1, 8), result.RequestedEndDate);
+        Assert.AreEqual(2, result.Count);
+        Assert.IsFalse(result.IsEmpty);
+        Assert.AreEqual(new DateOnly(2024, 1, 3), result.FirstObservedDate);
+        Assert.AreEqual(new DateOnly(2024, 1, 6), result.LastObservedDate);
+
+        // The result is itself the rate sequence (indexable, enumerable, LINQ-friendly).
+        Assert.AreEqual(new DateOnly(2024, 1, 3), result[0].Date);
+    }
+
+    /// <summary>
+    /// Verifies that an empty range result reports no observed span.
+    /// </summary>
+    [TestMethod]
+    public void GetRates_WhenPairAbsent_ShouldReportEmptyWithNullObservedSpan()
+    {
+        FixedDatedExchangeRateProvider table = new(SingleRate());
+
+        ExchangeRateRangeResult result = table.GetRates("EUR", "JPY", new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 31));
+
+        Assert.IsTrue(result.IsEmpty);
+        Assert.AreEqual(0, result.Count);
+        Assert.IsNull(result.FirstObservedDate);
+        Assert.IsNull(result.LastObservedDate);
+    }
 }

--- a/Bodu.Financial/test/Financial/FixedDatedExchangeRateProviderTests.GetRatesAsync.cs
+++ b/Bodu.Financial/test/Financial/FixedDatedExchangeRateProviderTests.GetRatesAsync.cs
@@ -22,7 +22,7 @@ public partial class FixedDatedExchangeRateProviderTests
         ]);
 
         IReadOnlyList<ExchangeRate> rates =
-            await table.GetRatesAsync("USD", "AUD", new DateOnly(2024, 1, 3), new DateOnly(2024, 1, 6));
+            [.. await table.GetRatesAsync("USD", "AUD", new DateOnly(2024, 1, 3), new DateOnly(2024, 1, 6))];
 
         Assert.AreEqual(2, rates.Count);
         Assert.AreEqual(new DateOnly(2024, 1, 3), rates[0].Date);
@@ -38,7 +38,7 @@ public partial class FixedDatedExchangeRateProviderTests
         FixedDatedExchangeRateProvider table = new(SingleRate());
 
         IReadOnlyList<ExchangeRate> rates =
-            await table.GetRatesAsync("EUR", "JPY", new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 31));
+            [.. await table.GetRatesAsync("EUR", "JPY", new DateOnly(2024, 1, 1), new DateOnly(2024, 1, 31))];
 
         Assert.AreEqual(0, rates.Count);
     }


### PR DESCRIPTION
The Yahoo Finance chart endpoint answers requests that omit a recognizable
User-Agent with 429 Too Many Requests. The User-Agent from
YahooExchangeRateOptions.UserAgent was only applied by the dependency-injection
registration (onto HttpClient.DefaultRequestHeaders), so a provider constructed
directly with a bare HttpClient sent no User-Agent and was rejected.

Apply the header per request in YahooChartExchangeRateSource via
HttpRequestMessage/SendAsync, so it is honored whether the provider is built
directly or resolved from DI, without mutating the shared client. Non-success
responses still surface via EnsureSuccessStatusCode.

https://claude.ai/code/session_01BL3rBF4AdQMi1uQhXGhA9e