### PR TITLE
Fix DateOnly.PreviousDateOfWeek same-weekday regression

### DIFF
--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousDateOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousDateOfWeek.cs
@@ -34,6 +34,6 @@ public static partial class DateOnlyExtensions
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
 
-        return date.AddDays(- ((7 + date.DayOfWeek - dayOfWeek) % 7) switch { 0 => 7, int d => d });
+        return date.AddDays(-(((7 + date.DayOfWeek - dayOfWeek) % 7) switch { 0 => 7, int d => d }));
     }
 }


### PR DESCRIPTION
PR #505's analyzer-only reformatting unintentionally changed operator
binding in DateOnly.PreviousDateOfWeek: moving the unary minus outside
the parentheses made the `switch { 0 => 7, ... }` govern the already-
negated modulo instead of negating the switch result.

When `date.DayOfWeek == dayOfWeek` the modulo is 0, so `-0` still hit the
`0 => 7` arm and the method did `AddDays(+7)` — jumping a week forward
instead of returning the date seven days earlier as documented. This
broke the same-weekday rows of PreviousDateOfWeek and the calendar
Seek_WhenBefore_ShouldReturnPreviousWeekday test.

Restore the original parenthesization so the negation wraps the whole
switch result.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LUPMkV2fLM9xzbsVSYRvHN