### PR TITLE
docs: apidoc pages for the SQLite and distributed exchange-rate cache backends

### DIFF
--- a/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.md
+++ b/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.md
@@ -1,0 +1,44 @@
+---
+uid: Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection
+---
+
+# Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection
+
+## Purpose
+
+**Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection** provides the `Microsoft.Extensions.DependencyInjection` wiring for the [distributed exchange-rate cache](Bodu.Financial.ExchangeRates.Caching.Distributed.md). Both methods on the <xref:Bodu.Financial.DependencyInjection.IFinancialServiceBuilder> bind <xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DistributedExchangeRateCacheOptions> (default section `Financial:ExchangeRateCache:Distributed`) and register a singleton <xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DistributedExchangeRateCache> bound to the provider, resolvable as <xref:Bodu.Financial.ExchangeRates.Caching.IExchangeRateCache> and as a keyed `IExchangeRateCache` under the provider name; options validate on start:
+
+- `AddDistributedExchangeRateCache(name, …)` binds over the `IDistributedCache` already registered in the container (Redis, in-memory, SQL Server, …).
+- `AddRedisExchangeRateCache(name, configureRedis, …)` is a convenience that first registers a Redis `IDistributedCache` (via `AddStackExchangeRedisCache`) and then the exchange-rate cache over it.
+
+## Static documentation
+
+- **[Caching and aggregating exchange rates guide](~/guides/financial/exchange-rate-caching.md)** — see *Persistent and shared backends*.
+
+## Key types
+
+- <xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.DistributedExchangeRateCacheServiceBuilderExtensions> — the registration surface:
+  - `AddDistributedExchangeRateCache(providerName, configuration?, sectionName?, configure?)` — over an existing `IDistributedCache`.
+  - `AddRedisExchangeRateCache(configureRedis, providerName, configuration?, sectionName?, configure?)` — registers Redis and the cache together.
+
+## Minimal sample
+
+```csharp
+using Bodu.Financial.DependencyInjection;
+using Bodu.Financial.ExchangeRates.Caching;
+using Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+// Over an already-registered IDistributedCache.
+services.AddStackExchangeRedisCache(o => o.Configuration = "localhost:6379");
+services.AddBoduFinancial()
+        .AddDistributedExchangeRateCache("RBA");
+
+// Or register Redis and the cache together.
+services.AddBoduFinancial()
+        .AddRedisExchangeRateCache("RBA", redis => redis.Configuration = "localhost:6379");
+
+var cache = provider.GetRequiredService<IExchangeRateCache>();
+```
+
+See the [caching guide](~/guides/financial/exchange-rate-caching.md) for the read-through decorator the cache backs.

--- a/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Distributed.md
+++ b/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Distributed.md
@@ -1,0 +1,36 @@
+---
+uid: Bodu.Financial.ExchangeRates.Caching.Distributed
+---
+
+# Bodu.Financial.ExchangeRates.Caching.Distributed
+
+## Purpose
+
+**Bodu.Financial.ExchangeRates.Caching.Distributed** is a distributed (Redis-capable) <xref:Bodu.Financial.ExchangeRates.Caching.IExchangeRateCache> for the [`Bodu.Financial`](Bodu.Financial.md) exchange-rate stack. <xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DistributedExchangeRateCache> persists one provider's dated rates and fetch-coverage windows over a `Microsoft.Extensions.Caching.Distributed.IDistributedCache`, so several application instances can share one warm cache — a fetch by one instance serves the others. It is behaviourally identical to the in-memory, TOML, and SQLite caches in [`Bodu.Financial.ExchangeRates.Caching`](Bodu.Financial.ExchangeRates.Caching.md) — the same freshness, merge, coverage, and validation semantics, asserted against the same shared cache contract tests — so it drops in behind a <xref:Bodu.Financial.ExchangeRates.Caching.CachingExchangeRateProvider>.
+
+Each currency pair is stored as one JSON blob under a stable key; decimals are serialized as invariant strings and dates and instants as invariant ISO text for lossless round-trips. Because it depends only on the `IDistributedCache` abstraction it is unit-testable against `MemoryDistributedCache` and, in production, backed by Redis or any other implementation. Consistency is best-effort: same-process races are guarded by a per-pair lock, and the decorator's range write persists rows and coverage as one atomic blob, so a reader never observes coverage without its rows.
+
+## Static documentation
+
+- **[Caching and aggregating exchange rates guide](~/guides/financial/exchange-rate-caching.md)** — the cache contract, the read-through decorator, and how a backend plugs in (see *Persistent and shared backends*).
+
+## Key types
+
+- <xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DistributedExchangeRateCache> — the `IExchangeRateCache` over an `IDistributedCache`.
+- <xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DistributedExchangeRateCacheOptions> — the bound `Provider` and the key-prefix settings for the per-pair entries in the distributed store.
+
+## Minimal sample
+
+```csharp
+using Bodu.Financial;
+using Bodu.Financial.ExchangeRates.Caching;
+using Bodu.Financial.ExchangeRates.Caching.Distributed;
+
+var options = new DistributedExchangeRateCacheOptions { Provider = "RBA" };
+var cache = new DistributedExchangeRateCache(distributedCache, options);   // any IDistributedCache
+
+// Front a source provider with read-through caching shared across processes.
+IDatedExchangeRateProvider cached = new CachingExchangeRateProvider(rba, cache, new CachingExchangeRateOptions());
+```
+
+For dependency-injection wiring (including a Redis convenience overload), see [`Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection`](Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.md).

