### PR TITLE
Add strong-name signing infrastructure and versioning controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+# Builds, strong-name (real) signs, packs, and optionally publishes the Bodu packages.
+#
+# Triggered for a release by pushing a version tag (e.g. v1.0.0), or manually via the Actions tab.
+# The private strong-name key is never stored in the repo: it is supplied as the base64-encoded
+# BODU_SNK secret, decoded to a path outside the working tree for the duration of the job, and shredded
+# afterwards. Real signing is opt-in here (BoduRealSign=true); ordinary CI builds stay public-signed.
+#
+# Required/optional secrets:
+#   BODU_SNK        (required) base64 of the full private Bodu.snk strong-name key.
+#   NUGET_API_KEY   (optional) nuget.org push key. When unset, packages are built and uploaded as
+#                   artifacts but not published, so the workflow is safe to run as a dry run.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish the packed packages to nuget.org (requires NUGET_API_KEY).'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      CONFIGURATION: Release
+      ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Pack Bodu.CodeStyle.XmlDocumentation analyzer (local feed)
+        working-directory: Bodu.CodeStyle
+        run: |
+          dotnet pack Bodu.CodeStyle.XmlDocumentation/Bodu.CodeStyle.XmlDocumentation.csproj \
+            --configuration "$CONFIGURATION" \
+            --output "${{ github.workspace }}/local-packages"
+
+      - name: Guard — fail fast if the public key is not configured
+        shell: bash
+        run: |
+          # Real signing produces strong-named assemblies whose retained cross-library
+          # InternalsVisibleTo grants must carry the public key (BoduPublicKey). Refuse to publish a
+          # half-configured release where signing is on but the public key was never populated.
+          key=$(dotnet msbuild Bodu.Core/src/Bodu.Core.csproj -nologo -v:q \
+            -getProperty:BoduPublicKey 2>/dev/null | tr -d '[:space:]')
+          if [ -z "$key" ]; then
+            echo "::error::BoduPublicKey is empty in bld/Signing.props. Populate it (sn -tp Bodu.public.snk) before releasing a signed build."
+            exit 1
+          fi
+          echo "BoduPublicKey is configured."
+
+      - name: Decode strong-name private key
+        shell: bash
+        env:
+          BODU_SNK: ${{ secrets.BODU_SNK }}
+        run: |
+          if [ -z "$BODU_SNK" ]; then
+            echo "::error::Secret BODU_SNK is not set. Add the base64 of the private Bodu.snk key."
+            exit 1
+          fi
+          printf '%s' "$BODU_SNK" | base64 -d > "$RUNNER_TEMP/Bodu.snk"
+          # Sanity check: a valid .snk is non-empty binary.
+          if [ ! -s "$RUNNER_TEMP/Bodu.snk" ]; then
+            echo "::error::Decoded key is empty — BODU_SNK is not valid base64 of a .snk file."
+            exit 1
+          fi
+
+      - name: Pack (real-signed, shipping)
+        shell: bash
+        run: |
+          dotnet pack bodu.slnx \
+            --configuration "$CONFIGURATION" \
+            --output "$ARTIFACTS_DIR" \
+            -p:BoduSignAssembly=true \
+            -p:BoduRealSign=true \
+            -p:BoduStrongNameKeyFile="$RUNNER_TEMP/Bodu.snk" \
+            -p:BoduShipping=true
+
+      - name: Shred strong-name private key
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/Bodu.snk" ]; then
+            shred -u "$RUNNER_TEMP/Bodu.snk" 2>/dev/null || rm -f "$RUNNER_TEMP/Bodu.snk"
+          fi
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: |
+            ${{ env.ARTIFACTS_DIR }}/*.nupkg
+            ${{ env.ARTIFACTS_DIR }}/*.snupkg
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Publish to nuget.org
+        # Publish on a tag release, or a manual run that opted in — and only when the key exists.
+        if: ${{ github.event_name == 'push' || github.event.inputs.publish == 'true' }}
+        shell: bash
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::warning::NUGET_API_KEY is not set — skipping publish. Packages remain available as artifacts."
+            exit 0
+          fi
+          dotnet nuget push "$ARTIFACTS_DIR"/*.nupkg \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,11 @@ slnx.sqlite
 /ConsoleApp2/
 /bc-csharp/
 **/.cr/personal/
