### PR TITLE
Fix NU5017 when packing analyzer-only XmlDocumentation package

### DIFF
--- a/Bodu.CodeStyle/Bodu.CodeStyle.XmlDocumentation/Bodu.CodeStyle.XmlDocumentation.csproj
+++ b/Bodu.CodeStyle/Bodu.CodeStyle.XmlDocumentation/Bodu.CodeStyle.XmlDocumentation.csproj
@@ -9,6 +9,15 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+
+    <!--
+      This is an analyzer-only package: it ships the analyzer/code-fix assemblies under
+      analyzers/dotnet/cs and excludes the build output (IncludeBuildOutput=false), so there is
+      no primary assembly or .pdb for a symbol package to carry. The shared snupkg policy from
+      bld/SourceLink.props (IncludeSymbols=true) would therefore produce an empty symbol package
+      and fail packing with NU5017. Opt this package out of symbol packaging.
+    -->
+    <IncludeSymbols>false</IncludeSymbols>
     <PackageId>Bodu.CodeStyle.XmlDocumentation</PackageId>
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>


### PR DESCRIPTION
The Bodu.CodeStyle.XmlDocumentation package ships only the analyzer and
code-fix assemblies under analyzers/dotnet/cs and sets
IncludeBuildOutput=false, so it has no primary assembly or .pdb. The
shared bld/SourceLink.props policy enables a snupkg symbol package
(IncludeSymbols=true) for every project, so pack attempted to build a
symbol package with no content and failed with NU5017 ("Cannot create a
package that has no dependencies nor content") even though the main
package was created successfully.

Opt this analyzer-only package out of symbol packaging. This fixes both
the codestyle-build-test "Pack" step (--no-build) and the build-test
"Pack analyzer (local feed)" step, the latter of which was aborting the
job before any tests ran.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lh3i95TRiFTAv7y6pn68gY