### PR TITLE
Fix PreviousDateOfWeek regression, build/test all projects in CI, repair stale benchmark

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,17 +19,6 @@ jobs:
     timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
-    env:
-      TEST_PROJECTS: >-
-        Bodu.Core/test/Bodu.Core.Test.csproj
-        Bodu.Numerics/test/Bodu.Numerics.Test.csproj
-        Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj
-        Bodu.IO.Hashing/test/Bodu.IO.Hashing.Test.csproj
-        Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
-        Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/Bodu.Globalization.Calendar.Americas.Test.csproj
-        Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/Bodu.Globalization.Calendar.Europe.Test.csproj
-        Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/Bodu.Globalization.Calendar.AsiaPacific.Test.csproj
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,6 +38,29 @@ jobs:
           dotnet pack Bodu.CodeStyle.XmlDocumentation/Bodu.CodeStyle.XmlDocumentation.csproj \
             --configuration Release \
             --output "${{ github.workspace }}/local-packages"
+
+      - name: Discover test projects
+        run: |
+          # Every '*.Test.csproj' that is a member of bodu.slnx. Deriving the list from the
+          # solution keeps CI in sync as projects are added or removed, and naturally excludes
+          # the benchmark harnesses (which are not test projects and are not built in CI).
+          projects=$(grep -oE 'Path="[^"]*\.Test\.csproj"' bodu.slnx \
+            | sed -E 's/^Path="//; s/"$//; s/\\/\//g' \
+            | sort -u)
+
+          if [ -z "$projects" ]; then
+            echo "::error::No test projects discovered in bodu.slnx" >&2
+            exit 1
+          fi
+
+          echo "Discovered test projects:"
+          echo "$projects"
+
+          {
+            echo 'TEST_PROJECTS<<EOF'
+            echo "$projects"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
 
       - name: Restore
         run: |

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousDateOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousDateOfWeek.cs
@@ -34,6 +34,6 @@ public static partial class DateOnlyExtensions
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
 
-        return date.AddDays(- ((7 + date.DayOfWeek - dayOfWeek) % 7) switch { 0 => 7, int d => d });
+        return date.AddDays(-(((7 + date.DayOfWeek - dayOfWeek) % 7) switch { 0 => 7, int d => d }));
     }
 }

--- a/Bodu.Text.Configuration/bench/Text.Configuration.Benchmarks/DocumentParseBenchmarks.cs
+++ b/Bodu.Text.Configuration/bench/Text.Configuration.Benchmarks/DocumentParseBenchmarks.cs
@@ -6,7 +6,6 @@
 
 using System.Text;
 using BenchmarkDotNet.Attributes;
-using Bodu.Text.Ini;
 
 namespace Bodu.Text.Configuration.Benchmarks;
 
@@ -53,7 +52,7 @@ public class DocumentParseBenchmarks
     /// </summary>
     /// <returns>The parsed document.</returns>
     [Benchmark(Baseline = true)]
-    public IniDocument Parse_Default() =>
+    public ConfigurationDocument Parse_Default() =>
         ConfigurationDocument.Parse(_source);
 
     /// <summary>
@@ -62,7 +61,7 @@ public class DocumentParseBenchmarks
     /// </summary>
     /// <returns>The parsed document.</returns>
     [Benchmark]
-    public IniDocument Parse_EditorConfigCompatible() =>
+    public ConfigurationDocument Parse_EditorConfigCompatible() =>
         ConfigurationDocument.Parse(_source, ConfigurationParseOptions.EditorConfigCompatible);
 
     /// <summary>

--- a/Bodu.Text.Configuration/bench/Text.Configuration.Benchmarks/ResolverBenchmarks.cs
+++ b/Bodu.Text.Configuration/bench/Text.Configuration.Benchmarks/ResolverBenchmarks.cs
@@ -11,14 +11,14 @@ using Bodu.Text.Ini;
 namespace Bodu.Text.Configuration.Benchmarks;
 
 /// <summary>