--- a/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.md
+++ b/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.md
@@ -1,0 +1,34 @@
+---
+uid: Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection
+---
+
+# Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection
+
+## Purpose
+
+**Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection** provides the `Microsoft.Extensions.DependencyInjection` wiring for the [SQLite exchange-rate cache](Bodu.Financial.ExchangeRates.Caching.Sqlite.md). `AddSqliteExchangeRateCache(name, …)` on the <xref:Bodu.Financial.DependencyInjection.IFinancialServiceBuilder> binds <xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.SqliteExchangeRateCacheOptions> (default section `Financial:ExchangeRateCache:Sqlite`) and registers a singleton <xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.SqliteExchangeRateCache> bound to the provider, resolvable as <xref:Bodu.Financial.ExchangeRates.Caching.IExchangeRateCache> and as a keyed `IExchangeRateCache` under the provider name. The single instance (and its keep-alive connection) is disposed by the container on shutdown, and options validate on start.
+
+## Static documentation
+
+- **[Caching and aggregating exchange rates guide](~/guides/financial/exchange-rate-caching.md)** — see *Persistent and shared backends*.
+
+## Key types
+
+- <xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.SqliteExchangeRateCacheServiceBuilderExtensions> — `AddSqliteExchangeRateCache(providerName, configuration?, sectionName?, configure?)` on the financial service builder.
+
+## Minimal sample
+
+```csharp
+using Bodu.Financial.DependencyInjection;
+using Bodu.Financial.ExchangeRates.Caching;
+using Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+services.AddBoduFinancial()
+        .AddSqliteExchangeRateCache("RBA", configure: o => o.DatabaseFilePath = "/var/cache/rba.db");
+
+// Resolve the cache (or the keyed cache for "RBA") and wrap a source with a CachingExchangeRateProvider over it.
+var cache = provider.GetRequiredService<IExchangeRateCache>();
+```
+
+See the [caching guide](~/guides/financial/exchange-rate-caching.md) for the read-through decorator the cache backs.

--- a/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Sqlite.md
+++ b/docs/apidoc/Bodu.Financial.ExchangeRates.Caching.Sqlite.md
@@ -1,0 +1,36 @@
+---
+uid: Bodu.Financial.ExchangeRates.Caching.Sqlite
+---
+
+# Bodu.Financial.ExchangeRates.Caching.Sqlite
+
+## Purpose
+
+**Bodu.Financial.ExchangeRates.Caching.Sqlite** is a SQLite-backed persistent <xref:Bodu.Financial.ExchangeRates.Caching.IExchangeRateCache> for the [`Bodu.Financial`](Bodu.Financial.md) exchange-rate stack. <xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.SqliteExchangeRateCache> persists one provider's dated rates and fetch-coverage windows in a SQLite database, so they survive process restarts and need not be re-fetched while fresh. It is behaviourally identical to the in-memory, TOML, and distributed caches in [`Bodu.Financial.ExchangeRates.Caching`](Bodu.Financial.ExchangeRates.Caching.md) — the same freshness, merge, coverage, and validation semantics, asserted against the same shared cache contract tests — so it drops in anywhere an `IExchangeRateCache` is expected, behind a <xref:Bodu.Financial.ExchangeRates.Caching.CachingExchangeRateProvider>.
+
+Decimal rates are stored as invariant strings and dates and instants as invariant ISO text for lossless round-trips; same-pair writes are serialized under a per-pair lock and run in a transaction (so a reader never observes coverage without its rows), and a storage failure degrades to an empty read or skipped write rather than throwing. The cache holds one keep-alive connection for its lifetime and is `IDisposable`.
+
+## Static documentation
+
+- **[Caching and aggregating exchange rates guide](~/guides/financial/exchange-rate-caching.md)** — the cache contract, the read-through decorator, and how a backend plugs in (see *Persistent and shared backends*).
+
+## Key types
+
+- <xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.SqliteExchangeRateCache> — the SQLite `IExchangeRateCache`; dispose it to release the keep-alive connection.
+- <xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.SqliteExchangeRateCacheOptions> — the bound `Provider` and the SQLite connection (for example `DatabaseFilePath`).
+
+## Minimal sample
+
+```csharp
+using Bodu.Financial;
+using Bodu.Financial.ExchangeRates.Caching;
+using Bodu.Financial.ExchangeRates.Caching.Sqlite;
+
+var options = new SqliteExchangeRateCacheOptions { Provider = "RBA", DatabaseFilePath = "/var/cache/rba.db" };
+using var cache = new SqliteExchangeRateCache(options);
+
+// Front a source provider with read-through caching backed by SQLite.
+IDatedExchangeRateProvider cached = new CachingExchangeRateProvider(rba, cache, new CachingExchangeRateOptions());
+```
+
+For dependency-injection wiring, see [`Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection`](Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.md).

