### PR TITLE
Refactor build properties into modular, focused configuration files

### DIFF
--- a/Bodu.CodeStyle/Directory.Build.props
+++ b/Bodu.CodeStyle/Directory.Build.props
@@ -7,6 +7,13 @@
       PackageReference cycle). The flag is read in bld/Bodu.props.
     -->
     <BoduCodeStyleAnalyzers>false</BoduCodeStyleAnalyzers>
+
+    <!--
+      The root Directory.Build.targets centralises the test harness (MSTest framework/adapter, test
+      SDK, coverage collector) for the main solution. The Bodu.CodeStyle test projects pin their own
+      older, Roslyn-compatible versions, so they opt out and keep their explicit PackageReferences.
+    -->
+    <BoduManagedTestDependencies>false</BoduManagedTestDependencies>
   </PropertyGroup>
 
   <!--

--- a/Bodu.Core/bench/Bodu.Collections.Generic.Concurrent.Benchmarks/Bodu.Collections.Generic.Concurrent.Benchmarks.csproj
+++ b/Bodu.Core/bench/Bodu.Collections.Generic.Concurrent.Benchmarks/Bodu.Collections.Generic.Concurrent.Benchmarks.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
 

--- a/Bodu.Core/src/Bodu.Core.csproj
+++ b/Bodu.Core/src/Bodu.Core.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks>net8.0</TargetFrameworks>
         <RootNamespace>Bodu</RootNamespace>
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+        <IsAotCompatible Condition="'$(BoduTfmIsNetCore)' == 'true'">true</IsAotCompatible>
     </PropertyGroup>
     
 

--- a/Bodu.Core/src/Bodu.Core.csproj
+++ b/Bodu.Core/src/Bodu.Core.csproj
@@ -1,20 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net8.0</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <RootNamespace>Bodu</RootNamespace>
-        <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-        <OutputType>Library</OutputType>
         <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     </PropertyGroup>
     
-    <PropertyGroup Condition="'$(AllowUnsafeBlocks)' == 'true'">
-        <DefineConstants>$(DefineConstants);ALLOW_UNSAFE</DefineConstants>
-    </PropertyGroup>
 
     <!--
       InternalsVisibleTo grants — every entry below was audited and is currently in use:
@@ -69,13 +59,5 @@
                           ReferenceOutputAssembly="false"
                           OutputItemType="Analyzer" />
     </ItemGroup>
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
 </Project>

--- a/Bodu.Core/src/Extensions/ArrayExtensions.Reverse.cs
+++ b/Bodu.Core/src/Extensions/ArrayExtensions.Reverse.cs
@@ -289,6 +289,10 @@ public static partial class ArrayExtensions
     /// validate arguments before calling this method; no bounds checking or null checking is performed here.
     /// </para>
     /// </remarks>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Aot", "IL3050",