+
+# -----------------------------
+# Strong-name signing keys
+# -----------------------------
+# Commit only the public key (bld/Bodu.public.snk). The PRIVATE key must never be committed —
+# supply it from a secret at release time, ideally to a path outside the working tree.
+*.snk
+!bld/Bodu.public.snk

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,6 +20,28 @@
     <Version Condition="'$(VersionSuffix)' != ''">$(BoduPackageVersionOverride)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
+  <!--
+    Pin AssemblyVersion to Major.Minor.0.0 so the assembly's binding identity stays stable across
+    patch and out-of-band releases, while FileVersion, PackageVersion, and InformationalVersion still
+    carry the full version. This matters most once assemblies are strong-named (bld/Signing.props),
+    where AssemblyVersion is part of the strong identity and a patch bump would otherwise force every
+    consumer to rebind. VersionPrefix holds the effective version at this point — the lock-step
+    BoduBaseVersion, or the out-of-band override applied above. A project may opt out by setting
+    AssemblyVersion explicitly in its own body.
+  -->
+  <PropertyGroup Condition="'$(VersionPrefix)' != ''">
+    <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">$([System.Version]::Parse('$(VersionPrefix)').Major).$([System.Version]::Parse('$(VersionPrefix)').Minor).0.0</AssemblyVersion>
+
+    <!--
+      FileVersion carries the full effective version (including the patch) for diagnostics, even
+      though AssemblyVersion is pinned to Major.Minor.0.0 above. Without this the SDK would default
+      FileVersion to the pinned AssemblyVersion and the patch component would be lost. VersionPrefix
+      holds the numeric effective version with no pre-release suffix, which is the correct FileVersion
+      source.
+    -->
+    <FileVersion Condition="'$(FileVersion)' == ''">$(VersionPrefix)</FileVersion>
+  </PropertyGroup>
+
   <Target Name="BoduReportVersionOverride" BeforeTargets="Build;Pack"
           Condition="'$(BoduPackageVersionOverride)' != ''">
     <Message Importance="high"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,32 @@
 <Project>
 
   <!--
+    Deliberate out-of-band version override. By default every Bodu library ships lock-step at the
+    shared BoduBaseVersion (bld/Versioning.props). A project breaks rank for an isolated fix by
+    setting <BoduPackageVersionOverride> in its own csproj (or passing -p:BoduPackageVersionOverride
+    for a one-off release build), and is reported below so the divergence is visible in build output
+    and traceable in source control.
+
+    This overrides Version (not just VersionPrefix) because the SDK finalizes Version from
+    VersionPrefix earlier than this file is imported (Directory.Build.targets is imported at the top
+    of Microsoft.Common.targets, after the default Version has already been computed). Version is the
+    value AssemblyVersion, FileVersion, PackageVersion, and InformationalVersion all derive from in
+    later build targets, so reassigning it here flows the override through every version field.
+    VersionPrefix is kept in sync for any consumer that reads it directly.
+  -->
+  <PropertyGroup Condition="'$(BoduPackageVersionOverride)' != ''">
+    <VersionPrefix>$(BoduPackageVersionOverride)</VersionPrefix>
+    <Version Condition="'$(VersionSuffix)' == ''">$(BoduPackageVersionOverride)</Version>
+    <Version Condition="'$(VersionSuffix)' != ''">$(BoduPackageVersionOverride)-$(VersionSuffix)</Version>
+  </PropertyGroup>
+
+  <Target Name="BoduReportVersionOverride" BeforeTargets="Build;Pack"
+          Condition="'$(BoduPackageVersionOverride)' != ''">
+    <Message Importance="high"
+             Text="$(MSBuildProjectName): out-of-band version override $(BoduPackageVersionOverride) (lock-step baseline is $(BoduBaseVersion))." />
+  </Target>
+
+  <!--
     Define BODU_EXTENSION_MEMBERS when the building SDK is .NET 10 or later, which ships the C# 14
     compiler that supports extension members. Combined with LangVersion=latest (bld/Bodu.props), this
     lets sources express convenience members as C# 14 extension properties; older SDKs fall back to