--- a/docs/guides/financial/exchange-rate-caching.md
+++ b/docs/guides/financial/exchange-rate-caching.md
@@ -224,6 +224,26 @@ For a new **file format**, derive from
 instead and override only `FileExtension`, `Serialize`, and `Deserialize` — the
 base handles the directory layout and best-effort IO.
 
+### Persistent and shared backends
+
+Two further `IExchangeRateCache` backends ship as separate packages and drop in the
+same way — construct one and hand it to a `CachingExchangeRateProvider`, or register
+it through its `*.DependencyInjection` companion:
+
+- [`SqliteExchangeRateCache`](xref:Bodu.Financial.ExchangeRates.Caching.Sqlite.SqliteExchangeRateCache)
+  (`Bodu.Financial.ExchangeRates.Caching.Sqlite`) persists rates and coverage in a
+  SQLite database — durable across restarts, with per-pair transactional writes.
+  Register it with `AddSqliteExchangeRateCache("RBA", …)`.
+- [`DistributedExchangeRateCache`](xref:Bodu.Financial.ExchangeRates.Caching.Distributed.DistributedExchangeRateCache)
+  (`Bodu.Financial.ExchangeRates.Caching.Distributed`) stores each pair as a JSON blob
+  in any `IDistributedCache` (Redis, SQL Server, in-memory), so several processes share
+  one warm cache. Register it with `AddDistributedExchangeRateCache("RBA")` or
+  `AddRedisExchangeRateCache("RBA", redis => …)`.
+
+Every backend shares the same freshness, merge, and coverage semantics — the same
+`ExchangeRateCacheContractTests` — so the choice is one of reach: in-memory or TOML
+for a single process, SQLite for durable single-process, distributed for many.
+
 ## Grouping providers with the aggregator
 
 [`AggregatingExchangeRateProvider`](xref:Bodu.Financial.ExchangeRates.Caching.AggregatingExchangeRateProvider)


### PR DESCRIPTION
## What

Documentation-only follow-up to #491, closing the gap deliberately left when the exchange-rate **provider** apidoc pages were added (the **cache-backend** packages had none).

Adds DocFX apidoc namespace landing pages (purpose / key types / minimal sample, matching the existing `…Caching` template) for:

- `Bodu.Financial.ExchangeRates.Caching.Sqlite` + `.DependencyInjection`
- `Bodu.Financial.ExchangeRates.Caching.Distributed` + `.DependencyInjection`

And adds a **"Persistent and shared backends"** section to the caching guide (`docs/guides/financial/exchange-rate-caching.md`) so the SQLite (durable, single-process) and distributed/Redis (shared across processes) caches sit alongside the in-memory and TOML backends already documented there.

With this, every `Bodu.Financial.ExchangeRates.*` namespace now has an apidoc landing page.

## Notes

- **Docs only** — no production code changes (5 files, +170).
- Every `<xref:>` target was verified to be a public type, and the link conventions match the rest of the docs (relative apidoc `.md`, `~/guides/…`, no HTML entities). The authoritative check is the `build-docs` job (`docfx --warningsAsErrors`), which couldn't be run locally.
- Branched fresh from `master` and cherry-picked the single docs commit (the original session branch was squash-merged in #491, so a PR from it would have re-proposed already-merged work).

https://claude.ai/code/session_01Kyu3WS4767X1P8xER2rWoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kyu3WS4767X1P8xER2rWoe)_