-/// Measures throughput of <see cref="ConfigurationExtensions.Resolve(IniDocument, string?)" /> when applied
+/// Measures throughput of <see cref="ConfigurationExtensions.Resolve(IniDocumentBase, string?)" /> when applied
 /// to documents with progressively more sections, exercising the compiled-pattern cache that
 /// <see cref="ConfigurationPattern" /> maintains.
 /// </summary>
 [MemoryDiagnoser]
 public class ResolverBenchmarks
 {
-    private IniDocument _document = null!;
+    private ConfigurationDocument _document = null!;
     private string _targetPath = string.Empty;
 
     /// <summary>

--- a/Bodu.Text.Configuration/bench/Text.Configuration.Benchmarks/WriterRoundTripBenchmarks.cs
+++ b/Bodu.Text.Configuration/bench/Text.Configuration.Benchmarks/WriterRoundTripBenchmarks.cs
@@ -13,13 +13,13 @@ namespace Bodu.Text.Configuration.Benchmarks;
 
 /// <summary>
 /// Measures round-trip throughput: parse a document and then write it back via
-/// <see cref="ConfigurationDocument.Save(IniDocument, Stream, ConfigurationWriteOptions?, bool)" />.
+/// <see cref="ConfigurationDocument.Save(IniDocumentBase, Stream, ConfigurationWriteOptions?, bool)" />.
 /// </summary>
 [MemoryDiagnoser]
 public class WriterRoundTripBenchmarks
 {
     private string _source = string.Empty;
-    private IniDocument _parsed = null!;
+    private ConfigurationDocument _parsed = null!;
 
     /// <summary>
     /// Gets or sets the number of sections in the synthetic document round-tripped by each iteration.
@@ -58,7 +58,7 @@ public class WriterRoundTripBenchmarks
     [Benchmark(Baseline = true)]
     public long ParseAndSave()
     {
-        IniDocument doc = ConfigurationDocument.Parse(_source);
+        var doc = ConfigurationDocument.Parse(_source);
         using MemoryStream stream = new();
         ConfigurationDocument.Save(doc, stream);
         return stream.Length;


### PR DESCRIPTION
## Summary

Fixes the `master` CI failure and closes the coverage gap that let it ship, then repairs a stale benchmark surfaced along the way.

### 1. Fix `DateOnly.PreviousDateOfWeek` same-weekday regression

PR #505's "analyzer-only" reformatting unintentionally changed operator binding in `DateOnlyExtensions.PreviousDateOfWeek`:

```csharp
// before (correct) — negation wraps the whole switch result
date.AddDays(-(((7 + date.DayOfWeek - dayOfWeek) % 7) switch { 0 => 7, int d => d }))

// after #505 (broken) — switch governs the already-negated modulo
date.AddDays(- ((7 + date.DayOfWeek - dayOfWeek) % 7) switch { 0 => 7, int d => d })
```

When `date.DayOfWeek == dayOfWeek` the modulo is `0`, so `-0` still matched the `0 => 7` arm and the method did `AddDays(+7)` — moving a week *forward* instead of returning the date seven days earlier (as its XML doc guarantees). Restored the original parenthesization.

Failing tests now green: `PreviousDateOfWeek_WhenCalled_ShouldReturnExpectedDate` (same-weekday rows) and the calendar `Seek_WhenBefore_ShouldReturnPreviousWeekday`.

### 2. Build and test all solution projects in CI

`build-test.yml` iterated a hardcoded list of only **8** test projects, so ~29 product areas (all of `Bodu.Financial` and its exchange-rate/caching packages, the `Bodu.Text.*` libraries, the Africa/MiddleEast calendar bundles, Builder/Plugins/DI, Excel.Binary, IO.Compound) were never built or tested — which is why the `PreviousDateOfWeek` break only showed up via a downstream calendar test.

Replaced the static list with a discovery step that derives the `*.Test.csproj` members from `bodu.slnx` (now **38** projects). This keeps CI in sync as projects are added/removed and covers every product project transitively through its test references. Building the whole solution directly isn't viable for the test job: the BenchmarkDotNet harnesses are excluded from the Debug build and one no longer compiled (see #3), so discovering test projects is the right scope.

### 3. Repair stale `Bodu.Text.Configuration` benchmark

Discovered while validating #2. The Text.Configuration benchmarks still referenced the old `Bodu.Text.Ini` / concrete `IniDocument` API (replaced by `ConfigurationDocument` over the shared `IniDocumentBase`). Because the project is excluded from Debug builds, the rot was invisible until a Release solution build surfaced 5 compile errors. Updated the parse/resolve/round-trip benchmarks to the current types and fixed the doc-comment `cref`s (CS1574 is a repo-wide error).

## Verification

- The three previously-failing tests pass.
- Full regression run across all 38 test projects locally (matching CI's `test.runsettings`); the only failures were the three above, now fixed.
- `dotnet build bodu.slnx --configuration Release` builds all 102 projects with **0 errors**.
- Workflow YAML validated; discovery yields exactly 38 existing test projects, includes Africa/MiddleEast, excludes benchmark harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUPMkV2fLM9xzbsVSYRvHN)_