--- a/bld/InternalsVisibleTo.targets
+++ b/bld/InternalsVisibleTo.targets
@@ -25,4 +25,37 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Append the strong-name public key to every InternalsVisibleTo grant when signing is enabled. A
+    strong-named assembly may only grant its internals to a friend that presents a matching public
+    key, so "Bodu.Core.Test" must become "Bodu.Core.Test, PublicKey=<hex>". Every Bodu project (src
+    and test) signs with the same key (bld/Signing.props), so the one BoduPublicKey value applies to
+    all grants. The original grants stay unqualified in the project files; the public key is woven in
+    centrally here only when SignAssembly is true and BoduPublicKey is populated, so unsigned builds
+    are unaffected.
+
+    Gated on the same SignAssembly/BoduPublicKey pair that turns on signing, and idempotent — grants
+    that already carry a PublicKey are skipped. Runs after BoduDropTestInternalsVisibleToOnShipping
+    (DependsOnTargets) so that on a shipping build the ".Test" grants are removed by their bare name
+    before the key is appended; otherwise the appended suffix would defeat the ".Test" name match.
+  -->
+  <Target Name="BoduAppendPublicKeyToInternalsVisibleTo"
+          BeforeTargets="CreateGeneratedAssemblyInfoInputsCacheFile;CoreGenerateAssemblyInfo"
+          DependsOnTargets="BoduDropTestInternalsVisibleToOnShipping"
+          Condition="'$(SignAssembly)' == 'true' and '$(BoduPublicKey)' != ''">
+    <ItemGroup>
+      <!-- Snapshot the friend names of grants that do not yet carry a public key. -->
+      <_BoduUnsignedInternalsVisibleTo Include="%(AssemblyAttribute._Parameter1)"
+                                       Condition="'%(AssemblyAttribute.Identity)' == 'System.Runtime.CompilerServices.InternalsVisibleTo' And !$([System.String]::Copy('%(AssemblyAttribute._Parameter1)').Contains('PublicKey='))" />
+    </ItemGroup>
+    <ItemGroup>
+      <!-- Drop the bare grants and re-add them with the public key appended. -->
+      <AssemblyAttribute Remove="@(AssemblyAttribute)"
+                         Condition="'%(Identity)' == 'System.Runtime.CompilerServices.InternalsVisibleTo' And !$([System.String]::Copy('%(_Parameter1)').Contains('PublicKey='))" />
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>%(_BoduUnsignedInternalsVisibleTo.Identity), PublicKey=$(BoduPublicKey)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/bld/SIGNING.md
+++ b/bld/SIGNING.md
@@ -5,47 +5,74 @@ inert; enabling it is a two-value change once a key exists. This is *identity* s
 `PublicKeyToken`), not publisher trust — for consumer-verifiable publisher identity, add a code-signing
 certificate and author-sign the NuGet packages separately.
 
+## Key management
+
+| File | Where it lives | Notes |
+|---|---|---|
+| `bld/Bodu.public.snk` | **committed** | Public key only. All it takes to public-sign. Produced by `sn -p`. |
+| `Bodu.snk` (full key pair) | **never in the repo** | Stored in a secret store / CI secret. `.gitignore` blocks `*.snk` except the public one. Needed only for a real-signing release. |
+
+The default build model is **public signing**: every build stamps the correct public-key identity and
+`PublicKeyToken` using the committed public key, with no real RSA signature — which .NET Core / .NET 5+
+does not verify at load anyway. A real signature is optional and applied only by a release that opts in
+with `-p:BoduRealSign=true` and supplies the private key.
+
 ## What is already wired
 
-- `bld/Signing.props` — `BoduSignAssembly` (off), `SignAssembly`, `AssemblyOriginatorKeyFile`
-  (→ `bld/Bodu.snk`), `PublicSign` (on for non-CI), and the `BoduPublicKey` hex string (empty).
+- `bld/Signing.props` — `BoduSignAssembly` (off), `SignAssembly`, `BoduStrongNameKeyFile`
+  (→ committed `bld/Bodu.public.snk`), `PublicSign` (on unless `BoduRealSign=true`), and the
+  `BoduPublicKey` hex string (empty).
 - `bld/InternalsVisibleTo.targets` — `BoduAppendPublicKeyToInternalsVisibleTo` weaves
   `, PublicKey=$(BoduPublicKey)` into every `InternalsVisibleTo` grant when signing is on, so the bare
   grants in the project files need no per-project edits.
 - `Directory.Build.targets` — pins `AssemblyVersion` to `Major.Minor.0.0` so a patch or out-of-band
   release never shifts the strong-name binding identity (`FileVersion` / `InformationalVersion` still
   carry the full patch).
+- `.gitignore` — ignores `*.snk` except `bld/Bodu.public.snk`, so the private key cannot be committed
+  by accident.
 
-## Enabling
+## Enabling (public signing — the normal path)
 
