### PR TITLE
Validate cache storage at host start and add live-Redis integration tests

### DIFF
--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/src/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/DistributedCacheStorageStartupValidator.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/src/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/DistributedCacheStorageStartupValidator.cs
@@ -1,0 +1,57 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DistributedCacheStorageStartupValidator.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial.ExchangeRates.Caching;
+using Bodu.Financial.ExchangeRates.Caching.Distributed;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection;
+
+/// <summary>
+/// Validates, at application startup, that the backing store of an exchange-rate cache configured with
+/// <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> can be reached, so an unreachable or misconfigured
+/// distributed cache fails the host start rather than the first lookup.
+/// </summary>
+/// <remarks>
+/// Registered as an <see cref="IValidateOptions{TOptions}" /> so the existing <c>ValidateOnStart</c> wiring runs it at
+/// host start. It is a no-op unless <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> is set.
+/// </remarks>
+internal sealed class DistributedCacheStorageStartupValidator
+    : IValidateOptions<DistributedExchangeRateCacheOptions>
+{
+    /// <summary>
+    /// The distributed cache the exchange-rate cache is backed by, probed at startup.
+    /// </summary>
+    private readonly IDistributedCache _distributedCache;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DistributedCacheStorageStartupValidator" /> class.
+    /// </summary>
+    /// <param name="distributedCache">The distributed cache backing the exchange-rate cache.</param>
+    public DistributedCacheStorageStartupValidator(IDistributedCache distributedCache) =>
+        _distributedCache = distributedCache;
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, DistributedExchangeRateCacheOptions options)
+    {
+        if (!options.ValidateStorageOnStart)
+            return ValidateOptionsResult.Skip;
+
+        try
+        {
+            // Constructing the cache runs the same sentinel-read probe the runtime uses; with ValidateStorageOnStart set
+            // the constructor throws rather than swallowing when the backing store is unreachable.
+            _ = new DistributedExchangeRateCache(_distributedCache, options);
+            return ValidateOptionsResult.Success;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return ValidateOptionsResult.Fail(
+                $"The distributed exchange-rate cache for provider '{options.Provider}' could not be reached at startup: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/src/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/DistributedExchangeRateCacheServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/src/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/DistributedExchangeRateCacheServiceBuilderExtensions.cs
@@ -93,6 +93,10 @@ public static class DistributedExchangeRateCacheServiceBuilderExtensions
             .Validate(static options => options.TryValidate(out _), "Distributed exchange-rate cache options are invalid.")
             .ValidateOnStart();
 
+        // Probe the backing store at host start when ValidateStorageOnStart is set, so an unreachable distributed cache
+        // fails the start rather than the first lookup. The probe runs through the same ValidateOnStart wiring.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DistributedExchangeRateCacheOptions>, DistributedCacheStorageStartupValidator>());
+
         // Register the concrete cache once as a singleton so a single instance — and its per-pair locks — backs every
         // resolution. The backing IDistributedCache is resolved from the container so any registered distributed cache
         // (Redis, in-memory, SQL Server, …) can host it.

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/DistributedExchangeRateCacheServiceBuilderExtensionsTests.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/DistributedExchangeRateCacheServiceBuilderExtensionsTests.cs
@@ -168,6 +168,43 @@ public sealed class DistributedExchangeRateCacheServiceBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that, with <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> set over an unreachable
+    /// backing store, the startup validation the host runs fails, so an unreachable distributed cache fails the host
+    /// start rather than the first lookup.
+    /// </summary>
+    [TestMethod]
+    public void AddDistributedExchangeRateCache_WhenValidateStorageOnStartAndStoreUnreachable_ShouldFailStartupValidation()
+    {
+        ServiceProvider provider = BuildProvider(services =>
+        {
+            services.AddSingleton<IDistributedCache>(new ThrowingDistributedCache());
+            services.AddBoduFinancial().AddDistributedExchangeRateCache("RBA", configure: o => o.ValidateStorageOnStart = true);
+        });
+
+        IStartupValidator startup = provider.GetRequiredService<IStartupValidator>();
+
+        _ = Assert.ThrowsExactly<OptionsValidationException>(startup.Validate);
+    }
+
+    /// <summary>
+    /// Verifies that, with <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> set over a reachable backing
+    /// store, the startup validation the host runs passes.
+    /// </summary>
+    [TestMethod]
+    public void AddDistributedExchangeRateCache_WhenValidateStorageOnStartAndStoreReachable_ShouldPassStartupValidation()
+    {
+        ServiceProvider provider = BuildProvider(services =>
+        {
+            services.AddDistributedMemoryCache();
+            services.AddBoduFinancial().AddDistributedExchangeRateCache("RBA", configure: o => o.ValidateStorageOnStart = true);
+        });
+
+        IStartupValidator startup = provider.GetRequiredService<IStartupValidator>();
+
+        startup.Validate();
+    }
+
+    /// <summary>
     /// Verifies that <c>AddRedisExchangeRateCache</c> registers a Redis <see cref="IDistributedCache" /> together with
     /// the exchange-rate cache, asserting service registration without requiring a live Redis server.
     /// </summary>

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/ThrowingDistributedCache.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection/test/Financial.ExchangeRates.Caching.Distributed.DependencyInjection/ThrowingDistributedCache.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowingDistributedCache.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Bodu.Financial.ExchangeRates.Caching.Distributed.DependencyInjection;
+
+/// <summary>
+/// An <see cref="IDistributedCache" /> whose every operation throws, standing in for an unreachable backing store so the
+/// startup storage probe can be exercised without a live distributed cache.
+/// </summary>
+internal sealed class ThrowingDistributedCache
+    : IDistributedCache
+{
+    /// <inheritdoc />
+    public byte[]? Get(string key) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public Task<byte[]?> GetAsync(string key, CancellationToken token = default) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public void Set(string key, byte[] value, DistributedCacheEntryOptions options) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public void Refresh(string key) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public Task RefreshAsync(string key, CancellationToken token = default) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public void Remove(string key) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+
+    /// <inheritdoc />
+    public Task RemoveAsync(string key, CancellationToken token = default) =>
+        throw new InvalidOperationException("The distributed cache is unavailable.");
+}

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Bodu.Financial.ExchangeRates.Caching.Distributed.Test.csproj
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Bodu.Financial.ExchangeRates.Caching.Distributed.Test.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <!-- Used only by the environment-gated live-Redis integration test (BODU_TEST_REDIS). -->
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.28" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Financial.ExchangeRates.Caching.Distributed/RedisDistributedExchangeRateCacheIntegrationTests.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Distributed/test/Financial.ExchangeRates.Caching.Distributed/RedisDistributedExchangeRateCacheIntegrationTests.cs
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RedisDistributedExchangeRateCacheIntegrationTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Financial.ExchangeRates.Caching.Distributed;
+
+/// <summary>
+/// Exercises <see cref="DistributedExchangeRateCache" /> against a live Redis server, covering the network round-trip
+/// and multi-writer race the in-memory <c>MemoryDistributedCache</c> tests cannot reproduce. The tests are
+/// environment-gated: they run only when <c>BODU_TEST_REDIS</c> holds a Redis connection string, and report inconclusive
+/// otherwise so the default build needs no Redis.
+/// </summary>
+[TestClass]
+public sealed class RedisDistributedExchangeRateCacheIntegrationTests
+{
+    /// <summary>
+    /// The environment variable holding the Redis connection string the tests connect to.
+    /// </summary>
+    private const string RedisConnectionEnvVar = "BODU_TEST_REDIS";
+
+    /// <summary>
+    /// The currency pair used by the tests.
+    /// </summary>
+    private static readonly ExchangeRatePair Pair = new("AUD", "USD");
+
+    /// <summary>
+    /// The freshness duration used by the tests.
+    /// </summary>
+    private static readonly TimeSpan Duration = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Verifies that an atomic range write persists and reads back through a live Redis store, exercising the real
+    /// network serialization round-trip end to end.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Stress")]
+    public void StoreFetchedRange_OverLiveRedis_ShouldRoundTripThroughTheStore()
+    {
+        string? connection = Environment.GetEnvironmentVariable(RedisConnectionEnvVar);
+        if (string.IsNullOrWhiteSpace(connection))
+        {
+            Assert.Inconclusive($"Set {RedisConnectionEnvVar} to a Redis connection string to run the live Redis integration test.");
+            return;
+        }
+
+        string keyPrefix = $"bodu-test:{Guid.NewGuid():N}:";
+        using var redis = new RedisCache(Options.Create(new RedisCacheOptions { Configuration = connection }));
+        var now = DateTimeOffset.UtcNow;
+        var date = new DateOnly(2023, 1, 3);
+        var cache = new DistributedExchangeRateCache(redis, new DistributedExchangeRateCacheOptions { Provider = "RedisTest", KeyPrefix = keyPrefix });
+
+        try
+        {
+            ExchangeRateCacheWriteStatus status = cache.StoreFetchedRange(
+                Pair, new[] { new CachedExchangeRate(date, 0.5m, now) }, date, date, Duration, now);
+
+            Assert.AreEqual(ExchangeRateCacheWriteStatus.Stored, status);
+
+            IReadOnlyList<CachedExchangeRate> rows = cache.GetRates(Pair, Duration, now);
+            Assert.AreEqual(1, rows.Count);
+            Assert.AreEqual(0.5m, rows[0].Rate);
+            Assert.IsTrue(cache.GetCoverage(Pair, Duration, now).Contains(date, date));
+        }
+        finally
+        {
+            redis.Remove($"{keyPrefix}RedisTest:AUDUSD");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that many concurrent same-pair range writes from two instances over one live Redis store leave the
+    /// per-pair blob internally consistent — one row whose rate is a writer's, with the window covered — proving the
+    /// last-write-wins blob set holds under real network races, not just an in-memory store.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Stress")]
+    public async Task StoreFetchedRange_WhenTwoInstancesRaceOverLiveRedis_ShouldKeepBlobConsistent()
+    {
+        string? connection = Environment.GetEnvironmentVariable(RedisConnectionEnvVar);
+        if (string.IsNullOrWhiteSpace(connection))
+        {
+            Assert.Inconclusive($"Set {RedisConnectionEnvVar} to a Redis connection string to run the live Redis integration test.");
+            return;
+        }
+
+        string keyPrefix = $"bodu-test:{Guid.NewGuid():N}:";
+        using var redis = new RedisCache(Options.Create(new RedisCacheOptions { Configuration = connection }));
+        var now = DateTimeOffset.UtcNow;
+        var date = new DateOnly(2023, 1, 3);
+        var cacheA = new DistributedExchangeRateCache(redis, new DistributedExchangeRateCacheOptions { Provider = "RedisTest", KeyPrefix = keyPrefix });
+        var cacheB = new DistributedExchangeRateCache(redis, new DistributedExchangeRateCacheOptions { Provider = "RedisTest", KeyPrefix = keyPrefix });
+
+        try
+        {
+            List<Task> writes = new();
+            for (int i = 0; i < 50; i++)
+            {
+                DistributedExchangeRateCache cache = (i % 2 == 0) ? cacheA : cacheB;
+                decimal rate = (i % 2 == 0) ? 0.5000m : 0.6000m;
+                writes.Add(Task.Run(() => cache.StoreFetchedRange(
+                    Pair, new[] { new CachedExchangeRate(date, rate, now) }, date, date, Duration, now)));
+            }
+
+            await Task.WhenAll(writes);
+
+            IReadOnlyList<CachedExchangeRate> rows = cacheB.GetRates(Pair, Duration, now);
+            Assert.AreEqual(1, rows.Count, "exactly one merged row survives, never a torn or duplicated set");
+            Assert.IsTrue(rows[0].Rate == 0.5000m || rows[0].Rate == 0.6000m, "the surviving rate is one writer's, not a mix");
+            Assert.IsTrue(cacheB.GetCoverage(Pair, Duration, now).Contains(date, date), "coverage is present with its row, never recorded without it");
+        }
+        finally
+        {
+            redis.Remove($"{keyPrefix}RedisTest:AUDUSD");
+        }
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/src/Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/SqliteCacheStorageStartupValidator.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/src/Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/SqliteCacheStorageStartupValidator.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SqliteCacheStorageStartupValidator.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial.ExchangeRates.Caching;
+using Bodu.Financial.ExchangeRates.Caching.Sqlite;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection;
+
+/// <summary>
+/// Validates, at application startup, that the SQLite database backing an exchange-rate cache configured with
+/// <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> can be opened and initialized, so a misconfigured or
+/// unwritable database fails the host start rather than the first lookup.
+/// </summary>
+/// <remarks>
+/// Registered as an <see cref="IValidateOptions{TOptions}" /> so the existing <c>ValidateOnStart</c> wiring runs it at
+/// host start. It is a no-op unless <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> is set.
+/// </remarks>
+internal sealed class SqliteCacheStorageStartupValidator
+    : IValidateOptions<SqliteExchangeRateCacheOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, SqliteExchangeRateCacheOptions options)
+    {
+        if (!options.ValidateStorageOnStart)
+            return ValidateOptionsResult.Skip;
+
+        try
+        {
+            // Constructing the cache runs the same open-and-ensure-schema probe the runtime uses; with
+            // ValidateStorageOnStart set the constructor throws rather than swallowing when the database is unusable.
+            using var probe = new SqliteExchangeRateCache(options);
+            return ValidateOptionsResult.Success;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return ValidateOptionsResult.Fail(
+                $"The SQLite exchange-rate cache database for provider '{options.Provider}' could not be opened at startup: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/src/Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/SqliteExchangeRateCacheServiceBuilderExtensions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/src/Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/SqliteExchangeRateCacheServiceBuilderExtensions.cs
@@ -87,6 +87,10 @@ public static class SqliteExchangeRateCacheServiceBuilderExtensions
             .Validate(static options => options.TryValidate(out _), "SQLite exchange-rate cache options are invalid.")
             .ValidateOnStart();
 
+        // Probe the database at host start when ValidateStorageOnStart is set, so a misconfigured or unwritable database
+        // fails the start rather than the first lookup. The probe runs through the same ValidateOnStart wiring.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<SqliteExchangeRateCacheOptions>, SqliteCacheStorageStartupValidator>());
+
         // Register the concrete cache once as a singleton so a single instance — and its single keep-alive connection
         // and per-pair locks — backs every resolution and the container disposes it on shutdown.
         services.TryAddSingleton(serviceProvider =>

--- a/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/test/Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/SqliteExchangeRateCacheServiceBuilderExtensionsTests.cs
+++ b/Bodu.Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/test/Financial.ExchangeRates.Caching.Sqlite.DependencyInjection/SqliteExchangeRateCacheServiceBuilderExtensionsTests.cs
@@ -181,6 +181,46 @@ public sealed class SqliteExchangeRateCacheServiceBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that, with <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> set over a database that
+    /// cannot be opened, the startup validation the host runs fails, so a misconfigured database fails the host start
+    /// rather than the first lookup.
+    /// </summary>
+    [TestMethod]
+    public void AddSqliteExchangeRateCache_WhenValidateStorageOnStartAndDatabaseUnusable_ShouldFailStartupValidation()
+    {
+        string unusablePath = Path.Combine(Path.GetDirectoryName(_databasePath)!, "missing-subdirectory", "x.db");
+        ServiceProvider provider = BuildProvider(builder =>
+            builder.AddSqliteExchangeRateCache("RBA", configure: o =>
+            {
+                o.DatabaseFilePath = unusablePath;
+                o.ValidateStorageOnStart = true;
+            }));
+
+        IStartupValidator startup = provider.GetRequiredService<IStartupValidator>();
+
+        _ = Assert.ThrowsExactly<OptionsValidationException>(startup.Validate);
+    }
+
+    /// <summary>
+    /// Verifies that, with <see cref="ExchangeRateCacheOptions.ValidateStorageOnStart" /> set over a usable database,
+    /// the startup validation the host runs passes.
+    /// </summary>
+    [TestMethod]
+    public void AddSqliteExchangeRateCache_WhenValidateStorageOnStartAndDatabaseUsable_ShouldPassStartupValidation()
+    {
+        ServiceProvider provider = BuildProvider(builder =>
+            builder.AddSqliteExchangeRateCache("RBA", configure: o =>
+            {
+                o.DatabaseFilePath = _databasePath;
+                o.ValidateStorageOnStart = true;
+            }));
+
+        IStartupValidator startup = provider.GetRequiredService<IStartupValidator>();
+
+        startup.Validate();
+    }
+
+    /// <summary>
     /// Builds a service provider after applying the supplied registration against a fresh financial builder.
     /// </summary>
     /// <param name="register">The registration callback.</param>

--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/ExchangeRateCacheOptions.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/ExchangeRateCacheOptions.cs
@@ -53,10 +53,11 @@ public class ExchangeRateCacheOptions
     /// <returns>The configured startup-validation setting.</returns>
     /// <remarks>
     /// The probe surfaces a misconfigured directory, an unopenable database, or an unreachable distributed cache at
-    /// construction. Under dependency injection a cache is constructed when first resolved, so resolve it during
-    /// startup to fail at start. This setting is independent of <see cref="ThrowOnStorageFailure" />: a cache can
-    /// validate once at construction yet still degrade best-effort on a later transient fault, or run best-effort at
-    /// construction yet fail fast on every later read or write.
+    /// construction. The SQLite and distributed dependency-injection packages run this probe through their
+    /// <c>ValidateOnStart</c> wiring, so a misconfigured store fails the host start; a cache constructed directly
+    /// probes in its constructor instead. This setting is independent of <see cref="ThrowOnStorageFailure" />: a cache
+    /// can validate once at construction yet still degrade best-effort on a later transient fault, or run best-effort
+    /// at construction yet fail fast on every later read or write.
     /// </remarks>
     public bool ValidateStorageOnStart { get; set; }
 


### PR DESCRIPTION
Follows up #499 with the two items flagged as deliberate scope-downs in that PR's review.

## D — Validate cache storage at host start, not first resolve

`ValidateStorageOnStart` previously only probed the store in the cache constructor, which under lazy DI fires at first resolve rather than at host start. The **SQLite** and **distributed** cache DI packages now register an `IValidateOptions<TOptions>` storage probe that runs through the existing `ValidateOnStart` wiring, so a misconfigured database or an unreachable distributed cache fails the host start.

- The probe reuses each backend's constructor probe (a throwaway construct), so behaviour stays identical; it is a no-op unless `ValidateStorageOnStart` is set.
- Scoped to the two dedicated cache DI packages: the file/TOML cache is built internally by the provider convenience constructor from `CachingExchangeRateOptions`, which doesn't carry the flag — a directly-constructed file cache still probes in its constructor.
- DI tests drive `IStartupValidator.Validate()` for the usable and unusable cases on both backends (SQLite DI 10/10, Distributed DI 13/13).

## F — Environment-gated live-Redis integration tests

Adds the real-Redis coverage the deterministic shared-`MemoryDistributedCache` tests cannot reproduce:

- a network serialization round-trip, and
- a two-instance concurrent same-pair race asserting the per-pair blob stays internally consistent (one merged row whose rate is a writer's, with the window covered).

Both are `[TestCategory("Stress")]` and gated on `BODU_TEST_REDIS`, so they report inconclusive (skip) when no connection string is set — the default and CI build need no Redis — and exercise a real server when it is.

## Verification

- `dotnet build bodu.slnx` — 0 errors (the lone CA1716 is pre-existing in `master`).
- SQLite DI 10/10, Distributed DI 13/13, Distributed 66 passed + 2 skipped (Redis) with no env var.
- Verified the Redis tests both ways: skip cleanly without `BODU_TEST_REDIS`, and pass against a local Redis 7 with it (2/2, cleaning up their namespaced keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Vw9mrM1D8uVvsvFPhaMhE)_