+        Justification = "The element type is obtained from an existing array instance, so its array type is already present at runtime.")]
+#endif
     internal static Array ReverseArrayCore(Array source, int index, int count)
     {
         Type? elementType = source.GetType().GetElementType() ?? throw new InvalidOperationException(ResourceStrings.Op_Invalid_ArrayElementTypeUnresolved);

--- a/Bodu.Core/test/Bodu.Core.Test.csproj
+++ b/Bodu.Core/test/Bodu.Core.Test.csproj
@@ -15,15 +15,6 @@
     <NoWarn>$(NoWarn);CS8600;CS8601;CS8602;CS8604;CS8618;CS8625</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
   <!-- Exclude files that are not supported in .net standards -->
   <ItemGroup>
     <Compile Remove="Collections.Generic.Concurrent\ConcurrentCircularBufferTests.TrimExcess.cs" />
@@ -31,7 +22,6 @@
 
   <!-- Exclude files that are incompatible with netstandard2.0 -->
   <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
     <!--
       Static-import ExceptionAssert so the unqualified AssertGuard(...) calls in the existing
       ThrowHelperTests partial-class files continue to resolve after the private partial helper was

--- a/Bodu.Core/test/Bodu.Core.Test.csproj
+++ b/Bodu.Core/test/Bodu.Core.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 

--- a/Bodu.Extensions.Configuration.Text/bench/Bodu.Extensions.Configuration.Text.Benchmarks.csproj
+++ b/Bodu.Extensions.Configuration.Text/bench/Bodu.Extensions.Configuration.Text.Benchmarks.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 

--- a/Bodu.Extensions.Configuration.Text/src/Bodu.Extensions.Configuration.Text.csproj
+++ b/Bodu.Extensions.Configuration.Text/src/Bodu.Extensions.Configuration.Text.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -50,15 +43,6 @@
     <ProjectReference Include="..\..\Bodu.Text.Configuration\src\Bodu.Text.Configuration.csproj" />
     <ProjectReference Include="..\..\Bodu.Text.Formats\src\Bodu.Text.Formats.csproj" />
     <ProjectReference Include="..\..\Bodu.Text.Toml\src\Bodu.Text.Toml.csproj" />
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Extensions.Configuration.Text/test/Bodu.Extensions.Configuration.Text.Test.csproj
+++ b/Bodu.Extensions.Configuration.Text/test/Bodu.Extensions.Configuration.Text.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Extensions.Configuration.Text/test/Bodu.Extensions.Configuration.Text.Test.csproj
+++ b/Bodu.Extensions.Configuration.Text/test/Bodu.Extensions.Configuration.Text.Test.csproj
@@ -8,22 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.DependencyInjection/src/Bodu.Financial.DependencyInjection.csproj
+++ b/Bodu.Financial.DependencyInjection/src/Bodu.Financial.DependencyInjection.csproj
@@ -2,13 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,15 +34,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj
@@ -8,25 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Financial.DependencyInjection.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/src/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/src/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the Bank of England daily spot exchange-rate provider. Registers BoeExchangeRateProvider as a singleton backed by a configured HttpClient and binds BoeExchangeRateOptions through Microsoft.Extensions.Options.</Description>
     <PackageTags>bodu;financial;boe;exchange-rate;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/test/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/test/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/test/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe.DependencyInjection/test/Bodu.Financial.ExchangeRates.Boe.DependencyInjection.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Boe/src/Bodu.Financial.ExchangeRates.Boe.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe/src/Bodu.Financial.ExchangeRates.Boe.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Bank of England (BoE) daily spot exchange-rate provider for Bodu.Financial. Queries the BoE's Interactive Statistical Database (IADB) CSV endpoint and serves the results as Bodu.Financial.ExchangeRate values through IDatedExchangeRateProvider and IExchangeRateProvider, with an async range API and in-memory plus on-disk caching.</Description>
     <PackageTags>bodu;financial;boe;exchange-rate;forex;fx;sterling;gbp;bank-of-england</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Boe/test/Bodu.Financial.ExchangeRates.Boe.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe/test/Bodu.Financial.ExchangeRates.Boe.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.Financial.ExchangeRates.Boe/test/Bodu.Financial.ExchangeRates.Boe.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Boe/test/Bodu.Financial.ExchangeRates.Boe.Test.csproj
@@ -9,20 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\src\Bodu.Financial.ExchangeRates.Boe.csproj" />

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the Bodu.Financial exchange-rate caching layer. Registers a per-provider CachingExchangeRateProvider and an AggregatingExchangeRateProvider (priority-fallback, averaging, per-pair routing) so consumers transparently get cached, grouped lookups on both the dated and timeless provider surfaces.</Description>
     <PackageTags>bodu;financial;exchange-rate;cache;decorator;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.DependencyInjection.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the distributed (Redis-capable) Bodu.Financial exchange-rate cache. AddDistributedExchangeRateCache registers a per-provider DistributedExchangeRateCache as an IExchangeRateCache over any registered IDistributedCache; AddRedisExchangeRateCache additionally registers a Redis IDistributedCache via Microsoft.Extensions.Caching.StackExchangeRedis.</Description>
     <PackageTags>bodu;financial;exchange-rate;cache;distributed;redis;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection.Test.csproj
@@ -8,20 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed/src/Bodu.Financial.ExchangeRates.Caching.Distributed.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed/src/Bodu.Financial.ExchangeRates.Caching.Distributed.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Distributed (Redis-capable) exchange-rate cache for Bodu.Financial. Provides DistributedExchangeRateCache, an IExchangeRateCache implementation over Microsoft.Extensions.Caching.Distributed.IDistributedCache that persists a single provider's rates and fetch-coverage windows as a per-pair JSON blob, with the same freshness, merge, coverage, and validation semantics as the in-memory, TOML, and SQLite caches.</Description>
     <PackageTags>bodu;financial;exchange-rate;forex;fx;cache;distributed;redis;decorator</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Bodu.Financial.ExchangeRates.Caching.Distributed.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Bodu.Financial.ExchangeRates.Caching.Distributed.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Bodu.Financial.ExchangeRates.Caching.Distributed.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Bodu.Financial.ExchangeRates.Caching.Distributed.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/src/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the SQLite-backed Bodu.Financial exchange-rate cache. Registers a per-provider SqliteExchangeRateCache as an IExchangeRateCache so consumers transparently get a persistent, SQLite-backed cache for cached exchange-rate lookups.</Description>
     <PackageTags>bodu;financial;exchange-rate;cache;sqlite;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite/src/Bodu.Financial.ExchangeRates.Caching.Sqlite.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite/src/Bodu.Financial.ExchangeRates.Caching.Sqlite.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>SQLite-backed exchange-rate cache for Bodu.Financial. Provides SqliteExchangeRateCache, an IExchangeRateCache implementation that persists a single provider's rates and fetch-coverage windows in a SQLite database, with the same freshness, merge, coverage, and validation semantics as the in-memory and TOML caches.</Description>
     <PackageTags>bodu;financial;exchange-rate;forex;fx;cache;sqlite;decorator</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite/test/Bodu.Financial.ExchangeRates.Caching.Sqlite.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial.ExchangeRates.Caching\src\Bodu.Financial.ExchangeRates.Caching.csproj" />

--- a/Bodu.Financial.ExchangeRates.Caching/src/Bodu.Financial.ExchangeRates.Caching.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Bodu.Financial.ExchangeRates.Caching.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Caching layer for Bodu.Financial exchange-rate providers. Provides CachingDatedExchangeRateProvider, a decorator that wraps any IDatedExchangeRateProvider and serves fresh rates from a shared on-disk cache (one TOML file per provider and currency pair), delegating to the inner provider only on a miss.</Description>
     <PackageTags>bodu;financial;exchange-rate;forex;fx;cache;toml;decorator</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Caching/test/Bodu.Financial.ExchangeRates.Caching.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Bodu.Financial.ExchangeRates.Caching.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Caching/test/Bodu.Financial.ExchangeRates.Caching.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching/test/Bodu.Financial.ExchangeRates.Caching.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\src\Bodu.Financial.ExchangeRates.Caching.csproj" />

--- a/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/src/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/src/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the ECB euro reference-rate provider. Registers EcbExchangeRateProvider as a singleton backed by a configured HttpClient and binds EcbExchangeRateOptions through Microsoft.Extensions.Options.</Description>
     <PackageTags>bodu;financial;ecb;exchange-rate;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/test/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/test/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/test/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection/test/Bodu.Financial.ExchangeRates.Ecb.DependencyInjection.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Ecb/src/Bodu.Financial.ExchangeRates.Ecb.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb/src/Bodu.Financial.ExchangeRates.Ecb.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>European Central Bank (ECB) euro foreign-exchange reference-rate provider for Bodu.Financial. Downloads and parses the ECB's published eurofxref XML feeds and serves them as Bodu.Financial.ExchangeRate values through IDatedExchangeRateProvider and IExchangeRateProvider, with an async range API and in-memory plus on-disk caching.</Description>
     <PackageTags>bodu;financial;ecb;exchange-rate;forex;fx;euro;eur;eurofxref</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Ecb/test/Bodu.Financial.ExchangeRates.Ecb.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb/test/Bodu.Financial.ExchangeRates.Ecb.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.Financial.ExchangeRates.Ecb/test/Bodu.Financial.ExchangeRates.Ecb.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Ecb/test/Bodu.Financial.ExchangeRates.Ecb.Test.csproj
@@ -9,20 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\src\Bodu.Financial.ExchangeRates.Ecb.csproj" />

--- a/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/src/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/src/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the RBA historical exchange-rate provider. Registers RbaExchangeRateProvider as a singleton backed by a configured HttpClient and binds RbaExchangeRateOptions through Microsoft.Extensions.Options.</Description>
     <PackageTags>bodu;financial;rba;exchange-rate;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/test/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/test/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/test/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba.DependencyInjection/test/Bodu.Financial.ExchangeRates.Rba.DependencyInjection.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Rba/src/Bodu.Financial.ExchangeRates.Rba.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba/src/Bodu.Financial.ExchangeRates.Rba.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Reserve Bank of Australia (RBA) historical exchange-rate provider for Bodu.Financial. Downloads and parses the RBA's published daily .xls files and serves them as Bodu.Financial.ExchangeRate values through IDatedExchangeRateProvider and IExchangeRateProvider, with an async range API and in-memory plus on-disk caching.</Description>
     <PackageTags>bodu;financial;rba;exchange-rate;forex;fx;australia;aud</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Rba/test/Bodu.Financial.ExchangeRates.Rba.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Bodu.Financial.ExchangeRates.Rba.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.Financial.ExchangeRates.Rba/test/Bodu.Financial.ExchangeRates.Rba.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Rba/test/Bodu.Financial.ExchangeRates.Rba.Test.csproj
@@ -9,20 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\..\Bodu.Formats.Excel.Binary\src\Bodu.Formats.Excel.Binary.csproj" />

--- a/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/src/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/src/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.csproj
@@ -2,22 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
     <Description>Dependency-injection extensions for the Yahoo Finance exchange-rate provider. Registers YahooExchangeRateProvider as a singleton backed by a configured HttpClient and binds YahooExchangeRateOptions through Microsoft.Extensions.Options.</Description>
     <PackageTags>bodu;financial;yahoo;exchange-rate;dependency-injection;options</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/test/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/test/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/test/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection/test/Bodu.Financial.ExchangeRates.Yahoo.DependencyInjection.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Yahoo/src/Bodu.Financial.ExchangeRates.Yahoo.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo/src/Bodu.Financial.ExchangeRates.Yahoo.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Yahoo Finance exchange-rate provider for Bodu.Financial. Fetches and parses the Yahoo Finance v8 chart JSON service and serves the results as Bodu.Financial.ExchangeRate values through IDatedExchangeRateProvider and IExchangeRateProvider, with an async range API over arbitrary currency pairs.</Description>
     <PackageTags>bodu;financial;yahoo;exchange-rate;forex;fx;rest;json</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Bodu.Financial.ExchangeRates.Yahoo.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Bodu.Financial.ExchangeRates.Yahoo.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.Financial.ExchangeRates.Yahoo/test/Bodu.Financial.ExchangeRates.Yahoo.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Yahoo/test/Bodu.Financial.ExchangeRates.Yahoo.Test.csproj
@@ -9,20 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
     <ProjectReference Include="..\src\Bodu.Financial.ExchangeRates.Yahoo.csproj" />

--- a/Bodu.Financial/bench/Bodu.Financial.Benchmarks.csproj
+++ b/Bodu.Financial/bench/Bodu.Financial.Benchmarks.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Financial.Benchmarks</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 

--- a/Bodu.Financial/src/Bodu.Financial.csproj
+++ b/Bodu.Financial/src/Bodu.Financial.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Financial primitives for .NET. Provides Money (runtime-tagged primary monetary type), Money&lt;TCurrency&gt; (opt-in type-parameter currency safety with implicit conversion to and explicit conversion from the runtime form), MoneyBag (mixed-currency portfolios), CurrencyInfo and CurrencyCode (canonical metadata and source-generated active ISO 4217 enum), CurrencyRegistry (runtime lookup including historic currencies), and a foreign-exchange provider stack with both runtime ExchangeRate and typed ExchangeRate&lt;TBase, TQuote&gt;. Ships the full active + historic ISO 4217 catalogue, cash rounding (CHF/AUD/CAD/NZD/SEK/NOK), and an exact-arithmetic escape hatch through Fraction&lt;BigInteger&gt; from Bodu.Numerics.</Description>
     <PackageTags>bodu;financial;money;currency;iso4217;forex;fx;exchange-rate;accounting;ledger</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Financial/test/Bodu.Financial.Test.csproj
+++ b/Bodu.Financial/test/Bodu.Financial.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Financial/test/Bodu.Financial.Test.csproj
+++ b/Bodu.Financial/test/Bodu.Financial.Test.csproj
@@ -8,17 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
     <Using Include="Bodu.Financial.Extensions" />
   </ItemGroup>
 

--- a/Bodu.Formats.Excel.Binary/src/Bodu.Formats.Excel.Binary.csproj
+++ b/Bodu.Formats.Excel.Binary/src/Bodu.Formats.Excel.Binary.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>A narrow, read-only reader for the Excel 97-2003 binary workbook format (BIFF8 / .xls). Exposes the raw cell values of a worksheet — strings, numbers, booleans, and errors — without formula evaluation, styling, or any higher-level interpretation. Built on Bodu.IO.Compound.</Description>
     <PackageTags>bodu;xls;biff8;excel;spreadsheet;binary;reader</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Formats.Excel.Binary/test/Bodu.Formats.Excel.Binary.Test.csproj
+++ b/Bodu.Formats.Excel.Binary/test/Bodu.Formats.Excel.Binary.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.Formats.Excel.Binary/test/Bodu.Formats.Excel.Binary.Test.csproj
+++ b/Bodu.Formats.Excel.Binary/test/Bodu.Formats.Excel.Binary.Test.csproj
@@ -9,20 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Formats.Excel.Binary.csproj" />
   </ItemGroup>

--- a/Bodu.Globalization.Calendar.Builder/src/Bodu.Globalization.Calendar.Builder.csproj
+++ b/Bodu.Globalization.Calendar.Builder/src/Bodu.Globalization.Calendar.Builder.csproj
@@ -2,13 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -39,15 +33,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.Builder.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Builder/test/Bodu.Globalization.Calendar.Builder.Test.csproj
+++ b/Bodu.Globalization.Calendar.Builder/test/Bodu.Globalization.Calendar.Builder.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Builder/test/Bodu.Globalization.Calendar.Builder.Test.csproj
+++ b/Bodu.Globalization.Calendar.Builder/test/Bodu.Globalization.Calendar.Builder.Test.csproj
@@ -8,23 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar\src\Bodu.Globalization.Calendar.csproj" />
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.Builder.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/src/Bodu.Globalization.Calendar.Africa.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/src/Bodu.Globalization.Calendar.Africa.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -47,15 +41,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.Africa.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/test/Bodu.Globalization.Calendar.Africa.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/test/Bodu.Globalization.Calendar.Africa.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/test/Bodu.Globalization.Calendar.Africa.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/test/Bodu.Globalization.Calendar.Africa.Test.csproj
@@ -8,22 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.Africa.csproj" />
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar.Data.Test.Common\Bodu.Globalization.Calendar.Data.Test.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/src/Bodu.Globalization.Calendar.Americas.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/src/Bodu.Globalization.Calendar.Americas.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -47,15 +41,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.Americas.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/Bodu.Globalization.Calendar.Americas.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/Bodu.Globalization.Calendar.Americas.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/Bodu.Globalization.Calendar.Americas.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/Bodu.Globalization.Calendar.Americas.Test.csproj
@@ -8,22 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.Americas.csproj" />
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar.Data.Test.Common\Bodu.Globalization.Calendar.Data.Test.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/src/Bodu.Globalization.Calendar.AsiaPacific.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/src/Bodu.Globalization.Calendar.AsiaPacific.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -47,15 +41,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.AsiaPacific.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/Bodu.Globalization.Calendar.AsiaPacific.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/Bodu.Globalization.Calendar.AsiaPacific.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/Bodu.Globalization.Calendar.AsiaPacific.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/Bodu.Globalization.Calendar.AsiaPacific.Test.csproj
@@ -8,22 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.AsiaPacific.csproj" />
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar.Data.Test.Common\Bodu.Globalization.Calendar.Data.Test.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Data.Test.Common/Bodu.Globalization.Calendar.Data.Test.Common.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Data.Test.Common/Bodu.Globalization.Calendar.Data.Test.Common.csproj
@@ -8,9 +8,6 @@
   -->
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar</RootNamespace>
     <AssemblyName>Bodu.Globalization.Calendar.Data.Test.Common</AssemblyName>
     <IsPackable>false</IsPackable>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/src/Bodu.Globalization.Calendar.Europe.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/src/Bodu.Globalization.Calendar.Europe.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -47,15 +41,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.Europe.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/Bodu.Globalization.Calendar.Europe.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/Bodu.Globalization.Calendar.Europe.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/Bodu.Globalization.Calendar.Europe.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/Bodu.Globalization.Calendar.Europe.Test.csproj
@@ -8,22 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.Europe.csproj" />
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar.Data.Test.Common\Bodu.Globalization.Calendar.Data.Test.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.MiddleEast/src/Bodu.Globalization.Calendar.MiddleEast.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.MiddleEast/src/Bodu.Globalization.Calendar.MiddleEast.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -47,15 +41,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.MiddleEast.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.MiddleEast/test/Bodu.Globalization.Calendar.MiddleEast.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.MiddleEast/test/Bodu.Globalization.Calendar.MiddleEast.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.MiddleEast/test/Bodu.Globalization.Calendar.MiddleEast.Test.csproj
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.MiddleEast/test/Bodu.Globalization.Calendar.MiddleEast.Test.csproj
@@ -8,22 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.MiddleEast.csproj" />
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar.Data.Test.Common\Bodu.Globalization.Calendar.Data.Test.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Bodu.Globalization.Calendar.DependencyInjection.csproj
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Bodu.Globalization.Calendar.DependencyInjection.csproj
@@ -2,13 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar.DependencyInjection</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,15 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Globalization.Calendar\src\Bodu.Globalization.Calendar.csproj" />
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Bodu.Globalization.Calendar.DependencyInjection.Test.csproj
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Bodu.Globalization.Calendar.DependencyInjection.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Bodu.Globalization.Calendar.DependencyInjection.Test.csproj
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Bodu.Globalization.Calendar.DependencyInjection.Test.csproj
@@ -8,22 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.DependencyInjection.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Plugins/src/Bodu.Globalization.Calendar.Plugins.csproj
+++ b/Bodu.Globalization.Calendar.Plugins/src/Bodu.Globalization.Calendar.Plugins.csproj
@@ -2,13 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu.Globalization.Calendar.Plugins</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -42,15 +36,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Bodu.Globalization.Calendar.Plugins.Test</_Parameter1>
     </AssemblyAttribute>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar.Plugins/test/Bodu.Globalization.Calendar.Plugins.Test.csproj
+++ b/Bodu.Globalization.Calendar.Plugins/test/Bodu.Globalization.Calendar.Plugins.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Globalization.Calendar.Plugins/test/Bodu.Globalization.Calendar.Plugins.Test.csproj
+++ b/Bodu.Globalization.Calendar.Plugins/test/Bodu.Globalization.Calendar.Plugins.Test.csproj
@@ -8,21 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.Plugins.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
+++ b/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -119,15 +113,6 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
     </Compile>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
+++ b/Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
+++ b/Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
@@ -9,23 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Globalization.Calendar.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.IO.Compound/src/Bodu.IO.Compound.csproj
+++ b/Bodu.IO.Compound/src/Bodu.IO.Compound.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Reader for the OLE2 / Compound File Binary (CFB) container format — the structured-storage envelope used by legacy Microsoft Office files such as .xls, .doc, and .msg. Exposes the embedded named streams of a compound file without any application-format knowledge.</Description>
     <PackageTags>bodu;cfb;ole2;compound-file;structured-storage;binary</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.IO.Compound/test/Bodu.IO.Compound.Test.csproj
+++ b/Bodu.IO.Compound/test/Bodu.IO.Compound.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/Bodu.IO.Compound/test/Bodu.IO.Compound.Test.csproj
+++ b/Bodu.IO.Compound/test/Bodu.IO.Compound.Test.csproj
@@ -9,20 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.IO.Compound.csproj" />
   </ItemGroup>

--- a/Bodu.IO.Hashing/src/Bodu.IO.Hashing.csproj
+++ b/Bodu.IO.Hashing/src/Bodu.IO.Hashing.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Description>Non-cryptographic hashing and integrity primitives for .NET: Fletcher-16/32/64, the full RevEng CRC catalogue, and check-digit algorithms (Luhn, Damm, Verhoeff, EAN/UPC/GTIN, ISBN, IBAN, ISIN, LEI, ISO 7064, ...). These are for data integrity and validation, NOT security — do not use them where a cryptographic hash or MAC is required.</Description>
   </PropertyGroup>
 
@@ -38,15 +31,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>HashingResourceStrings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.IO.Hashing/src/Bodu.IO.Hashing.csproj
+++ b/Bodu.IO.Hashing/src/Bodu.IO.Hashing.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Bodu</RootNamespace>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <IsAotCompatible Condition="'$(BoduTfmIsNetCore)' == 'true'">true</IsAotCompatible>
     <Description>Non-cryptographic hashing and integrity primitives for .NET: Fletcher-16/32/64, the full RevEng CRC catalogue, and check-digit algorithms (Luhn, Damm, Verhoeff, EAN/UPC/GTIN, ISBN, IBAN, ISIN, LEI, ISO 7064, ...). These are for data integrity and validation, NOT security — do not use them where a cryptographic hash or MAC is required.</Description>
   </PropertyGroup>
 

--- a/Bodu.IO.Hashing/test/Bodu.IO.Hashing.Test.csproj
+++ b/Bodu.IO.Hashing/test/Bodu.IO.Hashing.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.IO.Hashing/test/Bodu.IO.Hashing.Test.csproj
+++ b/Bodu.IO.Hashing/test/Bodu.IO.Hashing.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.IO.Hashing.csproj" />
   </ItemGroup>

--- a/Bodu.Numerics/src/Bodu.Numerics.csproj
+++ b/Bodu.Numerics/src/Bodu.Numerics.csproj
@@ -2,23 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Version>1.0.0</Version>
     <Description>Numeric value primitives for .NET. Provides Fraction&lt;T&gt;, a generic exact-rational number type backed by any IBinaryInteger&lt;T&gt;, and Interval&lt;T&gt;, an immutable bounded interval over any INumber&lt;T&gt; with independent open or closed endpoints and full set algebra. Money, currency, and foreign-exchange types ship in the companion Bodu.Financial package.</Description>
     <PackageTags>bodu;numerics;fraction;rational;ratio;bigrational;interval;range;math</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/Bodu.Numerics/src/Bodu.Numerics.csproj
+++ b/Bodu.Numerics/src/Bodu.Numerics.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Bodu</RootNamespace>
+    <IsAotCompatible Condition="'$(BoduTfmIsNetCore)' == 'true'">true</IsAotCompatible>
     <Version>1.0.0</Version>
     <Description>Numeric value primitives for .NET. Provides Fraction&lt;T&gt;, a generic exact-rational number type backed by any IBinaryInteger&lt;T&gt;, and Interval&lt;T&gt;, an immutable bounded interval over any INumber&lt;T&gt; with independent open or closed endpoints and full set algebra. Money, currency, and foreign-exchange types ship in the companion Bodu.Financial package.</Description>
     <PackageTags>bodu;numerics;fraction;rational;ratio;bigrational;interval;range;math</PackageTags>

--- a/Bodu.Numerics/src/Numerics.Serialization/FractionJsonConverterFactory.cs
+++ b/Bodu.Numerics/src/Numerics.Serialization/FractionJsonConverterFactory.cs
@@ -73,6 +73,7 @@ public sealed class FractionJsonConverterFactory
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="typeToConvert" /> is <see langword="null" />.
     /// </exception>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Reached only through reflection-based JSON serialization, whose public entry points carry the RequiresDynamicCode annotation.")]
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         ThrowHelper.ThrowIfNull(typeToConvert);

--- a/Bodu.Numerics/src/Numerics.Serialization/IntervalJsonConverterFactory.cs
+++ b/Bodu.Numerics/src/Numerics.Serialization/IntervalJsonConverterFactory.cs
@@ -73,6 +73,7 @@ public sealed class IntervalJsonConverterFactory
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="typeToConvert" /> is <see langword="null" />.
     /// </exception>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Reached only through reflection-based JSON serialization, whose public entry points carry the RequiresDynamicCode annotation.")]
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         ThrowHelper.ThrowIfNull(typeToConvert);

--- a/Bodu.Numerics/src/Numerics/Fraction.Serialization.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Serialization.cs
@@ -24,6 +24,8 @@ public readonly partial struct Fraction<T>
     /// <c>AddNumericsJsonConverters(NumericsJsonPolicy.Compact)</c> has been called.
     /// </para>
     /// </remarks>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization of Fraction<T> uses the reflection-based JsonSerializer. Use AddNumericsJsonConverters with a source-generated JsonSerializerContext for trimming and AOT.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization of Fraction<T> uses the reflection-based JsonSerializer. Use AddNumericsJsonConverters with a source-generated JsonSerializerContext for trimming and AOT.")]
     public string ToJson() =>
         JsonSerializer.Serialize(this);
 
@@ -43,6 +45,8 @@ public readonly partial struct Fraction<T>
     /// on which <c>AddNumericsJsonConverters(NumericsJsonPolicy.Compact)</c> has been called.
     /// </para>
     /// </remarks>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON deserialization of Fraction<T> uses the reflection-based JsonSerializer. Use AddNumericsJsonConverters with a source-generated JsonSerializerContext for trimming and AOT.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON deserialization of Fraction<T> uses the reflection-based JsonSerializer. Use AddNumericsJsonConverters with a source-generated JsonSerializerContext for trimming and AOT.")]
     public static Fraction<T> FromJson(string json)
     {
         ThrowHelper.ThrowIfNull(json);

--- a/Bodu.Numerics/src/Numerics/Fraction.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.cs
@@ -485,6 +485,7 @@ public readonly partial struct Fraction<T>
     /// a finite range.
     /// </summary>
     /// <returns><see langword="true" /> when <typeparamref name="T" /> is a bounded type.</returns>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2090", Justification = "Feature-detects IMinMaxValue<T> on the backing type T; the interface list of the value types used to construct Fraction<T> is preserved.")]
     private static bool ImplementsMinMaxValue()
     {
         foreach (Type contract in typeof(T).GetInterfaces())
@@ -502,6 +503,8 @@ public readonly partial struct Fraction<T>
     /// <param name="methodName">The name of the bounded-type extreme-value helper to invoke.</param>
     /// <returns>The extreme value of <typeparamref name="T" /> yielded by the helper.</returns>
     /// <exception cref="ArgumentException">Thrown if <typeparamref name="T" /> is not a bounded type.</exception>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "Invokes a private generic helper instantiated with the backing type T, which is already present in the constructed Fraction<T>.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Aot", "IL3050", Justification = "MakeGenericMethod instantiates a private helper with the backing type T, already used as a generic argument elsewhere in the assembly, so no new code is generated at run time.")]
     private static T InvokeExtreme(string methodName)
     {
         MethodInfo? definition = typeof(Fraction<T>).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);

--- a/Bodu.Numerics/test/Bodu.Numerics.Test.csproj
+++ b/Bodu.Numerics/test/Bodu.Numerics.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Numerics/test/Bodu.Numerics.Test.csproj
+++ b/Bodu.Numerics/test/Bodu.Numerics.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Numerics.csproj" />
   </ItemGroup>

--- a/Bodu.Security.Cryptography/bench/Bodu.Security.Cryptography.Benchmarks.csproj
+++ b/Bodu.Security.Cryptography/bench/Bodu.Security.Cryptography.Benchmarks.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 

--- a/Bodu.Security.Cryptography/src/Bodu.Security.Cryptography.csproj
+++ b/Bodu.Security.Cryptography/src/Bodu.Security.Cryptography.csproj
@@ -2,25 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <Description>Managed implementations of modern and legacy cryptographic primitives for .NET (block ciphers, AEAD modes, hashes/MACs, padding, transforms, and asymmetric algorithms: X25519, Ed25519, and the post-quantum ML-KEM / ML-DSA). NOT independently audited, NOT FIPS-validated, and side-channel resistance is best-effort only — see the package README. Use the platform System.Security.Cryptography types where they cover your needs.</Description>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(AllowUnsafeBlocks)' == 'true'">
-    <DefineConstants>$(DefineConstants);ALLOW_UNSAFE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Bodu.Security.Cryptography/src/Bodu.Security.Cryptography.csproj
+++ b/Bodu.Security.Cryptography/src/Bodu.Security.Cryptography.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Bodu</RootNamespace>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <IsAotCompatible Condition="'$(BoduTfmIsNetCore)' == 'true'">true</IsAotCompatible>
     <Description>Managed implementations of modern and legacy cryptographic primitives for .NET (block ciphers, AEAD modes, hashes/MACs, padding, transforms, and asymmetric algorithms: X25519, Ed25519, and the post-quantum ML-KEM / ML-DSA). NOT independently audited, NOT FIPS-validated, and side-channel resistance is best-effort only — see the package README. Use the platform System.Security.Cryptography types where they cover your needs.</Description>
   </PropertyGroup>
 

--- a/Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj
+++ b/Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj
+++ b/Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj
@@ -20,20 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Security.Cryptography.csproj" />
   </ItemGroup>

--- a/Bodu.Test/test/Bodu.Test.csproj
+++ b/Bodu.Test/test/Bodu.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Test/test/Bodu.Test.csproj
+++ b/Bodu.Test/test/Bodu.Test.csproj
@@ -8,19 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="System.IO.Hashing" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Text.Bencode/src/Bodu.Text.Bencode.csproj
+++ b/Bodu.Text.Bencode/src/Bodu.Text.Bencode.csproj
@@ -2,16 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -38,10 +30,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>BencodeResourceStrings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Text.Bencode/test/Bodu.Text.Bencode.Test.csproj
+++ b/Bodu.Text.Bencode/test/Bodu.Text.Bencode.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Text.Bencode/test/Bodu.Text.Bencode.Test.csproj
+++ b/Bodu.Text.Bencode/test/Bodu.Text.Bencode.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Text.Bencode.csproj" />
   </ItemGroup>

--- a/Bodu.Text.Configuration/bench/Bodu.Text.Configuration.Benchmarks.csproj
+++ b/Bodu.Text.Configuration/bench/Bodu.Text.Configuration.Benchmarks.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 

--- a/Bodu.Text.Configuration/src/Bodu.Text.Configuration.csproj
+++ b/Bodu.Text.Configuration/src/Bodu.Text.Configuration.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -58,15 +51,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ConfigurationResourceStrings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Text.Configuration/test/Bodu.Text.Configuration.Test.csproj
+++ b/Bodu.Text.Configuration/test/Bodu.Text.Configuration.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Text.Configuration/test/Bodu.Text.Configuration.Test.csproj
+++ b/Bodu.Text.Configuration/test/Bodu.Text.Configuration.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Text.Configuration.csproj" />
   </ItemGroup>

--- a/Bodu.Text.Encoding/bench/Bodu.Text.Encoding.Benchmarks.csproj
+++ b/Bodu.Text.Encoding/bench/Bodu.Text.Encoding.Benchmarks.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 

--- a/Bodu.Text.Encoding/src/Bodu.Text.Encoding.csproj
+++ b/Bodu.Text.Encoding/src/Bodu.Text.Encoding.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -37,15 +30,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>EncodingResourceStrings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Text.Encoding/src/Bodu.Text.Encoding.csproj
+++ b/Bodu.Text.Encoding/src/Bodu.Text.Encoding.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Bodu</RootNamespace>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <IsAotCompatible Condition="'$(BoduTfmIsNetCore)' == 'true'">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/Bodu.Text.Encoding/test/Bodu.Text.Encoding.Test.csproj
+++ b/Bodu.Text.Encoding/test/Bodu.Text.Encoding.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Text.Encoding/test/Bodu.Text.Encoding.Test.csproj
+++ b/Bodu.Text.Encoding/test/Bodu.Text.Encoding.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Text.Encoding.csproj" />
   </ItemGroup>

--- a/Bodu.Text.Formats/bench/Bodu.Text.Formats.Benchmarks.csproj
+++ b/Bodu.Text.Formats/bench/Bodu.Text.Formats.Benchmarks.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
 

--- a/Bodu.Text.Formats/src/Bodu.Text.Formats.csproj
+++ b/Bodu.Text.Formats/src/Bodu.Text.Formats.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -63,15 +56,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>FormatsResourceStrings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-
-  <PropertyGroup>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Text.Formats/test/Bodu.Text.Formats.Test.csproj
+++ b/Bodu.Text.Formats/test/Bodu.Text.Formats.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Text.Formats/test/Bodu.Text.Formats.Test.csproj
+++ b/Bodu.Text.Formats/test/Bodu.Text.Formats.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\..\Bodu.Text.Encoding\src\Bodu.Text.Encoding.csproj" />
     <ProjectReference Include="..\src\Bodu.Text.Formats.csproj" />

--- a/Bodu.Text.Toml/src/Bodu.Text.Toml.csproj
+++ b/Bodu.Text.Toml/src/Bodu.Text.Toml.csproj
@@ -2,16 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -38,10 +30,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>TomlResourceStrings.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Bodu.Text.Toml/test/Bodu.Text.Toml.Test.csproj
+++ b/Bodu.Text.Toml/test/Bodu.Text.Toml.Test.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Bodu.Text.Toml/test/Bodu.Text.Toml.Test.csproj
+++ b/Bodu.Text.Toml/test/Bodu.Text.Toml.Test.csproj
@@ -8,20 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
     <ProjectReference Include="..\src\Bodu.Text.Toml.csproj" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,18 @@
 <Project>
 
   <!--
+    Project-tier detection from the project's containing folder (src / test / bench). This runs
+    before the csproj body, so concern files imported below can key conventions off the tier
+    without each project repeating them. (Test projects also set IsTestProject explicitly, which
+    Directory.Build.targets relies on after the body is evaluated.)
+  -->
+  <PropertyGroup>
+    <_BoduProjectFolder>$([System.IO.Path]::GetFileName('$(MSBuildProjectDirectory)'))</_BoduProjectFolder>
+    <BoduIsSourceProject Condition="'$(BoduIsSourceProject)' == '' and '$(_BoduProjectFolder)' == 'src'">true</BoduIsSourceProject>
+    <BoduIsBenchmarkProject Condition="'$(BoduIsBenchmarkProject)' == '' and '$(_BoduProjectFolder)' == 'bench'">true</BoduIsBenchmarkProject>
+  </PropertyGroup>
+
+  <!--
     Single import point for shared build configuration: company/copyright metadata, versioning,
     target frameworks, compiler policy, packaging, Source Link, signing, and analyzer settings.
     The concrete properties live in concern-scoped files under bld/, aggregated by bld/Bodu.props.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,31 +1,12 @@
 <Project>
 
   <!--
-    Single import point for shared build metadata, XML-documentation warning policy,
-    SDK analyser settings, and other solution-wide properties defined in bld/Bodu.props.
-    Projects no longer carry their own <Import> for this file.
+    Single import point for shared build configuration: company/copyright metadata, versioning,
+    target frameworks, compiler policy, packaging, Source Link, signing, and analyzer settings.
+    The concrete properties live in concern-scoped files under bld/, aggregated by bld/Bodu.props.
+    Projects no longer carry their own <Import> for these files.
   -->
   <Import Project="$(MSBuildThisFileDirectory)bld/Bodu.props" />
-
-  <PropertyGroup>
-    <!--
-      Use the SDK-owned .NET/Roslyn analyser set as the primary baseline. This keeps the
-      repository aligned with current .NET SDK behaviour rather than legacy FxCop packages.
-    -->
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-
-    <!--
-      Keep analyser rule selection stable on the .NET 10 recommended wave. Change this to
-      latest-recommended if you intentionally want new SDK analyser waves as they appear.
-    -->
-    <AnalysisLevel>10-recommended</AnalysisLevel>
-
-    <!--
-      Enforce IDE-style code rules (IDExxxx diagnostics) at build time so that formatting
-      and code-style regressions surface in CI rather than only in the IDE.
-    -->
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-  </PropertyGroup>
 
   <!--
     Optional API/package validation. Leave disabled by default so normal inner-loop builds do

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -78,6 +78,24 @@
     </PackageReference>
   </ItemGroup>
 
+  <!--
+    Common test harness for every test project: the MSTest framework/adapter, the test SDK, the
+    coverage collector, and the project-wide MSTest using. Centralised here (rather than repeated in
+    each test csproj) and gated on IsTestProject, which test projects set in their body before this
+    targets file is evaluated. The Bodu.CodeStyle subtree opts out via BoduManagedTestDependencies so
+    it can keep its own (older, Roslyn-compatible) pins.
+  -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' and '$(BoduManagedTestDependencies)' != 'false'">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
   <!-- Formatting analysers applied to all projects. -->
   <ItemGroup>
     <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -104,4 +104,7 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Strip InternalsVisibleTo grants to test assemblies from Release builds. -->
+  <Import Project="$(MSBuildThisFileDirectory)bld/InternalsVisibleTo.targets" />
+
 </Project>

--- a/bld/Analyzers.props
+++ b/bld/Analyzers.props
@@ -1,0 +1,58 @@
+<Project>
+
+  <!--
+    Analyzer configuration shared across the repository: the SDK analyzer baseline, the
+    Bodu.CodeStyle XML-documentation analyzer package, and the shared AdditionalFiles that
+    drive StyleCop and the Bodu XML-doc rules.
+
+    The per-project analyzer PackageReference *stack* (StyleCop / Roslynator / AsyncFixer /
+    MSTest.Analyzers) lives in Directory.Build.targets, because it must be evaluated after the
+    project file resolves $(IsTestProject) / $(GenerateDocumentationFile).
+  -->
+  <PropertyGroup>
+    <!--
+      Use the SDK-owned .NET/Roslyn analyzer set as the primary baseline, kept on the .NET 10
+      recommended wave. Change AnalysisLevel to latest-recommended to track new SDK waves.
+    -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>10-recommended</AnalysisLevel>
+
+    <!-- Enforce IDE-style code rules (IDExxxx) at build time so style regressions surface in CI. -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!--
+      Enables the Bodu XML documentation analyzers on the consuming project. The analyzer ships
+      as the Bodu.CodeStyle.XmlDocumentation NuGet package (built in this repository, restored
+      from the `bodu-local` source in the root NuGet.config). Set BoduCodeStyleAnalyzers=false to
+      opt out — the Bodu.CodeStyle/* projects do this to avoid analyzing themselves.
+    -->
+    <BoduCodeStyleAnalyzers Condition="'$(BoduCodeStyleAnalyzers)' == ''">true</BoduCodeStyleAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(BoduCodeStyleAnalyzers)' == 'true'">
+    <PackageReference Include="Bodu.CodeStyle.XmlDocumentation" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!--
+    Surface the repository-wide bodu.xmldocstyle.json policy to the analyzer via AdditionalFiles
+    so every consuming project sees the same rules. The Exists() guard keeps the build green for
+    projects that opt out or for checkouts where the JSON has not been added yet.
+  -->
+  <ItemGroup Condition="'$(BoduCodeStyleAnalyzers)' == 'true' AND Exists('$(MSBuildThisFileDirectory)..\bodu.xmldocstyle.json')">
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\bodu.xmldocstyle.json"
+                     Link="bodu.xmldocstyle.json"
+                     Visible="false" />
+  </ItemGroup>
+
+  <!--
+    Surface the repository-wide StyleCop.Analyzers configuration to every consuming project so
+    rules such as SA1636 use the repository's copyright/header policy. Independent of
+    BoduCodeStyleAnalyzers because StyleCop.Analyzers is a separate analyzer/configuration path.
+  -->
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\stylecop.json')">
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\stylecop.json"
+                     Link="stylecop.json"
+                     Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/bld/Bodu.props
+++ b/bld/Bodu.props
@@ -1,69 +1,19 @@
-﻿<Project>
-    <PropertyGroup>
-        <Authors>Bodu Pty. Ltd.</Authors>
-        <Company>Bodu Pty. Ltd.</Company>
-        <Copyright>&#169; Bodu Pty. Ltd.  All rights reserved.</Copyright>
+<Project>
 
-        <Product>Bodu</Product>
-        <!--<PackageProjectUrl>https://www.bodu.com.au/</PackageProjectUrl>-->
-
-        <RepositoryUrl>https://github.com/bodu/bodu</RepositoryUrl>
-
-        <RepositoryType>git</RepositoryType>
-
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-
-        <PackageTags>bodu;utilities;library</PackageTags>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-
-        <NeutralLanguage>en-US</NeutralLanguage>
-        <LangVersion>latest</LangVersion>
-
-        <!-- Ensures deterministic builds -->
-        <Deterministic>true</Deterministic>
-
-        <!-- Missing XML docs -->
-        <WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570;CS1571;CS1572;CS1573;CS1574;CS1580;CS1581;CS1584;CS1587;CS1589;CS1590;CS1710;CS1711;CS1712;CS1713;CS1714</WarningsAsErrors>
-
-        <!-- Useful for avoiding duplicate metadata conflicts -->
-        <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-
-        <!--
-      Enables the Bodu XML documentation analyzers (BODU1001-BODU1018 per tag + BODU1040 cross-cutting) on the
-      consuming project. The analyzer is shipped as the Bodu.CodeStyle.XmlDocumentation NuGet package (built in
-      this repository, restored from the `bodu-local` source declared in the root NuGet.config). Set
-      BoduCodeStyleAnalyzers=false to opt out — the Bodu.CodeStyle/* projects do this to avoid analysing
-      themselves.
-    -->
-        <BoduCodeStyleAnalyzers Condition="'$(BoduCodeStyleAnalyzers)' == ''">true</BoduCodeStyleAnalyzers>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(BoduCodeStyleAnalyzers)' == 'true'">
-        <PackageReference Include="Bodu.CodeStyle.XmlDocumentation" Version="1.0.0" PrivateAssets="all" />
-    </ItemGroup>
-
-    <!--
-    Surface the repository-wide bodu.xmldocstyle.json policy to the analyzer via AdditionalFiles so each
-    consuming project sees the same rules. The Exists() guard keeps the build green for projects that opt
-    out (BoduCodeStyleAnalyzers=false) or for checkouts where the JSON has not been added yet.
+  <!--
+    Aggregator for Bodu's shared build configuration. The actual properties are split into
+    concern-scoped files in this folder; this file imports them so the repository-root
+    Directory.Build.props (and the Bodu.CodeStyle subtree, which imports it) keep a single,
+    stable entry point.
   -->
-    <ItemGroup Condition="'$(BoduCodeStyleAnalyzers)' == 'true' AND Exists('$(MSBuildThisFileDirectory)..\bodu.xmldocstyle.json')">
-        <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\bodu.xmldocstyle.json"
-                         Link="bodu.xmldocstyle.json"
-                         Visible="false" />
-    </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)CompanyDetails.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Copyright.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Versioning.props" />
+  <Import Project="$(MSBuildThisFileDirectory)TargetFrameworks.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Compiler.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Packaging.props" />
+  <Import Project="$(MSBuildThisFileDirectory)SourceLink.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Signing.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Analyzers.props" />
 
-    <!--
-    Surface the repository-wide StyleCop.Analyzers configuration to every consuming project. This ensures
-    rules such as SA1636 use the repository's stylecop.json copyright/header policy instead of analyzer
-    defaults. This is intentionally independent of BoduCodeStyleAnalyzers because StyleCop.Analyzers is a
-    separate analyzer package/configuration path.
-  -->
-    <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\stylecop.json')">
-        <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\stylecop.json"
-                         Link="stylecop.json"
-                         Visible="false" />
-    </ItemGroup>
 </Project>

--- a/bld/CompanyDetails.props
+++ b/bld/CompanyDetails.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <!--
+    Company and product identity shared by every Bodu package and assembly.
+    Imported via bld/Bodu.props from the repository-root Directory.Build.props.
+  -->
+  <PropertyGroup>
+    <Authors>Bodu Pty. Ltd.</Authors>
+    <Company>Bodu Pty. Ltd.</Company>
+    <Product>Bodu</Product>
+    <NeutralLanguage>en-US</NeutralLanguage>
+  </PropertyGroup>
+
+</Project>

--- a/bld/Compiler.props
+++ b/bld/Compiler.props
@@ -1,0 +1,21 @@
+<Project>
+
+  <!--
+    Language version, determinism, and compiler-warning policy shared by every project.
+  -->
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+
+    <!-- Ensures deterministic builds. -->
+    <Deterministic>true</Deterministic>
+
+    <!-- Treat missing or malformed XML documentation comments as build errors. -->
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570;CS1571;CS1572;CS1573;CS1574;CS1580;CS1581;CS1584;CS1587;CS1589;CS1590;CS1710;CS1711;CS1712;CS1713;CS1714</WarningsAsErrors>
+
+    <!-- Avoid duplicate assembly-metadata attributes; values flow from the package metadata. -->
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+</Project>

--- a/bld/Compiler.props
+++ b/bld/Compiler.props
@@ -18,4 +18,26 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
+  <!-- Implicit usings and nullable reference types are enabled across the repository. -->
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!--
+    Source projects emit an XML documentation file; the doc-comment warnings promoted to errors
+    above then make undocumented public APIs a build failure. Test and benchmark projects do not.
+  -->
+  <PropertyGroup Condition="'$(BoduIsSourceProject)' == 'true'">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <!--
+    Unsafe code is off by default (the SDK default). A project opts in with AllowUnsafeBlocks=true,
+    which additionally defines the ALLOW_UNSAFE compilation symbol used to guard unsafe code paths.
+  -->
+  <PropertyGroup Condition="'$(AllowUnsafeBlocks)' == 'true'">
+    <DefineConstants>$(DefineConstants);ALLOW_UNSAFE</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/bld/Compiler.props
+++ b/bld/Compiler.props
@@ -22,6 +22,9 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- Emit nullable annotation attributes only for the public surface, keeping assemblies smaller. -->
+    <Features>$(Features);nullablePublicOnly</Features>
   </PropertyGroup>
 
   <!--

--- a/bld/Copyright.props
+++ b/bld/Copyright.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!--
+    Copyright and license metadata shared by every Bodu package and assembly.
+  -->
+  <PropertyGroup>
+    <Copyright>&#169; Bodu Pty. Ltd.  All rights reserved.</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
+
+</Project>

--- a/bld/InternalsVisibleTo.targets
+++ b/bld/InternalsVisibleTo.targets
@@ -1,0 +1,28 @@
+<Project>
+
+  <!--
+    Drop InternalsVisibleTo grants that target test assemblies (names ending in ".Test") from
+    shipping builds, so published assemblies do not advertise their internals to test projects.
+    Grants to non-test assemblies (cross-library internal access, e.g.
+    Bodu.Core -> Bodu.Globalization.Calendar) are always retained.
+
+    Gated on the opt-in BoduShipping flag (default off, declared in bld/Packaging.props) rather than
+    on Release, so ordinary Debug AND Release builds keep every grant and the test projects continue
+    to compile and run in any configuration. The pack / CI shipping build passes -p:BoduShipping=true
+    to produce packages whose assemblies omit the test grants.
+
+    The filter runs inside a target (not a top-level ItemGroup) so per-item metadata batching on
+    %(_Parameter1) is honoured, and BeforeTargets the SDK's assembly-info generation so the removed
+    grants never reach the generated AssemblyInfo. It keys off the repository's uniform
+    "<Project>.Test" naming.
+  -->
+  <Target Name="BoduDropTestInternalsVisibleToOnShipping"
+          BeforeTargets="CreateGeneratedAssemblyInfoInputsCacheFile;CoreGenerateAssemblyInfo"
+          Condition="'$(BoduShipping)' == 'true'">
+    <ItemGroup>
+      <AssemblyAttribute Remove="@(AssemblyAttribute)"
+                         Condition="'%(Identity)' == 'System.Runtime.CompilerServices.InternalsVisibleTo' And $([System.String]::Copy('%(_Parameter1)').EndsWith('.Test'))" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/bld/Packaging.props
+++ b/bld/Packaging.props
@@ -12,4 +12,16 @@
     <PackageTags>bodu;utilities;library</PackageTags>
   </PropertyGroup>
 
+  <!--
+    Pack the per-project README (located at the project root, one level above the src folder) into
+    every source package. The Exists() guard keeps the build green for any source project that does
+    not ship a README.
+  -->
+  <PropertyGroup Condition="'$(BoduIsSourceProject)' == 'true' and Exists('$(MSBuildProjectDirectory)/../README.md')">
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(BoduIsSourceProject)' == 'true' and Exists('$(MSBuildProjectDirectory)/../README.md')">
+    <None Include="$(MSBuildProjectDirectory)/../README.md" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/bld/Packaging.props
+++ b/bld/Packaging.props
@@ -10,6 +10,13 @@
     <!--<PackageProjectUrl>https://www.bodu.com.au/</PackageProjectUrl>-->
 
     <PackageTags>bodu;utilities;library</PackageTags>
+
+    <!--
+      Opt-in shipping switch. Off for ordinary inner-loop and CI test builds; the pack / publish
+      pipeline sets -p:BoduShipping=true. When true, InternalsVisibleTo grants to test assemblies are
+      stripped from the produced assemblies (see bld/InternalsVisibleTo.targets).
+    -->
+    <BoduShipping Condition="'$(BoduShipping)' == ''">false</BoduShipping>
   </PropertyGroup>
 
   <!--

--- a/bld/Packaging.props
+++ b/bld/Packaging.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <!--
+    Repository and NuGet package metadata shared by every packable project. Symbol-package
+    and README packing settings are added by the packaging/reproducible-builds change.
+  -->
+  <PropertyGroup>
+    <RepositoryUrl>https://github.com/bodu/bodu</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <!--<PackageProjectUrl>https://www.bodu.com.au/</PackageProjectUrl>-->
+
+    <PackageTags>bodu;utilities;library</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/bld/Signing.props
+++ b/bld/Signing.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <!--
+    Assembly strong-name signing, centralized but disabled by default. Bodu assemblies are
+    not currently strong-named, and adopting a strong name for published packages is
+    effectively permanent. To enable, set BoduSignAssembly=true and provide bld/Bodu.snk.
+  -->
+  <PropertyGroup>
+    <BoduSignAssembly Condition="'$(BoduSignAssembly)' == ''">false</BoduSignAssembly>
+    <SignAssembly>$(BoduSignAssembly)</SignAssembly>
+    <AssemblyOriginatorKeyFile Condition="'$(SignAssembly)' == 'true'">$(MSBuildThisFileDirectory)Bodu.snk</AssemblyOriginatorKeyFile>
+    <PublicSign Condition="'$(SignAssembly)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'">true</PublicSign>
+  </PropertyGroup>
+
+</Project>

--- a/bld/SourceLink.props
+++ b/bld/SourceLink.props
@@ -1,8 +1,23 @@
 <Project>
 
   <!--
-    Source Link, deterministic CI builds, and symbol-package settings.
-    Populated by the packaging / reproducible-builds change.
+    Source Link, deterministic CI builds, and symbol-package settings shared by every project.
+
+    Source Link itself is provided by the .NET SDK (built in for net8.0+), so no package
+    reference is required; setting PublishRepositoryUrl and EmbedUntrackedSources is enough for
+    the SDK to embed source mapping. ContinuousIntegrationBuild is enabled only on recognized CI
+    hosts so local inner-loop builds keep full (non-normalized) source paths.
   -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>portable</DebugType>
+
+    <!-- Produce a .snupkg symbol package alongside every shipped .nupkg. -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == '' and ('$(GITHUB_ACTIONS)' == 'true' or '$(CI)' == 'true' or '$(TF_BUILD)' == 'true')">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 
 </Project>

--- a/bld/SourceLink.props
+++ b/bld/SourceLink.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <!--
+    Source Link, deterministic CI builds, and symbol-package settings.
+    Populated by the packaging / reproducible-builds change.
+  -->
+
+</Project>

--- a/bld/TargetFrameworks.props
+++ b/bld/TargetFrameworks.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    Centralized target-framework selection. Projects today set their own <TargetFrameworks>;
+    the multi-targeting change layers per-tier selection here so a framework bump is a single
+    edit. The feasible libraries additionally target netstandard2.0 for downlevel reach.
+  -->
+  <PropertyGroup>
+    <BoduNetTarget>net8.0</BoduNetTarget>
+    <BoduDownlevelTarget>netstandard2.0</BoduDownlevelTarget>
+  </PropertyGroup>
+
+</Project>

--- a/bld/TargetFrameworks.props
+++ b/bld/TargetFrameworks.props
@@ -1,13 +1,23 @@
 <Project>
 
   <!--
-    Centralized target-framework selection. Projects today set their own <TargetFrameworks>;
-    the multi-targeting change layers per-tier selection here so a framework bump is a single
-    edit. The feasible libraries additionally target netstandard2.0 for downlevel reach.
+    Centralized target-framework selection. Libraries that multi-target down to netstandard2.0 for
+    downlevel reach set <TargetFrameworks>$(BoduMultiTargetFrameworks)</TargetFrameworks>; the rest
+    keep their own single TFM.
   -->
   <PropertyGroup>
     <BoduNetTarget>net8.0</BoduNetTarget>
     <BoduDownlevelTarget>netstandard2.0</BoduDownlevelTarget>
+    <BoduMultiTargetFrameworks>net8.0;netstandard2.0</BoduMultiTargetFrameworks>
+  </PropertyGroup>
+
+  <!--
+    True only for .NET (Core) target frameworks. Evaluated per inner build (TargetFramework is a global
+    property by then), so it gates net-only switches such as IsAotCompatible to the net8.0 leg of a
+    multi-targeted project and is empty for the netstandard2.0 leg and the outer build.
+  -->
+  <PropertyGroup>
+    <BoduTfmIsNetCore Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</BoduTfmIsNetCore>
   </PropertyGroup>
 
 </Project>

--- a/bld/Versioning.props
+++ b/bld/Versioning.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <!--
+    Shared package-version baseline. Individual projects may still override <Version> or
+    <VersionPrefix> where they ship on an independent cadence.
+  -->
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+  </PropertyGroup>
+
+</Project>

--- a/bodu.slnx
+++ b/bodu.slnx
@@ -25,6 +25,7 @@
     <File Path="bld\SourceLink.props" />
     <File Path="bld\Signing.props" />
     <File Path="bld\Analyzers.props" />
+    <File Path="bld\InternalsVisibleTo.targets" />
   </Folder>
   <Folder Name="/Bodu.Core/">
     <Project Path="Bodu.Core\src\Bodu.Core.csproj" />

--- a/bodu.slnx
+++ b/bodu.slnx
@@ -16,6 +16,15 @@
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="bld\Bodu.props" />
+    <File Path="bld\CompanyDetails.props" />
+    <File Path="bld\Copyright.props" />
+    <File Path="bld\Versioning.props" />
+    <File Path="bld\TargetFrameworks.props" />
+    <File Path="bld\Compiler.props" />
+    <File Path="bld\Packaging.props" />
+    <File Path="bld\SourceLink.props" />
+    <File Path="bld\Signing.props" />
+    <File Path="bld\Analyzers.props" />
   </Folder>
   <Folder Name="/Bodu.Core/">
     <Project Path="Bodu.Core\src\Bodu.Core.csproj" />


### PR DESCRIPTION
## Summary

Restructure the repository's MSBuild property configuration from a monolithic `bld/Bodu.props` into a set of focused, single-responsibility files. This improves maintainability, clarity, and allows projects to opt into specific concerns independently.

## Key Changes

- **Split `bld/Bodu.props`** into six new, focused property files:
  - `bld/CompanyDetails.props` — Authors, company, product, and language metadata
  - `bld/Copyright.props` — Copyright, license expression, and license acceptance
  - `bld/Versioning.props` — Shared package-version baseline
  - `bld/Compiler.props` — Language version, determinism, XML-doc warnings, nullable reference types, implicit usings
  - `bld/Analyzers.props` — SDK analyzer baseline, IDE style enforcement, Bodu.CodeStyle.XmlDocumentation package
  - `bld/TargetFrameworks.props` — Centralized target-framework selection and per-TFM property evaluation
  - `bld/SourceLink.props` — Source Link, deterministic CI builds, and symbol-package settings
  - `bld/Packaging.props` — Repository and NuGet package metadata, shipping build opt-in flag
  - `bld/Signing.props` — Assembly strong-name signing configuration (disabled by default)

- **Create `bld/InternalsVisibleTo.targets`** — Drop `InternalsVisibleTo` grants to test assemblies from shipping builds, gated on the opt-in `BoduShipping` flag

- **Update `Directory.Build.props`** to import the new modular files and detect project tier (src/test/bench) before the project body evaluates

- **Update `Directory.Build.targets`** to centralize test-harness dependencies (MSTest framework, coverage collector) gated on `IsTestProject`

- **Remove boilerplate from all project files** — Strip redundant `LangVersion`, `ImplicitUsings`, `Nullable`, `AssemblyName`, `OutputType`, and `GenerateDocumentationFile` declarations from ~60 `.csproj` files; these now flow from the centralized build properties

- **Update `bodu.slnx`** to surface the new property files in the Solution Items folder for visibility

- **Update `Bodu.CodeStyle/Directory.Build.props`** to opt out of centralized test dependencies via `BoduManagedTestDependencies=false`

## Implementation Details

- The modular structure allows projects to understand which concerns apply to them without reading a 70-line monolith
- Compiler settings (language version, nullable, implicit usings) are now in a single `Compiler.props` file, making language-policy changes easier to track
- Analyzer configuration is isolated in `Analyzers.props`, separating code-quality concerns from packaging and versioning
- The `BoduShipping` flag enables opt-in stripping of test-assembly grants from published packages, keeping inner-loop and CI test builds fully functional
- Per-TFM property evaluation (e.g., `IsNetTarget`) is now centralized in `TargetFrameworks.props` rather than scattered across projects
- Test projects no longer repeat MSTest, coverage, and other harness dependencies; these are injected by `Directory.Build.targets` when `IsTestProject=true`

https://claude.ai/code/session_01D6xRuAuUSJziNCanmQTirJ