-1. **Generate the key pair** (needs `sn` from the .NET Framework SDK, or Mono's `sn` on Linux/macOS):
+1. **Commit the public key** only:
 
    ```bash
-   sn -k 2048 bld/Bodu.snk            # private + public — keep the private half secret
-   sn -p bld/Bodu.snk bld/Bodu.public.snk   # public-only, safe to commit
-   sn -tp bld/Bodu.public.snk         # prints the full PublicKey hex (and the short token)
+   git add -f bld/Bodu.public.snk     # -f because *.snk is gitignored
    ```
 
-   Recommended model: commit `bld/Bodu.public.snk`, keep the private `Bodu.snk` in a CI secret, and
-   let `PublicSign=true` cover local/dev builds. Real signing happens only in the release pipeline,
-   which supplies the private key.
+   Store the full private `Bodu.snk` in your secret manager (GitHub Actions secret, Azure Key Vault,
+   1Password, …). Do **not** put it in the working tree.
 
-2. **Populate `BoduPublicKey`** in `bld/Signing.props` with the long hex `PublicKey` from `sn -tp`
-   (not the 8-byte token).
+2. **Populate `BoduPublicKey`** in `bld/Signing.props` with the long hex `PublicKey` from
+   `sn -tp bld/Bodu.public.snk` (the long key, not the 8-byte token).
 
-3. **Turn it on** — repo-wide default in `bld/Signing.props`, or per build:
+3. **Turn it on** — set the repo-wide default in `bld/Signing.props`, or per build:
 
    ```bash
    dotnet build bodu.slnx -p:BoduSignAssembly=true
    ```
 
-   `SignAssembly` applies to **src and test** projects alike (the test assemblies must be signed with
-   the same key to receive the `InternalsVisibleTo` grants), so this is all-or-nothing across the
-   solution.
+   `SignAssembly` applies to **src and test** projects alike (test assemblies must carry the same
+   public key to receive the `InternalsVisibleTo` grants), so this is all-or-nothing across the
+   solution. Run `dotnet test bodu.slnx --settings bvt.runsettings` once after enabling.
+
+## Optional: a real, verifiable signature at release
+
+Only needed if you want a full RSA signature (e.g. for .NET Framework consumers with verification on).
+The release job materializes the private key from its secret to a path **outside** the working tree and
+opts into real signing:
+
+```bash
+# e.g. in CI, $BODU_SNK_SECRET holds the base64 of the full Bodu.snk
+printf '%s' "$BODU_SNK_SECRET" | base64 -d > "$RUNNER_TEMP/Bodu.snk"
+dotnet pack bodu.slnx -c Release \
+  -p:BoduSignAssembly=true \
+  -p:BoduRealSign=true \
+  -p:BoduStrongNameKeyFile="$RUNNER_TEMP/Bodu.snk"
+```
 
 ## Notes
 
 - Strong naming is **effectively permanent** for published packages — the key cannot change later
   without breaking every consumer's binding.
-- On .NET Core / .NET 5+ the strong-name signature is **not verified at load**; it exists for identity,
-  friend-assembly (`InternalsVisibleTo`) support, and consumers who are themselves strong-named.
+- The strong name is *identity*, not publisher trust. For consumer-verifiable publisher identity, add a
+  code-signing certificate and author-sign the NuGet packages separately.

--- a/bld/SIGNING.md
+++ b/bld/SIGNING.md
@@ -1,0 +1,51 @@
+# Strong-name signing (Path A)
+
+Bodu assemblies ship **unsigned by default**. The infrastructure to strong-name them is staged and
+inert; enabling it is a two-value change once a key exists. This is *identity* signing only (a stable
+`PublicKeyToken`), not publisher trust — for consumer-verifiable publisher identity, add a code-signing
+certificate and author-sign the NuGet packages separately.
+
+## What is already wired
+
+- `bld/Signing.props` — `BoduSignAssembly` (off), `SignAssembly`, `AssemblyOriginatorKeyFile`
+  (→ `bld/Bodu.snk`), `PublicSign` (on for non-CI), and the `BoduPublicKey` hex string (empty).
+- `bld/InternalsVisibleTo.targets` — `BoduAppendPublicKeyToInternalsVisibleTo` weaves
+  `, PublicKey=$(BoduPublicKey)` into every `InternalsVisibleTo` grant when signing is on, so the bare
+  grants in the project files need no per-project edits.
+- `Directory.Build.targets` — pins `AssemblyVersion` to `Major.Minor.0.0` so a patch or out-of-band
+  release never shifts the strong-name binding identity (`FileVersion` / `InformationalVersion` still
+  carry the full patch).
+
+## Enabling
+
+1. **Generate the key pair** (needs `sn` from the .NET Framework SDK, or Mono's `sn` on Linux/macOS):
+
+   ```bash
+   sn -k 2048 bld/Bodu.snk            # private + public — keep the private half secret
+   sn -p bld/Bodu.snk bld/Bodu.public.snk   # public-only, safe to commit
+   sn -tp bld/Bodu.public.snk         # prints the full PublicKey hex (and the short token)
+   ```
+
+   Recommended model: commit `bld/Bodu.public.snk`, keep the private `Bodu.snk` in a CI secret, and
+   let `PublicSign=true` cover local/dev builds. Real signing happens only in the release pipeline,
+   which supplies the private key.
+
+2. **Populate `BoduPublicKey`** in `bld/Signing.props` with the long hex `PublicKey` from `sn -tp`
+   (not the 8-byte token).
+
+3. **Turn it on** — repo-wide default in `bld/Signing.props`, or per build:
+
+   ```bash
+   dotnet build bodu.slnx -p:BoduSignAssembly=true
+   ```
+
+   `SignAssembly` applies to **src and test** projects alike (the test assemblies must be signed with
+   the same key to receive the `InternalsVisibleTo` grants), so this is all-or-nothing across the
+   solution.
+
+## Notes
+
+- Strong naming is **effectively permanent** for published packages — the key cannot change later
+  without breaking every consumer's binding.
+- On .NET Core / .NET 5+ the strong-name signature is **not verified at load**; it exists for identity,
+  friend-assembly (`InternalsVisibleTo`) support, and consumers who are themselves strong-named.

--- a/bld/Signing.props
+++ b/bld/Signing.props
@@ -12,4 +12,20 @@
     <PublicSign Condition="'$(SignAssembly)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'">true</PublicSign>
   </PropertyGroup>
 
+  <!--
+    Full public key for the Bodu strong-name identity, as the hex string printed by
+    'sn -tp Bodu.public.snk' (the long PublicKey, not the short 8-byte PublicKeyToken). It is
+    consumed by bld/InternalsVisibleTo.targets, which appends ", PublicKey=$(BoduPublicKey)" to every
+    InternalsVisibleTo grant when signing is enabled, because a strong-named assembly may only grant
+    its internals to a friend that presents this public key.
+
+    Left empty until the key pair is generated and checked in. While empty (or while SignAssembly is
+    false) the public-key suffix is not applied, so unsigned builds continue to grant internals by
+    simple name. Populating this and setting BoduSignAssembly=true is all that is required to turn on
+    strong-name signing across the solution.
+  -->
+  <PropertyGroup>
+    <BoduPublicKey Condition="'$(BoduPublicKey)' == ''"></BoduPublicKey>
+  </PropertyGroup>
+
 </Project>

--- a/bld/Signing.props
+++ b/bld/Signing.props
@@ -8,8 +8,24 @@
   <PropertyGroup>
     <BoduSignAssembly Condition="'$(BoduSignAssembly)' == ''">false</BoduSignAssembly>
     <SignAssembly>$(BoduSignAssembly)</SignAssembly>
-    <AssemblyOriginatorKeyFile Condition="'$(SignAssembly)' == 'true'">$(MSBuildThisFileDirectory)Bodu.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition="'$(SignAssembly)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'">true</PublicSign>
+
+    <!--
+      Key file used for strong-naming. Defaults to the committed public-only key (Bodu.public.snk),
+      which is all that public signing needs. A real-signing release overrides BoduStrongNameKeyFile
+      with the full private key — materialized from a secret at build time, never committed — and sets
+      BoduRealSign=true.
+    -->
+    <BoduStrongNameKeyFile Condition="'$(BoduStrongNameKeyFile)' == ''">$(MSBuildThisFileDirectory)Bodu.public.snk</BoduStrongNameKeyFile>
+    <AssemblyOriginatorKeyFile Condition="'$(SignAssembly)' == 'true'">$(BoduStrongNameKeyFile)</AssemblyOriginatorKeyFile>
+
+    <!--
+      Public-sign by default: the committed key is public-only, so builds stamp the correct public-key
+      identity (and PublicKeyToken) without a real RSA signature — which .NET Core / .NET 5+ does not
+      verify at load. A release that wants a full, verifiable signature (for example, for .NET Framework
+      consumers with verification enabled) sets BoduRealSign=true and supplies the private key through
+      BoduStrongNameKeyFile.
+    -->
+    <PublicSign Condition="'$(SignAssembly)' == 'true' and '$(BoduRealSign)' != 'true'">true</PublicSign>
   </PropertyGroup>
 
   <!--

--- a/bld/Versioning.props
+++ b/bld/Versioning.props
@@ -1,11 +1,20 @@
 <Project>
 
   <!--
-    Shared package-version baseline. Individual projects may still override <Version> or
-    <VersionPrefix> where they ship on an independent cadence.
+    Shared, lock-step package-version baseline. Every Bodu library ships at BoduBaseVersion by
+    default, so consumers can treat a matched version number across all Bodu.* packages as a
+    coherent set.
+
+    Breaking rank: a single library that needs an out-of-band fix overrides this deliberately by
+    setting <BoduPackageVersionOverride> in its own .csproj. That property is applied (and reported)
+    in the repository-root Directory.Build.targets, which is processed after the project body so the
+    divergence is explicit, visible in build output, and auditable in source control. Do not edit
+    <VersionPrefix> directly in a project to break rank — use BoduPackageVersionOverride so the
+    intent is obvious.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <BoduBaseVersion>1.0.0</BoduBaseVersion>
+    <VersionPrefix>$(BoduBaseVersion)</VersionPrefix>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

This change introduces a complete strong-name signing infrastructure for Bodu assemblies, along with enhanced versioning controls to support both lock-step and out-of-band release cadences. Assemblies ship **unsigned by default**; signing is opt-in via a two-property change once a key pair exists.

## Key Changes

- **New `bld/SIGNING.md`**: Comprehensive documentation of the strong-name signing model, key management strategy (public key committed, private key in secrets), and step-by-step enablement instructions for both public signing (default) and real signing (release-time, optional).

- **`bld/Signing.props` enhancements**:
  - Introduced `BoduStrongNameKeyFile` property (defaults to committed `bld/Bodu.public.snk`)
  - Introduced `BoduRealSign` property to distinguish public signing (default, no RSA signature) from real signing (full signature, requires private key)
  - Updated `PublicSign` condition to enable public signing by default unless `BoduRealSign=true`
  - Added `BoduPublicKey` property (hex string) for `InternalsVisibleTo` grants; left empty until key pair is generated

- **`bld/InternalsVisibleTo.targets` enhancements**:
  - New `BoduAppendPublicKeyToInternalsVisibleTo` target that weaves `, PublicKey=$(BoduPublicKey)` into every `InternalsVisibleTo` grant when signing is enabled
  - Idempotent and gated on both `SignAssembly` and `BoduPublicKey` being populated
  - Runs after test-grant removal so unsigned builds are unaffected

- **`Directory.Build.targets` enhancements**:
  - New `BoduPackageVersionOverride` property for deliberate out-of-band version breaks (single library on independent cadence)
  - `AssemblyVersion` pinned to `Major.Minor.0.0` so binding identity stays stable across patch and out-of-band releases
  - `FileVersion` explicitly set to full `VersionPrefix` to preserve patch component in diagnostics
  - New `BoduReportVersionOverride` target reports divergence from lock-step baseline in build output

- **`bld/Versioning.props` refactored**:
  - Renamed `VersionPrefix` source to `BoduBaseVersion` for clarity (lock-step baseline)
  - Updated comments to explain lock-step model and out-of-band override mechanism

- **`.gitignore` updated**:
  - Added `*.snk` to ignore all strong-name keys by default
  - Exception: `!bld/Bodu.public.snk` to allow committing the public key only

## Implementation Details

- **Public signing by default**: Builds stamp the correct public-key identity and `PublicKeyToken` using the committed public key, with no real RSA signature — which .NET Core / .NET 5+ does not verify at load.
- **Real signing opt-in**: A release that wants a full, verifiable signature (e.g., for .NET Framework consumers with verification enabled) sets `BoduRealSign=true` and supplies the private key via `BoduStrongNameKeyFile` from a secret.
- **Stable binding identity**: `AssemblyVersion` is pinned to `Major.Minor.0.0` so strong-named assemblies do not force consumer rebinding on patch releases.
- **Centralized public-key weaving**: The `BoduPublicKey` hex string is applied to all `InternalsVisibleTo` grants in one place, so project files need no per-project edits.
- **Auditable out-of-band releases**: The `BoduPackageVersionOverride` mechanism is explicit and reported in build output, making divergence from lock-step versioning visible and traceable.

https://claude.ai/code/session_01GTGeSEaddxbfeKn5FyBDcb