### PR TITLE
Implement strict-failure modes in the file exchange-rate cache

### DIFF
--- a/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/FileExchangeRateCacheBase.cs
+++ b/Bodu.Financial.ExchangeRates.Caching/src/Financial.ExchangeRates.Caching/FileExchangeRateCacheBase.cs
@@ -51,10 +51,28 @@ public abstract class FileExchangeRateCacheBase<TOptions>
         _directory = string.IsNullOrWhiteSpace(options.CacheDirectory)
             ? Path.Combine(Path.GetTempPath(), "bodu-exchange-rates")
             : options.CacheDirectory!;
+
+        if (Options.ValidateStorageOnStart)
+        {
+            // Eagerly create the per-provider directory so a misconfigured or unwritable location surfaces at
+            // construction rather than on the first write. The failure propagates by design; this mirrors the
+            // startup probe the SQLite and distributed backends run under the same option.
+            Directory.CreateDirectory(Path.Combine(_directory, SanitizeProvider(Provider)));
+        }
     }
 
     /// <inheritdoc />
     public string CacheDirectory => _directory;
+
+    /// <summary>
+    /// Gets a value indicating whether a caught storage failure should degrade to a best-effort fallback rather than
+    /// propagate. Used as the exception filter on the read and write catch blocks so a strict cache fails fast.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> when <see cref="ExchangeRateCacheOptions.ThrowOnStorageFailure" /> is not set; otherwise
+    /// <see langword="false" />, so the failure propagates.
+    /// </returns>
+    private bool ShouldSwallowStorageFailure => !Options.ThrowOnStorageFailure;
 
     /// <summary>
     /// Gets the file extension, including the leading period, applied to cached rate files.
@@ -91,11 +109,11 @@ public abstract class FileExchangeRateCacheBase<TOptions>
             _parsed[pair] = (stamp, state);
             return state;
         }
-        catch (IOException)
+        catch (IOException) when (ShouldSwallowStorageFailure)
         {
             return CachePairState.Empty;
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException) when (ShouldSwallowStorageFailure)
         {
             return CachePairState.Empty;
         }
@@ -128,13 +146,14 @@ public abstract class FileExchangeRateCacheBase<TOptions>
             _parsed.TryRemove(pair, out _);
             return true;
         }
-        catch (IOException)
+        catch (IOException) when (ShouldSwallowStorageFailure)
         {
             // Best-effort cache: a failed write must not break rate retrieval. Report the failure so the caller can
-            // refetch rather than trust coverage that was never persisted.
+            // refetch rather than trust coverage that was never persisted. When ThrowOnStorageFailure is set the
+            // failure propagates instead.
             return false;
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException) when (ShouldSwallowStorageFailure)
         {
             // Best-effort cache: see above.
             return false;


### PR DESCRIPTION
## Summary

Fixes the `master` CI failure introduced (surfaced) by the now solution-wide build-test run (#507). Two tests in `Bodu.Financial.ExchangeRates.Caching.Test` were failing on the Linux runner:

- `TomlFileExchangeRateCacheTests.Constructor_WhenDirectoryUncreatableAndValidateStorageOnStart_ShouldThrow`
- `TomlFileExchangeRateCacheTests.StoreFetchedRange_WhenFileWriteFailsAndStrict_ShouldThrow`

Both expected a `DirectoryNotFoundException` but none was thrown.

## Root cause

This was an **unimplemented feature**, not a platform quirk (Linux does throw `DirectoryNotFoundException` when a directory is created under a file path). `ExchangeRateCacheOptions.ThrowOnStorageFailure` and `ValidateStorageOnStart` are documented options, and the **SQLite** and **Distributed** backends both honor them — but `FileExchangeRateCacheBase` never did. It swallowed every `IOException`/`UnauthorizedAccessException` unconditionally and ran no startup probe.

PR #499 added the feature, the options, and these tests, but missed wiring it into the file backend. The gap shipped invisibly because the file-cache tests were not in the old 8-project CI list — exactly the blind spot #507 closed. The first solution-wide run caught it.

## Fix

Implemented the feature in `FileExchangeRateCacheBase`, mirroring the established sibling pattern:

- Added a `ShouldSwallowStorageFailure` (`= !ThrowOnStorageFailure`) exception filter on the read and write catch blocks, so a strict cache propagates the storage failure instead of degrading to an empty read / skipped write.
- When `ValidateStorageOnStart` is set, the constructor eagerly creates the per-provider directory so a misconfigured or unwritable location fails fast rather than on first use.

Default behavior (both flags `false`) is unchanged — the read/write filters and the probe are inert unless a strict flag is set.

## Verification

- The two previously-failing tests now pass.
- Full `Bodu.Financial.ExchangeRates.Caching.Test` suite: **207 passed, 1 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUPMkV2fLM9xzbsVSYRvHN)_